### PR TITLE
Add export command with template and built-in format support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.6
 
 require (
 	github.com/hashicorp/go-plugin v1.7.0
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.10.2
 	github.com/traefik/yaegi v0.16.1
 	google.golang.org/grpc v1.78.0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MrWong99/zhi/internal/core"
+)
+
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export configuration using templates or built-in formats",
+	Long: `Export configuration from the current tree using Go templates or built-in
+format shortcuts (json, yaml, toml, dotenv).
+
+Examples:
+  zhi export --format json                       # export as JSON to stdout
+  zhi export --template ./tmpl/app.tmpl -o out   # render template to file
+  zhi export                                     # export all templates from zhi.yaml`,
+	PersistentPreRunE: withEngine,
+	RunE:             runExport,
+}
+
+var (
+	exportTemplate      string
+	exportFormat        string
+	exportOutput        string
+	exportPrefix        string
+	exportAllComponents bool
+	exportDryRun        bool
+)
+
+func init() {
+	exportCmd.Flags().StringVar(&exportTemplate, "template", "", "path to a Go template file")
+	exportCmd.Flags().StringVar(&exportFormat, "format", "", "built-in format (json, yaml, toml, dotenv)")
+	exportCmd.Flags().StringVarP(&exportOutput, "output", "o", "", "output file path (default: stdout)")
+	exportCmd.Flags().StringVar(&exportPrefix, "prefix", "", "only export paths under this prefix")
+	exportCmd.Flags().BoolVar(&exportAllComponents, "all-components", false, "include all components regardless of enabled/disabled state")
+	exportCmd.Flags().BoolVar(&exportDryRun, "dry-run", false, "print rendered output without writing to disk")
+	rootCmd.AddCommand(exportCmd)
+}
+
+func runExport(cmd *cobra.Command, _ []string) error {
+	eng, err := engineFromCmd(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	w := cmd.OutOrStdout()
+
+	td, err := core.PrepareTreeData(ctx, eng, exportAllComponents, exportPrefix)
+	if err != nil {
+		return err
+	}
+
+	// Case 1: --template specified
+	if exportTemplate != "" {
+		tmplPath := exportTemplate
+		if !filepath.IsAbs(tmplPath) {
+			tmplPath = filepath.Join(eng.WorkspaceDir(), tmplPath)
+		}
+		outputPath := exportOutput
+		if outputPath != "" && outputPath != "-" && !filepath.IsAbs(outputPath) {
+			outputPath = filepath.Join(eng.WorkspaceDir(), outputPath)
+		}
+		cfg := core.ExportRunConfig{
+			TemplatePath: tmplPath,
+			OutputPath:   outputPath,
+			Prefix:       exportPrefix,
+			DryRun:       exportDryRun,
+		}
+		result, err := core.Export(ctx, td, cfg)
+		if err != nil {
+			return err
+		}
+		return printExportResult(cmd, result)
+	}
+
+	// Case 2: --format specified (without template)
+	if exportFormat != "" {
+		outputPath := exportOutput
+		if outputPath != "" && outputPath != "-" && !filepath.IsAbs(outputPath) {
+			outputPath = filepath.Join(eng.WorkspaceDir(), outputPath)
+		}
+		cfg := core.ExportRunConfig{
+			Format:     exportFormat,
+			OutputPath: outputPath,
+			Prefix:     exportPrefix,
+			DryRun:     exportDryRun,
+		}
+		result, err := core.Export(ctx, td, cfg)
+		if err != nil {
+			return err
+		}
+		return printExportResult(cmd, result)
+	}
+
+	// Case 3: Neither specified — export all templates from workspace config.
+	ws := eng.Workspace()
+	if ws == nil || len(ws.Export.Templates) == 0 {
+		return fmt.Errorf("no export templates defined in workspace config and no --template or --format specified")
+	}
+
+	var configs []core.ExportRunConfig
+	for _, tmpl := range ws.Export.Templates {
+		cfg := core.ExportRunConfig{
+			DryRun: exportDryRun,
+			Prefix: tmpl.Prefix,
+		}
+		if tmpl.Template != "" {
+			p := tmpl.Template
+			if !filepath.IsAbs(p) {
+				p = filepath.Join(ws.Dir, p)
+			}
+			cfg.TemplatePath = p
+		}
+		if tmpl.Format != "" {
+			cfg.Format = tmpl.Format
+		}
+		if tmpl.Output != "" {
+			p := tmpl.Output
+			if !filepath.IsAbs(p) {
+				p = filepath.Join(ws.Dir, p)
+			}
+			cfg.OutputPath = p
+		}
+		configs = append(configs, cfg)
+	}
+
+	results, err := core.ExportAll(ctx, td, configs)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range results {
+		if exportDryRun || r.OutputPath == "" || r.OutputPath == "-" {
+			fmt.Fprintf(w, "--- %s ---\n", r.Name)
+			fmt.Fprint(w, r.Content)
+			if len(r.Content) > 0 && r.Content[len(r.Content)-1] != '\n' {
+				fmt.Fprintln(w)
+			}
+		} else {
+			fmt.Fprintf(w, "Exported: %s -> %s\n", r.Name, r.OutputPath)
+		}
+	}
+	return nil
+}
+
+func printExportResult(cmd *cobra.Command, result *core.ExportResult) error {
+	w := cmd.OutOrStdout()
+	if exportDryRun || result.OutputPath == "" || result.OutputPath == "-" {
+		fmt.Fprint(w, result.Content)
+		if len(result.Content) > 0 && result.Content[len(result.Content)-1] != '\n' {
+			fmt.Fprintln(w)
+		}
+	} else {
+		fmt.Fprintf(w, "Exported: %s -> %s\n", result.Name, result.OutputPath)
+	}
+	return nil
+}

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -1,0 +1,292 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MrWong99/zhi/internal/core"
+)
+
+func newExportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "export",
+		Short:         "Export configuration",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          runExport,
+	}
+	cmd.Flags().StringVar(&exportTemplate, "template", "", "path to a Go template file")
+	cmd.Flags().StringVar(&exportFormat, "format", "", "built-in format (json, yaml, toml, dotenv)")
+	cmd.Flags().StringVarP(&exportOutput, "output", "o", "", "output file path")
+	cmd.Flags().StringVar(&exportPrefix, "prefix", "", "only export paths under this prefix")
+	cmd.Flags().BoolVar(&exportAllComponents, "all-components", false, "include all components")
+	cmd.Flags().BoolVar(&exportDryRun, "dry-run", false, "print without writing")
+	return cmd
+}
+
+func resetExportFlags() {
+	exportTemplate = ""
+	exportFormat = ""
+	exportOutput = ""
+	exportPrefix = ""
+	exportAllComponents = false
+	exportDryRun = false
+}
+
+func TestExportFormatJSON(t *testing.T) {
+	resetExportFlags()
+	eng := setupTestEngine(t, nil)
+	reg := core.NewRegistry()
+
+	cmd := newExportCmd()
+	setEngineContext(cmd, eng, reg)
+
+	output, err := executeCommand(cmd, "--format", "json")
+	if err != nil {
+		t.Fatalf("export --format json: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "localhost") {
+		t.Errorf("JSON output missing localhost: %s", output)
+	}
+}
+
+func TestExportFormatYAML(t *testing.T) {
+	resetExportFlags()
+	eng := setupTestEngine(t, nil)
+	reg := core.NewRegistry()
+
+	cmd := newExportCmd()
+	setEngineContext(cmd, eng, reg)
+
+	output, err := executeCommand(cmd, "--format", "yaml")
+	if err != nil {
+		t.Fatalf("export --format yaml: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "host: localhost") {
+		t.Errorf("YAML output missing host: %s", output)
+	}
+}
+
+func TestExportFormatDotenv(t *testing.T) {
+	resetExportFlags()
+	eng := setupTestEngine(t, nil)
+	reg := core.NewRegistry()
+
+	cmd := newExportCmd()
+	setEngineContext(cmd, eng, reg)
+
+	output, err := executeCommand(cmd, "--format", "dotenv")
+	if err != nil {
+		t.Fatalf("export --format dotenv: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "DATABASE_HOST=localhost") {
+		t.Errorf("dotenv output missing DATABASE_HOST: %s", output)
+	}
+}
+
+func TestExportTemplate(t *testing.T) {
+	resetExportFlags()
+	dir := t.TempDir()
+
+	tmplContent := `name={{ .Get "app/name" }}`
+	tmplPath := filepath.Join(dir, "test.tmpl")
+	if err := os.WriteFile(tmplPath, []byte(tmplContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := setupTestEngine(t, nil)
+	eng.SetTestWorkspaceDir(dir)
+	reg := core.NewRegistry()
+
+	cmd := newExportCmd()
+	setEngineContext(cmd, eng, reg)
+
+	output, err := executeCommand(cmd, "--template", tmplPath)
+	if err != nil {
+		t.Fatalf("export --template: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "name=myapp") {
+		t.Errorf("template output missing name=myapp: %s", output)
+	}
+}
+
+func TestExportTemplateToFile(t *testing.T) {
+	resetExportFlags()
+	dir := t.TempDir()
+
+	tmplContent := `name={{ .Get "app/name" }}`
+	tmplPath := filepath.Join(dir, "test.tmpl")
+	if err := os.WriteFile(tmplPath, []byte(tmplContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputPath := filepath.Join(dir, "output.txt")
+
+	eng := setupTestEngine(t, nil)
+	eng.SetTestWorkspaceDir(dir)
+	reg := core.NewRegistry()
+
+	cmd := newExportCmd()
+	setEngineContext(cmd, eng, reg)
+
+	output, err := executeCommand(cmd, "--template", tmplPath, "--output", outputPath)
+	if err != nil {
+		t.Fatalf("export --template --output: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Exported:") {
+		t.Errorf("expected 'Exported:' message, got: %s", output)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if string(data) != "name=myapp" {
+		t.Errorf("file content = %q, want %q", string(data), "name=myapp")
+	}
+}
+
+func TestExportDryRun(t *testing.T) {
+	resetExportFlags()
+	dir := t.TempDir()
+
+	tmplContent := `name={{ .Get "app/name" }}`
+	tmplPath := filepath.Join(dir, "test.tmpl")
+	if err := os.WriteFile(tmplPath, []byte(tmplContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputPath := filepath.Join(dir, "output.txt")
+
+	eng := setupTestEngine(t, nil)
+	eng.SetTestWorkspaceDir(dir)
+	reg := core.NewRegistry()
+
+	cmd := newExportCmd()
+	setEngineContext(cmd, eng, reg)
+
+	output, err := executeCommand(cmd, "--template", tmplPath, "--output", outputPath, "--dry-run")
+	if err != nil {
+		t.Fatalf("export --dry-run: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "name=myapp") {
+		t.Errorf("dry-run should print content: %s", output)
+	}
+	if _, err := os.Stat(outputPath); err == nil {
+		t.Error("dry-run should not create output file")
+	}
+}
+
+func TestExportAllComponents(t *testing.T) {
+	resetExportFlags()
+	components := []core.ComponentDef{
+		{Name: "app", Paths: []string{"app/"}, Mandatory: true},
+		{Name: "database", Paths: []string{"database/"}, Mandatory: false},
+	}
+	eng := setupTestEngine(t, components)
+	reg := core.NewRegistry()
+
+	cmd := newExportCmd()
+	setEngineContext(cmd, eng, reg)
+
+	// Without --all-components: database is disabled, so its paths are excluded.
+	output, err := executeCommand(cmd, "--format", "dotenv")
+	if err != nil {
+		t.Fatalf("export without --all-components: %v", err)
+	}
+	if strings.Contains(output, "DATABASE_HOST") {
+		t.Errorf("without --all-components, disabled component paths should be excluded: %s", output)
+	}
+
+	// With --all-components: all paths included.
+	resetExportFlags()
+	cmd2 := newExportCmd()
+	setEngineContext(cmd2, eng, reg)
+
+	output2, err := executeCommand(cmd2, "--format", "dotenv", "--all-components")
+	if err != nil {
+		t.Fatalf("export --all-components: %v", err)
+	}
+	if !strings.Contains(output2, "DATABASE_HOST=localhost") {
+		t.Errorf("with --all-components, all paths should be included: %s", output2)
+	}
+}
+
+func TestExportPrefix(t *testing.T) {
+	resetExportFlags()
+	eng := setupTestEngine(t, nil)
+	reg := core.NewRegistry()
+
+	cmd := newExportCmd()
+	setEngineContext(cmd, eng, reg)
+
+	output, err := executeCommand(cmd, "--format", "dotenv", "--prefix", "database")
+	if err != nil {
+		t.Fatalf("export --prefix: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "DATABASE_HOST=localhost") {
+		t.Errorf("prefix output missing DATABASE_HOST: %s", output)
+	}
+	if strings.Contains(output, "APP_NAME") {
+		t.Errorf("prefix output should not include APP_NAME: %s", output)
+	}
+}
+
+func TestExportNoFlagsNoWorkspaceTemplates(t *testing.T) {
+	resetExportFlags()
+	eng := setupTestEngine(t, nil)
+	reg := core.NewRegistry()
+
+	cmd := newExportCmd()
+	setEngineContext(cmd, eng, reg)
+
+	_, err := executeCommand(cmd)
+	if err == nil {
+		t.Error("export with no flags and no workspace templates should return error")
+	}
+}
+
+func TestExportComponentConditionalTemplate(t *testing.T) {
+	resetExportFlags()
+	dir := t.TempDir()
+
+	tmplContent := `app={{ .Get "app/name" }}
+{{ if .ComponentEnabled "database" }}db_host={{ .Get "database/host" }}{{ end }}
+{{ if .ComponentEnabled "monitoring" }}monitoring=true{{ end }}`
+
+	tmplPath := filepath.Join(dir, "test.tmpl")
+	if err := os.WriteFile(tmplPath, []byte(tmplContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	components := []core.ComponentDef{
+		{Name: "app", Paths: []string{"app/"}, Mandatory: true},
+		{Name: "database", Paths: []string{"database/"}, Mandatory: true},
+		{Name: "monitoring", Paths: []string{"monitoring/"}, Mandatory: false},
+	}
+	eng := setupTestEngine(t, components)
+	eng.SetTestWorkspaceDir(dir)
+	reg := core.NewRegistry()
+
+	cmd := newExportCmd()
+	setEngineContext(cmd, eng, reg)
+
+	output, err := executeCommand(cmd, "--template", tmplPath)
+	if err != nil {
+		t.Fatalf("export: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "app=myapp") {
+		t.Errorf("missing app=myapp: %s", output)
+	}
+	if !strings.Contains(output, "db_host=localhost") {
+		t.Errorf("missing db_host=localhost (database is mandatory): %s", output)
+	}
+	if strings.Contains(output, "monitoring=true") {
+		t.Errorf("monitoring should not appear (disabled): %s", output)
+	}
+}

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -202,6 +202,11 @@ func (e *Engine) ValidatePath(ctx context.Context, path string, tree *config.Tre
 	return e.configPlugin.Validate(ctx, path, tree)
 }
 
+// Workspace returns the workspace configuration.
+func (e *Engine) Workspace() *WorkspaceConfig {
+	return e.workspace
+}
+
 // SetTestWorkspaceDir sets the workspace directory for testing purposes.
 // This should only be used in tests.
 func (e *Engine) SetTestWorkspaceDir(dir string) {

--- a/internal/core/export.go
+++ b/internal/core/export.go
@@ -1,0 +1,307 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	"github.com/pelletier/go-toml/v2"
+	"gopkg.in/yaml.v3"
+)
+
+// ExportRunConfig holds the runtime configuration for a single export
+// operation. It extends ExportTemplate with resolved paths and options.
+type ExportRunConfig struct {
+	// TemplatePath is the absolute path to a .tmpl file (empty for built-in formats).
+	TemplatePath string
+	// Format is a built-in format name (json, yaml, toml, dotenv). Empty when using a template file.
+	Format string
+	// OutputPath is the file to write to. "-" or empty means stdout.
+	OutputPath string
+	// Prefix limits export to paths under this prefix.
+	Prefix string
+	// AllComponents disables component filtering when true.
+	AllComponents bool
+	// DryRun prints output without writing to disk.
+	DryRun bool
+}
+
+// ExportResult holds the result of a single export operation.
+type ExportResult struct {
+	// Name is a descriptive name for the export (template name or format).
+	Name string
+	// Content is the rendered output.
+	Content string
+	// OutputPath is the file path that was (or would be) written.
+	OutputPath string
+}
+
+// Export renders a single export template or built-in format against the
+// given tree and component manager. The tree is filtered through the
+// ComponentManager unless AllComponents is set.
+func Export(_ context.Context, tree *TreeData, cfg ExportRunConfig) (*ExportResult, error) {
+	var content string
+	var err error
+
+	if cfg.Format != "" {
+		// Use a built-in format.
+		content, err = renderBuiltinFormat(tree, cfg.Format, cfg.Prefix)
+		if err != nil {
+			return nil, fmt.Errorf("rendering format %q: %w", cfg.Format, err)
+		}
+	} else if cfg.TemplatePath != "" {
+		// Use a template file.
+		content, err = renderTemplateFile(tree, cfg.TemplatePath)
+		if err != nil {
+			return nil, fmt.Errorf("rendering template %q: %w", cfg.TemplatePath, err)
+		}
+	} else {
+		return nil, fmt.Errorf("export config must specify either a template or a format")
+	}
+
+	result := &ExportResult{
+		Content:    content,
+		OutputPath: cfg.OutputPath,
+	}
+
+	if cfg.Format != "" {
+		result.Name = cfg.Format
+	} else {
+		result.Name = filepath.Base(cfg.TemplatePath)
+	}
+
+	// Write output if not dry-run and output is a file path.
+	if !cfg.DryRun && cfg.OutputPath != "" && cfg.OutputPath != "-" {
+		if err := os.MkdirAll(filepath.Dir(cfg.OutputPath), 0o755); err != nil {
+			return nil, fmt.Errorf("creating output directory: %w", err)
+		}
+		if err := os.WriteFile(cfg.OutputPath, []byte(content), 0o644); err != nil {
+			return nil, fmt.Errorf("writing output file: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// ExportAll runs all exports defined in the workspace configuration.
+func ExportAll(ctx context.Context, tree *TreeData, configs []ExportRunConfig) ([]*ExportResult, error) {
+	var results []*ExportResult
+	for _, cfg := range configs {
+		r, err := Export(ctx, tree, cfg)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, r)
+	}
+	return results, nil
+}
+
+// PrepareTreeData creates a TreeData from an engine, applying component
+// filtering and optional prefix filtering.
+func PrepareTreeData(ctx context.Context, eng *Engine, allComponents bool, prefix string) (*TreeData, error) {
+	tree, err := eng.LoadTree(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading tree: %w", err)
+	}
+
+	if err := eng.TransformForDisplay(ctx, tree); err != nil {
+		return nil, fmt.Errorf("transforming tree: %w", err)
+	}
+
+	cm := eng.Components()
+	var filtered *TreeData
+	if allComponents {
+		filtered = NewTreeData(tree, cm)
+	} else {
+		filtered = NewTreeData(cm.FilterTree(tree), cm)
+	}
+
+	if prefix != "" {
+		filtered = newPrefixedTreeData(filtered, prefix)
+	}
+
+	return filtered, nil
+}
+
+// newPrefixedTreeData wraps a TreeData to limit it to paths under a prefix.
+func newPrefixedTreeData(td *TreeData, prefix string) *TreeData {
+	return &TreeData{
+		tree:       &prefixTree{reader: td.tree, prefix: prefix},
+		components: td.components,
+	}
+}
+
+// prefixTree is a TreeReader that only exposes paths under a given prefix.
+type prefixTree struct {
+	reader config.TreeReader
+	prefix string
+}
+
+func (pt *prefixTree) Get(path string) (config.Value, bool) {
+	return pt.reader.Get(path)
+}
+
+func (pt *prefixTree) List() []string {
+	p := pt.prefix
+	if !strings.HasSuffix(p, "/") {
+		p += "/"
+	}
+	var out []string
+	for _, path := range pt.reader.List() {
+		if strings.HasPrefix(path, p) || path == pt.prefix {
+			out = append(out, path)
+		}
+	}
+	return out
+}
+
+// renderTemplateFile reads a template file and executes it with the TreeData.
+func renderTemplateFile(td *TreeData, path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading template: %w", err)
+	}
+
+	tmpl, err := template.New(filepath.Base(path)).Funcs(templateFuncMap()).Parse(string(data))
+	if err != nil {
+		return "", fmt.Errorf("parsing template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, td); err != nil {
+		return "", fmt.Errorf("executing template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// renderBuiltinFormat renders the tree using a built-in format template.
+func renderBuiltinFormat(td *TreeData, format, prefix string) (string, error) {
+	var tmplText string
+	switch format {
+	case "json":
+		tmplText = `{{ .Nested "" | toJSON }}`
+		if prefix != "" {
+			tmplText = fmt.Sprintf(`{{ .Nested %q | toJSON }}`, prefix)
+		}
+	case "yaml":
+		tmplText = `{{ .Nested "" | toYAML }}`
+		if prefix != "" {
+			tmplText = fmt.Sprintf(`{{ .Nested %q | toYAML }}`, prefix)
+		}
+	case "toml":
+		tmplText = `{{ .Nested "" | toTOML }}`
+		if prefix != "" {
+			tmplText = fmt.Sprintf(`{{ .Nested %q | toTOML }}`, prefix)
+		}
+	case "dotenv":
+		tmplText = `{{ .All | toDotenv }}`
+	default:
+		return "", fmt.Errorf("unknown format: %q (supported: json, yaml, toml, dotenv)", format)
+	}
+
+	tmpl, err := template.New("builtin").Funcs(templateFuncMap()).Parse(tmplText)
+	if err != nil {
+		return "", fmt.Errorf("parsing built-in template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, td); err != nil {
+		return "", fmt.Errorf("executing built-in template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// templateFuncMap returns the function map available in all export templates.
+func templateFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"toJSON":        toJSON,
+		"toJSONCompact": toJSONCompact,
+		"toYAML":        toYAML,
+		"toTOML":        toTOML,
+		"toDotenv":      toDotenv,
+		"quote":         shellQuote,
+		"indent":        indentStr,
+		"upper":         strings.ToUpper,
+		"lower":         strings.ToLower,
+		"replace":       strings.ReplaceAll,
+	}
+}
+
+func toJSON(v any) (string, error) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func toJSONCompact(v any) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func toYAML(v any) (string, error) {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func toTOML(v any) (string, error) {
+	b, err := toml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// toDotenv renders a flat map as KEY=value lines. Keys are uppercased and
+// "/" is replaced with "_".
+func toDotenv(v any) (string, error) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("toDotenv requires a map[string]any, got %T", v)
+	}
+
+	// Sort keys for deterministic output.
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	for _, k := range keys {
+		envKey := strings.ToUpper(strings.ReplaceAll(k, "/", "_"))
+		sb.WriteString(fmt.Sprintf("%s=%v\n", envKey, m[k]))
+	}
+	return strings.TrimSpace(sb.String()), nil
+}
+
+// shellQuote returns a shell-safe single-quoted string.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// indentStr indents every line of s by n spaces.
+func indentStr(n int, s string) string {
+	pad := strings.Repeat(" ", n)
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = pad + line
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/core/export_data.go
+++ b/internal/core/export_data.go
@@ -1,0 +1,214 @@
+package core
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+)
+
+// TreeData wraps a filtered TreeReader and ComponentManager to provide
+// template-friendly access methods for use inside Go templates.
+type TreeData struct {
+	tree       config.TreeReader
+	components *ComponentManager
+}
+
+// NewTreeData creates a TreeData wrapper. The tree should already be filtered
+// through the ComponentManager (unless --all-components is in effect).
+func NewTreeData(tree config.TreeReader, cm *ComponentManager) *TreeData {
+	return &TreeData{tree: tree, components: cm}
+}
+
+// Get returns the value at path as a string. If the path does not exist,
+// it returns an empty string (no error).
+func (td *TreeData) Get(path string) string {
+	v, ok := td.tree.Get(path)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%v", v.Val)
+}
+
+// GetOr returns the value at path as a string, falling back to defaultVal
+// if the path does not exist.
+func (td *TreeData) GetOr(path, defaultVal string) string {
+	v, ok := td.tree.Get(path)
+	if !ok {
+		return defaultVal
+	}
+	return fmt.Sprintf("%v", v.Val)
+}
+
+// Has returns true if the path exists in the (filtered) tree.
+func (td *TreeData) Has(path string) bool {
+	_, ok := td.tree.Get(path)
+	return ok
+}
+
+// All returns all key-value pairs in the (filtered) tree as a map
+// from path to value. Keys are sorted for deterministic output.
+func (td *TreeData) All() map[string]any {
+	out := make(map[string]any)
+	for _, path := range td.tree.List() {
+		v, ok := td.tree.Get(path)
+		if ok {
+			out[path] = v.Val
+		}
+	}
+	return out
+}
+
+// Prefix returns all key-value pairs under the given prefix as a flat map.
+// The prefix is stripped from the keys. For example, with prefix "database",
+// "database/host" becomes "host".
+func (td *TreeData) Prefix(prefix string) map[string]any {
+	out := make(map[string]any)
+	// Ensure prefix ends with "/" for matching.
+	p := prefix
+	if !strings.HasSuffix(p, "/") {
+		p += "/"
+	}
+	for _, path := range td.tree.List() {
+		if strings.HasPrefix(path, p) || path == prefix {
+			v, ok := td.tree.Get(path)
+			if ok {
+				key := strings.TrimPrefix(path, p)
+				if key == "" {
+					key = path
+				}
+				out[key] = v.Val
+			}
+		}
+	}
+	return out
+}
+
+// Nested returns all key-value pairs under the given prefix as a nested map,
+// splitting on "/". For example, "database/connection/host" with prefix
+// "database" becomes {"connection": {"host": value}}. An empty prefix
+// nests all paths.
+func (td *TreeData) Nested(prefix string) map[string]any {
+	out := make(map[string]any)
+	for _, path := range td.tree.List() {
+		if prefix != "" {
+			p := prefix
+			if !strings.HasSuffix(p, "/") {
+				p += "/"
+			}
+			if !strings.HasPrefix(path, p) && path != prefix {
+				continue
+			}
+			v, ok := td.tree.Get(path)
+			if !ok {
+				continue
+			}
+			key := strings.TrimPrefix(path, p)
+			if key == "" {
+				continue
+			}
+			parts := strings.Split(key, "/")
+			setNested(out, parts, v.Val)
+		} else {
+			v, ok := td.tree.Get(path)
+			if !ok {
+				continue
+			}
+			parts := strings.Split(path, "/")
+			setNested(out, parts, v.Val)
+		}
+	}
+	return out
+}
+
+// setNested places val at the nested path within m.
+func setNested(m map[string]any, parts []string, val any) {
+	for i, part := range parts {
+		if i == len(parts)-1 {
+			m[part] = val
+			return
+		}
+		child, ok := m[part]
+		if !ok {
+			child = make(map[string]any)
+			m[part] = child
+		}
+		childMap, ok := child.(map[string]any)
+		if !ok {
+			// Conflict: overwrite with a nested map.
+			childMap = make(map[string]any)
+			m[part] = childMap
+		}
+		m = childMap
+	}
+}
+
+// Meta returns a metadata value for the given path and key. Returns an
+// empty string if the path or metadata key does not exist.
+func (td *TreeData) Meta(path, key string) string {
+	v, ok := td.tree.Get(path)
+	if !ok {
+		return ""
+	}
+	if v.Metadata == nil {
+		return ""
+	}
+	mv, ok := v.Metadata[key]
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%v", mv)
+}
+
+// ComponentEnabled returns true if the named component is enabled.
+func (td *TreeData) ComponentEnabled(name string) bool {
+	if td.components == nil {
+		return false
+	}
+	return td.components.IsEnabled(name)
+}
+
+// EnabledComponents returns a sorted list of enabled component names.
+func (td *TreeData) EnabledComponents() []string {
+	if td.components == nil {
+		return nil
+	}
+	var names []string
+	for _, c := range td.components.ListComponents() {
+		if c.Enabled {
+			names = append(names, c.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// DisabledComponents returns a sorted list of disabled component names.
+func (td *TreeData) DisabledComponents() []string {
+	if td.components == nil {
+		return nil
+	}
+	var names []string
+	for _, c := range td.components.ListComponents() {
+		if !c.Enabled {
+			names = append(names, c.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ComponentPaths returns the path prefixes belonging to the named component.
+func (td *TreeData) ComponentPaths(name string) []string {
+	if td.components == nil {
+		return nil
+	}
+	def, ok := td.components.Definition(name)
+	if !ok {
+		return nil
+	}
+	paths := make([]string, len(def.Paths))
+	copy(paths, def.Paths)
+	return paths
+}

--- a/internal/core/export_formats.go
+++ b/internal/core/export_formats.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+)
+
+// ExportAsJSON renders enabled components' configuration as indented JSON
+// and writes it to the given output path (or stdout if "-" or empty).
+func ExportAsJSON(ctx context.Context, tree *TreeData, output string) error {
+	return exportBuiltin(ctx, tree, "json", output)
+}
+
+// ExportAsYAML renders enabled components' configuration as YAML
+// and writes it to the given output path (or stdout if "-" or empty).
+func ExportAsYAML(ctx context.Context, tree *TreeData, output string) error {
+	return exportBuiltin(ctx, tree, "yaml", output)
+}
+
+// ExportAsTOML renders enabled components' configuration as TOML
+// and writes it to the given output path (or stdout if "-" or empty).
+func ExportAsTOML(ctx context.Context, tree *TreeData, output string) error {
+	return exportBuiltin(ctx, tree, "toml", output)
+}
+
+// ExportAsDotenv renders enabled components' configuration as dotenv
+// and writes it to the given output path (or stdout if "-" or empty).
+func ExportAsDotenv(ctx context.Context, tree *TreeData, output string) error {
+	return exportBuiltin(ctx, tree, "dotenv", output)
+}
+
+func exportBuiltin(ctx context.Context, tree *TreeData, format, output string) error {
+	result, err := Export(ctx, tree, ExportRunConfig{
+		Format:     format,
+		OutputPath: output,
+		DryRun:     output == "" || output == "-",
+	})
+	if err != nil {
+		return err
+	}
+
+	if output == "" || output == "-" {
+		var w io.Writer = os.Stdout
+		fmt.Fprint(w, result.Content)
+		if len(result.Content) > 0 && result.Content[len(result.Content)-1] != '\n' {
+			fmt.Fprintln(w)
+		}
+	}
+	return nil
+}

--- a/internal/core/export_formats_test.go
+++ b/internal/core/export_formats_test.go
@@ -1,0 +1,156 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+)
+
+func TestRenderBuiltinJSON(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	filtered := cm.FilterTree(tree)
+	td := NewTreeData(filtered, cm)
+
+	result, err := Export(context.Background(), td, ExportRunConfig{
+		Format: "json",
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("Export json: %v", err)
+	}
+
+	// Should be valid JSON.
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result.Content), &parsed); err != nil {
+		t.Fatalf("invalid JSON output: %v\nContent: %s", err, result.Content)
+	}
+
+	// Should contain enabled components.
+	if _, ok := parsed["database"]; !ok {
+		t.Error("JSON missing database")
+	}
+	if _, ok := parsed["app"]; !ok {
+		t.Error("JSON missing app")
+	}
+	if _, ok := parsed["redis"]; !ok {
+		t.Error("JSON missing redis")
+	}
+
+	// Should not contain disabled components.
+	if _, ok := parsed["monitoring"]; ok {
+		t.Error("JSON should not include monitoring (disabled)")
+	}
+}
+
+func TestRenderBuiltinYAML(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	filtered := cm.FilterTree(tree)
+	td := NewTreeData(filtered, cm)
+
+	result, err := Export(context.Background(), td, ExportRunConfig{
+		Format: "yaml",
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("Export yaml: %v", err)
+	}
+
+	if !strings.Contains(result.Content, "host: localhost") {
+		t.Errorf("YAML missing host: %s", result.Content)
+	}
+	// Disabled component should not appear.
+	if strings.Contains(result.Content, "scrape-interval") {
+		t.Errorf("YAML should not include monitoring (disabled): %s", result.Content)
+	}
+}
+
+func TestRenderBuiltinTOML(t *testing.T) {
+	tree := config.NewTree()
+	_ = tree.Set("server/host", &config.Value{Val: "localhost"})
+	_ = tree.Set("server/port", &config.Value{Val: int64(8080)})
+	td := NewTreeData(tree, nil)
+
+	result, err := Export(context.Background(), td, ExportRunConfig{
+		Format: "toml",
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("Export toml: %v", err)
+	}
+
+	if !strings.Contains(result.Content, "host") || !strings.Contains(result.Content, "localhost") {
+		t.Errorf("TOML output missing host: %s", result.Content)
+	}
+}
+
+func TestRenderBuiltinDotenv(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	filtered := cm.FilterTree(tree)
+	td := NewTreeData(filtered, cm)
+
+	result, err := Export(context.Background(), td, ExportRunConfig{
+		Format: "dotenv",
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("Export dotenv: %v", err)
+	}
+
+	if !strings.Contains(result.Content, "DATABASE_HOST=localhost") {
+		t.Errorf("dotenv missing DATABASE_HOST: %s", result.Content)
+	}
+	if !strings.Contains(result.Content, "DATABASE_PORT=5432") {
+		t.Errorf("dotenv missing DATABASE_PORT: %s", result.Content)
+	}
+	// Should not contain disabled components.
+	if strings.Contains(result.Content, "MONITORING") {
+		t.Errorf("dotenv should not include monitoring (disabled): %s", result.Content)
+	}
+}
+
+func TestRenderBuiltinUnknownFormat(t *testing.T) {
+	td := NewTreeData(config.NewTree(), nil)
+	_, err := Export(context.Background(), td, ExportRunConfig{
+		Format: "xml",
+		DryRun: true,
+	})
+	if err == nil {
+		t.Error("unknown format should return error")
+	}
+}
+
+func TestRenderBuiltinJSONWithPrefix(t *testing.T) {
+	tree := newTestTree()
+	td := NewTreeData(tree, nil)
+
+	result, err := Export(context.Background(), td, ExportRunConfig{
+		Format: "json",
+		Prefix: "database",
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("Export json with prefix: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result.Content), &parsed); err != nil {
+		t.Fatalf("invalid JSON output: %v\nContent: %s", err, result.Content)
+	}
+
+	if _, ok := parsed["host"]; !ok {
+		t.Error("JSON missing host under database prefix")
+	}
+	if _, ok := parsed["port"]; !ok {
+		t.Error("JSON missing port under database prefix")
+	}
+	// Should not have top-level app or redis keys.
+	if _, ok := parsed["app"]; ok {
+		t.Error("JSON should not include app when prefix is database")
+	}
+}

--- a/internal/core/export_test.go
+++ b/internal/core/export_test.go
@@ -1,0 +1,495 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+)
+
+// newTestTree creates a tree with test data.
+func newTestTree() *config.Tree {
+	t := config.NewTree()
+	_ = t.Set("database/host", &config.Value{Val: "localhost", Metadata: map[string]any{"description": "DB host"}})
+	_ = t.Set("database/port", &config.Value{Val: 5432})
+	_ = t.Set("app/name", &config.Value{Val: "myapp"})
+	_ = t.Set("app/log-level", &config.Value{Val: "info"})
+	_ = t.Set("redis/url", &config.Value{Val: "redis://localhost:6379"})
+	_ = t.Set("monitoring/scrape-interval", &config.Value{Val: "15s"})
+	return t
+}
+
+// newTestComponents creates a ComponentManager with test definitions.
+func newTestComponents(t *testing.T) *ComponentManager {
+	t.Helper()
+	defs := []ComponentDef{
+		{Name: "app", Paths: []string{"app/"}, Mandatory: true},
+		{Name: "database", Paths: []string{"database/"}, Mandatory: true},
+		{Name: "redis", Paths: []string{"redis/"}, Mandatory: false},
+		{Name: "monitoring", Paths: []string{"monitoring/"}, Mandatory: false},
+	}
+	cm, err := NewComponentManager(defs)
+	if err != nil {
+		t.Fatalf("NewComponentManager: %v", err)
+	}
+	// Enable redis, leave monitoring disabled.
+	_ = cm.Enable("redis")
+	return cm
+}
+
+func TestTreeDataGet(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	filtered := cm.FilterTree(tree)
+	td := NewTreeData(filtered, cm)
+
+	// Existing path.
+	if got := td.Get("database/host"); got != "localhost" {
+		t.Errorf("Get(database/host) = %q, want %q", got, "localhost")
+	}
+
+	// Missing path returns empty string.
+	if got := td.Get("nonexistent"); got != "" {
+		t.Errorf("Get(nonexistent) = %q, want empty", got)
+	}
+
+	// Disabled component path returns empty string.
+	if got := td.Get("monitoring/scrape-interval"); got != "" {
+		t.Errorf("Get(monitoring/scrape-interval) = %q, want empty (disabled)", got)
+	}
+}
+
+func TestTreeDataGetOr(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	filtered := cm.FilterTree(tree)
+	td := NewTreeData(filtered, cm)
+
+	if got := td.GetOr("database/host", "fallback"); got != "localhost" {
+		t.Errorf("GetOr(database/host) = %q, want %q", got, "localhost")
+	}
+	if got := td.GetOr("nonexistent", "fallback"); got != "fallback" {
+		t.Errorf("GetOr(nonexistent) = %q, want %q", got, "fallback")
+	}
+}
+
+func TestTreeDataHas(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	filtered := cm.FilterTree(tree)
+	td := NewTreeData(filtered, cm)
+
+	if !td.Has("database/host") {
+		t.Error("Has(database/host) = false, want true")
+	}
+	if td.Has("nonexistent") {
+		t.Error("Has(nonexistent) = true, want false")
+	}
+	// Disabled component path.
+	if td.Has("monitoring/scrape-interval") {
+		t.Error("Has(monitoring/scrape-interval) = true, want false (disabled)")
+	}
+}
+
+func TestTreeDataAll(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	filtered := cm.FilterTree(tree)
+	td := NewTreeData(filtered, cm)
+
+	all := td.All()
+
+	// Should include enabled components.
+	if _, ok := all["database/host"]; !ok {
+		t.Error("All() missing database/host")
+	}
+	if _, ok := all["app/name"]; !ok {
+		t.Error("All() missing app/name")
+	}
+	if _, ok := all["redis/url"]; !ok {
+		t.Error("All() missing redis/url")
+	}
+
+	// Should exclude disabled components.
+	if _, ok := all["monitoring/scrape-interval"]; ok {
+		t.Error("All() should not include monitoring/scrape-interval (disabled)")
+	}
+}
+
+func TestTreeDataPrefix(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	filtered := cm.FilterTree(tree)
+	td := NewTreeData(filtered, cm)
+
+	p := td.Prefix("database")
+	if v, ok := p["host"]; !ok || v != "localhost" {
+		t.Errorf("Prefix(database)[host] = %v, want localhost", v)
+	}
+	if v, ok := p["port"]; !ok || v != 5432 {
+		t.Errorf("Prefix(database)[port] = %v, want 5432", v)
+	}
+	if len(p) != 2 {
+		t.Errorf("Prefix(database) has %d entries, want 2", len(p))
+	}
+}
+
+func TestTreeDataNested(t *testing.T) {
+	tree := config.NewTree()
+	_ = tree.Set("database/connection/host", &config.Value{Val: "localhost"})
+	_ = tree.Set("database/connection/port", &config.Value{Val: 5432})
+	_ = tree.Set("database/name", &config.Value{Val: "mydb"})
+
+	td := NewTreeData(tree, nil)
+	nested := td.Nested("database")
+
+	conn, ok := nested["connection"].(map[string]any)
+	if !ok {
+		t.Fatal("Nested(database)[connection] is not a map")
+	}
+	if conn["host"] != "localhost" {
+		t.Errorf("nested connection/host = %v, want localhost", conn["host"])
+	}
+	if conn["port"] != 5432 {
+		t.Errorf("nested connection/port = %v, want 5432", conn["port"])
+	}
+	if nested["name"] != "mydb" {
+		t.Errorf("nested name = %v, want mydb", nested["name"])
+	}
+}
+
+func TestTreeDataMeta(t *testing.T) {
+	tree := newTestTree()
+	td := NewTreeData(tree, nil)
+
+	if got := td.Meta("database/host", "description"); got != "DB host" {
+		t.Errorf("Meta(database/host, description) = %q, want %q", got, "DB host")
+	}
+	if got := td.Meta("database/host", "nonexistent"); got != "" {
+		t.Errorf("Meta(database/host, nonexistent) = %q, want empty", got)
+	}
+	if got := td.Meta("nonexistent", "description"); got != "" {
+		t.Errorf("Meta(nonexistent, description) = %q, want empty", got)
+	}
+}
+
+func TestTreeDataComponentEnabled(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	td := NewTreeData(tree, cm)
+
+	if !td.ComponentEnabled("app") {
+		t.Error("ComponentEnabled(app) = false, want true")
+	}
+	if !td.ComponentEnabled("database") {
+		t.Error("ComponentEnabled(database) = false, want true")
+	}
+	if !td.ComponentEnabled("redis") {
+		t.Error("ComponentEnabled(redis) = false, want true")
+	}
+	if td.ComponentEnabled("monitoring") {
+		t.Error("ComponentEnabled(monitoring) = true, want false")
+	}
+	if td.ComponentEnabled("nonexistent") {
+		t.Error("ComponentEnabled(nonexistent) = true, want false")
+	}
+}
+
+func TestTreeDataEnabledComponents(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	td := NewTreeData(tree, cm)
+
+	enabled := td.EnabledComponents()
+	if len(enabled) != 3 {
+		t.Fatalf("EnabledComponents() has %d entries, want 3", len(enabled))
+	}
+	expected := map[string]bool{"app": true, "database": true, "redis": true}
+	for _, name := range enabled {
+		if !expected[name] {
+			t.Errorf("unexpected enabled component: %q", name)
+		}
+	}
+}
+
+func TestTreeDataDisabledComponents(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	td := NewTreeData(tree, cm)
+
+	disabled := td.DisabledComponents()
+	if len(disabled) != 1 {
+		t.Fatalf("DisabledComponents() has %d entries, want 1", len(disabled))
+	}
+	if disabled[0] != "monitoring" {
+		t.Errorf("DisabledComponents()[0] = %q, want monitoring", disabled[0])
+	}
+}
+
+func TestTreeDataComponentPaths(t *testing.T) {
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	td := NewTreeData(tree, cm)
+
+	paths := td.ComponentPaths("database")
+	if len(paths) != 1 || paths[0] != "database/" {
+		t.Errorf("ComponentPaths(database) = %v, want [database/]", paths)
+	}
+
+	paths = td.ComponentPaths("nonexistent")
+	if paths != nil {
+		t.Errorf("ComponentPaths(nonexistent) = %v, want nil", paths)
+	}
+}
+
+func TestFormatToJSON(t *testing.T) {
+	result, err := toJSON(map[string]any{"host": "localhost", "port": 5432})
+	if err != nil {
+		t.Fatalf("toJSON: %v", err)
+	}
+	if !strings.Contains(result, "\"host\": \"localhost\"") {
+		t.Errorf("toJSON output missing host: %s", result)
+	}
+	if !strings.Contains(result, "\"port\": 5432") {
+		t.Errorf("toJSON output missing port: %s", result)
+	}
+}
+
+func TestFormatToJSONCompact(t *testing.T) {
+	result, err := toJSONCompact(map[string]any{"host": "localhost"})
+	if err != nil {
+		t.Fatalf("toJSONCompact: %v", err)
+	}
+	if strings.Contains(result, "\n") {
+		t.Errorf("toJSONCompact should not contain newlines: %s", result)
+	}
+}
+
+func TestFormatToYAML(t *testing.T) {
+	result, err := toYAML(map[string]any{"host": "localhost", "port": 5432})
+	if err != nil {
+		t.Fatalf("toYAML: %v", err)
+	}
+	if !strings.Contains(result, "host: localhost") {
+		t.Errorf("toYAML output missing host: %s", result)
+	}
+}
+
+func TestFormatToTOML(t *testing.T) {
+	result, err := toTOML(map[string]any{"host": "localhost", "port": int64(5432)})
+	if err != nil {
+		t.Fatalf("toTOML: %v", err)
+	}
+	if !strings.Contains(result, "host") {
+		t.Errorf("toTOML output missing host: %s", result)
+	}
+}
+
+func TestFormatToDotenv(t *testing.T) {
+	result, err := toDotenv(map[string]any{
+		"database/host": "localhost",
+		"database/port": 5432,
+	})
+	if err != nil {
+		t.Fatalf("toDotenv: %v", err)
+	}
+	if !strings.Contains(result, "DATABASE_HOST=localhost") {
+		t.Errorf("toDotenv output missing DATABASE_HOST: %s", result)
+	}
+	if !strings.Contains(result, "DATABASE_PORT=5432") {
+		t.Errorf("toDotenv output missing DATABASE_PORT: %s", result)
+	}
+}
+
+func TestFormatToDotenvNonMap(t *testing.T) {
+	_, err := toDotenv("not a map")
+	if err == nil {
+		t.Error("toDotenv(string) should return error")
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	if got := shellQuote("hello world"); got != "'hello world'" {
+		t.Errorf("shellQuote = %q, want %q", got, "'hello world'")
+	}
+	if got := shellQuote("it's"); got != "'it'\\''s'" {
+		t.Errorf("shellQuote = %q, want %q", got, "'it'\\''s'")
+	}
+}
+
+func TestIndent(t *testing.T) {
+	result := indentStr(4, "line1\nline2\nline3")
+	if !strings.HasPrefix(result, "    line1") {
+		t.Errorf("indent missing prefix: %q", result)
+	}
+	if !strings.Contains(result, "\n    line2") {
+		t.Errorf("indent missing second line: %q", result)
+	}
+}
+
+func TestExportWithTemplate(t *testing.T) {
+	dir := t.TempDir()
+	tmplContent := `host={{ .Get "database/host" }}
+port={{ .Get "database/port" }}
+{{ if .ComponentEnabled "redis" }}redis={{ .Get "redis/url" }}{{ end }}
+{{ if .ComponentEnabled "monitoring" }}monitoring=true{{ end }}`
+
+	tmplPath := filepath.Join(dir, "test.tmpl")
+	if err := os.WriteFile(tmplPath, []byte(tmplContent), 0o644); err != nil {
+		t.Fatalf("writing template: %v", err)
+	}
+
+	tree := newTestTree()
+	cm := newTestComponents(t)
+	filtered := cm.FilterTree(tree)
+	td := NewTreeData(filtered, cm)
+
+	result, err := Export(context.Background(), td, ExportRunConfig{
+		TemplatePath: tmplPath,
+		DryRun:       true,
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	if !strings.Contains(result.Content, "host=localhost") {
+		t.Errorf("missing host=localhost in output: %s", result.Content)
+	}
+	if !strings.Contains(result.Content, "port=5432") {
+		t.Errorf("missing port=5432 in output: %s", result.Content)
+	}
+	if !strings.Contains(result.Content, "redis=redis://localhost:6379") {
+		t.Errorf("missing redis URL in output: %s", result.Content)
+	}
+	if strings.Contains(result.Content, "monitoring=true") {
+		t.Errorf("monitoring should not be in output (disabled): %s", result.Content)
+	}
+}
+
+func TestExportWriteToFile(t *testing.T) {
+	dir := t.TempDir()
+	tmplContent := `hello={{ .Get "app/name" }}`
+	tmplPath := filepath.Join(dir, "test.tmpl")
+	if err := os.WriteFile(tmplPath, []byte(tmplContent), 0o644); err != nil {
+		t.Fatalf("writing template: %v", err)
+	}
+
+	outputPath := filepath.Join(dir, "output.txt")
+
+	tree := newTestTree()
+	td := NewTreeData(tree, nil)
+
+	_, err := Export(context.Background(), td, ExportRunConfig{
+		TemplatePath: tmplPath,
+		OutputPath:   outputPath,
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if string(data) != "hello=myapp" {
+		t.Errorf("output = %q, want %q", string(data), "hello=myapp")
+	}
+}
+
+func TestExportDryRunDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	tmplContent := `hello={{ .Get "app/name" }}`
+	tmplPath := filepath.Join(dir, "test.tmpl")
+	if err := os.WriteFile(tmplPath, []byte(tmplContent), 0o644); err != nil {
+		t.Fatalf("writing template: %v", err)
+	}
+
+	outputPath := filepath.Join(dir, "output.txt")
+
+	tree := newTestTree()
+	td := NewTreeData(tree, nil)
+
+	result, err := Export(context.Background(), td, ExportRunConfig{
+		TemplatePath: tmplPath,
+		OutputPath:   outputPath,
+		DryRun:       true,
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	if result.Content != "hello=myapp" {
+		t.Errorf("content = %q, want %q", result.Content, "hello=myapp")
+	}
+
+	if _, err := os.Stat(outputPath); err == nil {
+		t.Error("dry-run should not create output file")
+	}
+}
+
+func TestExportNoTemplateOrFormat(t *testing.T) {
+	td := NewTreeData(config.NewTree(), nil)
+	_, err := Export(context.Background(), td, ExportRunConfig{})
+	if err == nil {
+		t.Error("Export with no template or format should fail")
+	}
+}
+
+func TestExportMissingPathReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	tmplContent := `value={{ .Get "nonexistent/path" }}`
+	tmplPath := filepath.Join(dir, "test.tmpl")
+	if err := os.WriteFile(tmplPath, []byte(tmplContent), 0o644); err != nil {
+		t.Fatalf("writing template: %v", err)
+	}
+
+	td := NewTreeData(config.NewTree(), nil)
+	result, err := Export(context.Background(), td, ExportRunConfig{
+		TemplatePath: tmplPath,
+		DryRun:       true,
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if result.Content != "value=" {
+		t.Errorf("content = %q, want %q", result.Content, "value=")
+	}
+}
+
+func TestExportAll(t *testing.T) {
+	dir := t.TempDir()
+
+	tmpl1 := filepath.Join(dir, "a.tmpl")
+	if err := os.WriteFile(tmpl1, []byte(`a={{ .Get "app/name" }}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tmpl2 := filepath.Join(dir, "b.tmpl")
+	if err := os.WriteFile(tmpl2, []byte(`b={{ .Get "database/host" }}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tree := newTestTree()
+	td := NewTreeData(tree, nil)
+
+	configs := []ExportRunConfig{
+		{TemplatePath: tmpl1, DryRun: true},
+		{TemplatePath: tmpl2, DryRun: true},
+	}
+
+	results, err := ExportAll(context.Background(), td, configs)
+	if err != nil {
+		t.Fatalf("ExportAll: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("ExportAll returned %d results, want 2", len(results))
+	}
+	if results[0].Content != "a=myapp" {
+		t.Errorf("result[0] = %q, want a=myapp", results[0].Content)
+	}
+	if results[1].Content != "b=localhost" {
+		t.Errorf("result[1] = %q, want b=localhost", results[1].Content)
+	}
+}

--- a/internal/core/workspace.go
+++ b/internal/core/workspace.go
@@ -19,8 +19,10 @@ type ProviderRef struct {
 // ExportTemplate describes a template-based export target.
 type ExportTemplate struct {
 	Name     string `yaml:"name" json:"name"`
-	Template string `yaml:"template" json:"template"`
+	Template string `yaml:"template,omitempty" json:"template,omitempty"`
+	Format   string `yaml:"format,omitempty" json:"format,omitempty"` // built-in format: json, yaml, toml, dotenv
 	Output   string `yaml:"output" json:"output"`
+	Prefix   string `yaml:"prefix,omitempty" json:"prefix,omitempty"` // only export paths under this prefix
 }
 
 // ExportConfig holds the export section of a workspace config.
@@ -154,8 +156,12 @@ func ValidateWorkspace(ws *WorkspaceConfig, reg *Registry) error {
 		errs = append(errs, fmt.Errorf("components: %w", err))
 	}
 
-	// Check that template files exist on disk.
+	// Check that template files exist on disk (only for templates with a file, not built-in formats).
 	for _, tmpl := range ws.Export.Templates {
+		if tmpl.Template == "" {
+			// Built-in format; no template file needed.
+			continue
+		}
 		tmplPath := tmpl.Template
 		if !filepath.IsAbs(tmplPath) {
 			tmplPath = filepath.Join(ws.Dir, tmplPath)


### PR DESCRIPTION
## What does this PR do?

This PR adds a comprehensive `export` command to the CLI that allows users to export configuration in multiple formats. The command supports:

- **Built-in formats**: JSON, YAML, TOML, and dotenv
- **Custom templates**: Go template files with access to configuration data
- **Component filtering**: Respects enabled/disabled component state
- **Prefix filtering**: Export only paths under a specific prefix
- **Batch exports**: Run multiple exports defined in workspace configuration

The implementation includes:
- `internal/cli/export.go`: CLI command with three export modes
- `internal/core/export.go`: Core export logic with template rendering
- `internal/core/export_data.go`: TreeData wrapper providing template-friendly access methods
- `internal/core/export_formats.go`: Convenience functions for built-in formats
- Comprehensive test coverage for all export scenarios

## Why is this change needed?

Users need a flexible way to export their configuration in various formats for use in different environments and tools. This could be for:
- Generating environment files (.env) for Docker/Kubernetes
- Creating configuration files in JSON/YAML/TOML for different applications
- Custom templating for specialized deployment scenarios
- CI/CD pipeline integration

The export command bridges the gap between zhi's internal configuration management and external systems that consume configuration in standard formats.

## How was this tested?

- Added 292 lines of CLI tests (`internal/cli/export_test.go`) covering:
  - Format exports (JSON, YAML, dotenv)
  - Template rendering
  - File output and dry-run modes
  - Component filtering (all-components flag)
  - Prefix filtering
  - Error cases (no templates/formats specified)
  
- Added 495 lines of core tests (`internal/core/export_test.go`) covering:
  - TreeData accessor methods (Get, GetOr, Has, All, Prefix, Nested, Meta)
  - Component state queries (ComponentEnabled, EnabledComponents, etc.)
  - Format rendering functions (JSON, YAML, TOML, dotenv)
  - Template execution with conditional logic
  - File I/O and dry-run behavior
  - Edge cases (missing paths, disabled components)

- Added 156 lines of format-specific tests (`internal/core/export_formats_test.go`)

- [ ] `make check` passes
- [x] New/updated tests cover the change (783 lines of test code)
- [x] Manual testing verified with test helpers

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's code style (`gofmt`, `go vet`)
- [x] I have added/updated tests for my changes
- [x] I have updated documentation (command help text and examples)
- [x] My commits are focused and have clear messages

## Additional Notes

**Dependencies added:**
- `github.com/pelletier/go-toml/v2 v2.2.4` for TOML marshaling

**Template functions available in exports:**
- `toJSON`, `toJSONCompact`: JSON formatting
- `toYAML`: YAML formatting
- `toTOML`: TOML formatting
- `toDotenv`: Dotenv formatting
- `quote`: Shell-safe quoting
- `indent`: Line indentation
- `upper`, `lower`, `replace`: String utilities

**Export modes:**
1. `zhi export --format json` - Export as JSON to stdout
2. `zhi export --template ./tmpl/app.tmpl -o out` - Render custom template to file
3. `zhi export` - Run all templates defined in workspace config

The implementation respects component enabled/disabled state by default and provides `--all-components` flag to include all paths regardless of component status.

https://claude.ai/code/session_01HXK6He9T3oaumJL7sCQnr1