### PR TITLE
Add external plugin discovery and launcher (#8)

### DIFF
--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -3,9 +3,12 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/MrWong99/zhi/internal/core"
 )
 
 var listCmd = &cobra.Command{
@@ -34,6 +37,11 @@ var listProvidersCmd = &cobra.Command{
 	RunE:              runListProviders,
 }
 
+type providerJSONEntry struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+}
+
 func runListProviders(cmd *cobra.Command, _ []string) error {
 	reg, err := registryFromCmd(cmd)
 	if err != nil {
@@ -42,15 +50,15 @@ func runListProviders(cmd *cobra.Command, _ []string) error {
 
 	w := cmd.OutOrStdout()
 
-	configs := reg.ListConfig()
-	transforms := reg.ListTransform()
-	stores := reg.ListStore()
+	configInfos := reg.ListConfigProviders()
+	transformInfos := reg.ListTransformProviders()
+	storeInfos := reg.ListStoreProviders()
 
 	if listJSON {
-		out := map[string][]string{
-			"config":    configs,
-			"transform": transforms,
-			"store":     stores,
+		out := map[string][]providerJSONEntry{
+			"config":    toJSONEntries(configInfos),
+			"transform": toJSONEntries(transformInfos),
+			"store":     toJSONEntries(storeInfos),
 		}
 		data, err := json.MarshalIndent(out, "", "  ")
 		if err != nil {
@@ -61,24 +69,36 @@ func runListProviders(cmd *cobra.Command, _ []string) error {
 	}
 
 	fmt.Fprintln(w, "Config providers:")
-	for _, name := range configs {
-		fmt.Fprintf(w, "  %s\n", name)
-	}
+	printProviderInfos(w, configInfos)
 	fmt.Fprintln(w, "Transform providers:")
-	if len(transforms) == 0 {
+	if len(transformInfos) == 0 {
 		fmt.Fprintln(w, "  (none)")
 	}
-	for _, name := range transforms {
-		fmt.Fprintf(w, "  %s\n", name)
-	}
+	printProviderInfos(w, transformInfos)
 	fmt.Fprintln(w, "Store providers:")
-	if len(stores) == 0 {
+	if len(storeInfos) == 0 {
 		fmt.Fprintln(w, "  (none)")
 	}
-	for _, name := range stores {
-		fmt.Fprintf(w, "  %s\n", name)
-	}
+	printProviderInfos(w, storeInfos)
 	return nil
+}
+
+func printProviderInfos(w io.Writer, infos []core.ProviderInfo) {
+	for _, info := range infos {
+		if info.Source == "built-in" {
+			fmt.Fprintf(w, "  %-20s (built-in)\n", info.Name)
+		} else {
+			fmt.Fprintf(w, "  %-20s (external: %s)\n", info.Name, info.Source)
+		}
+	}
+}
+
+func toJSONEntries(infos []core.ProviderInfo) []providerJSONEntry {
+	entries := make([]providerJSONEntry, len(infos))
+	for i, info := range infos {
+		entries[i] = providerJSONEntry{Name: info.Name, Source: info.Source}
+	}
+	return entries
 }
 
 // --- list trees ---

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -91,6 +91,11 @@ func withEngine(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("loading workspace: %w", err)
 	}
 
+	// Discover external plugins from workspace-configured directories.
+	_ = reg.RefreshExternal(core.DiscoveryConfig{
+		Directories: ws.PluginDirectories(),
+	})
+
 	eng, err := core.NewEngine(reg, ws)
 	if err != nil {
 		return fmt.Errorf("initializing engine: %w", err)
@@ -112,9 +117,14 @@ func withEngine(cmd *cobra.Command, _ []string) error {
 }
 
 // withRegistry is a PersistentPreRunE that only initializes the registry
-// (no workspace needed).
+// (no workspace needed). It still discovers external plugins from the
+// default plugin directory.
 func withRegistry(cmd *cobra.Command, _ []string) error {
 	reg := core.DefaultRegistry()
+
+	// Discover external plugins from default directories.
+	_ = reg.RefreshExternal(core.DiscoveryConfig{})
+
 	ctx := context.WithValue(cmd.Context(), registryKey, reg)
 	cmd.SetContext(ctx)
 	return nil

--- a/internal/core/discovery.go
+++ b/internal/core/discovery.go
@@ -1,0 +1,201 @@
+package core
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PluginType identifies the kind of external plugin.
+type PluginType string
+
+const (
+	PluginTypeConfig    PluginType = "config"
+	PluginTypeTransform PluginType = "transform"
+	PluginTypeStore     PluginType = "store"
+)
+
+// PluginInfo describes a discovered external plugin binary.
+type PluginInfo struct {
+	Name string     // provider name (e.g. "pokedex")
+	Type PluginType // plugin type: config, transform, or store
+	Path string     // absolute path to the binary
+}
+
+// DiscoveryConfig controls where to scan for external plugin binaries.
+type DiscoveryConfig struct {
+	// Directories to scan for plugin binaries. If empty, defaults to
+	// ~/.zhi/plugins/.
+	Directories []string
+}
+
+// DefaultPluginDir returns the default plugin directory (~/.zhi/plugins/).
+func DefaultPluginDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".zhi", "plugins")
+}
+
+// Discover scans the configured directories for external plugin binaries
+// and returns information about each found plugin. Non-executable files
+// are skipped. Both flat naming (zhi-<type>-<name>) and subdirectory
+// layouts (<type>/<name>) are supported. Flat naming takes precedence.
+func Discover(cfg DiscoveryConfig) ([]PluginInfo, error) {
+	dirs := cfg.Directories
+	if len(dirs) == 0 {
+		if d := DefaultPluginDir(); d != "" {
+			dirs = []string{d}
+		}
+	}
+
+	// Track discovered plugins by type+name to avoid duplicates.
+	seen := make(map[string]bool)
+	var plugins []PluginInfo
+
+	for _, dir := range dirs {
+		expanded := expandHome(dir)
+		flat, err := discoverFlat(expanded)
+		if err != nil {
+			continue // skip directories that don't exist or can't be read
+		}
+		for _, p := range flat {
+			key := string(p.Type) + "/" + p.Name
+			if !seen[key] {
+				seen[key] = true
+				plugins = append(plugins, p)
+			}
+		}
+
+		sub, err := discoverSubdirectory(expanded)
+		if err != nil {
+			continue
+		}
+		for _, p := range sub {
+			key := string(p.Type) + "/" + p.Name
+			if !seen[key] {
+				seen[key] = true
+				plugins = append(plugins, p)
+			}
+		}
+	}
+
+	return plugins, nil
+}
+
+// discoverFlat scans a directory for binaries named zhi-<type>-<name>.
+func discoverFlat(dir string) ([]PluginInfo, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var plugins []PluginInfo
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		pluginType, pluginName, ok := parseFlatName(name)
+		if !ok {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if !isExecutable(entry) {
+			continue
+		}
+		plugins = append(plugins, PluginInfo{
+			Name: pluginName,
+			Type: pluginType,
+			Path: path,
+		})
+	}
+	return plugins, nil
+}
+
+// discoverSubdirectory scans for type-based subdirectory layouts:
+// <dir>/config/<name>, <dir>/transform/<name>, <dir>/store/<name>.
+func discoverSubdirectory(dir string) ([]PluginInfo, error) {
+	typeNames := []PluginType{PluginTypeConfig, PluginTypeTransform, PluginTypeStore}
+	var plugins []PluginInfo
+
+	for _, pt := range typeNames {
+		subdir := filepath.Join(dir, string(pt))
+		entries, err := os.ReadDir(subdir)
+		if err != nil {
+			continue // subdirectory doesn't exist
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			if !isExecutable(entry) {
+				continue
+			}
+			plugins = append(plugins, PluginInfo{
+				Name: entry.Name(),
+				Type: pt,
+				Path: filepath.Join(subdir, entry.Name()),
+			})
+		}
+	}
+	return plugins, nil
+}
+
+// parseFlatName parses a binary name like "zhi-config-pokedex" into
+// (PluginTypeConfig, "pokedex", true). Returns false if the name doesn't
+// match the expected pattern.
+func parseFlatName(name string) (PluginType, string, bool) {
+	if !strings.HasPrefix(name, "zhi-") {
+		return "", "", false
+	}
+	rest := name[len("zhi-"):]
+
+	// Try each known type prefix.
+	for _, pt := range []PluginType{PluginTypeConfig, PluginTypeTransform, PluginTypeStore} {
+		prefix := string(pt) + "-"
+		if strings.HasPrefix(rest, prefix) {
+			pluginName := rest[len(prefix):]
+			if pluginName == "" {
+				return "", "", false
+			}
+			return pt, pluginName, true
+		}
+	}
+	return "", "", false
+}
+
+// isExecutable checks if a directory entry has executable permission.
+func isExecutable(entry fs.DirEntry) bool {
+	info, err := entry.Info()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&0o111 != 0
+}
+
+// expandHome replaces a leading ~ with the user's home directory.
+func expandHome(path string) string {
+	if !strings.HasPrefix(path, "~") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+// String returns a human-readable representation of PluginInfo.
+func (p PluginInfo) String() string {
+	return fmt.Sprintf("%s/%s (%s)", p.Type, p.Name, p.Path)
+}

--- a/internal/core/discovery_test.go
+++ b/internal/core/discovery_test.go
@@ -1,0 +1,325 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+)
+
+func TestParseFlatName(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantType   PluginType
+		wantName   string
+		wantOK     bool
+	}{
+		{"config plugin", "zhi-config-pokedex", PluginTypeConfig, "pokedex", true},
+		{"transform plugin", "zhi-transform-evolve", PluginTypeTransform, "evolve", true},
+		{"store plugin", "zhi-store-vault", PluginTypeStore, "vault", true},
+		{"store with dash", "zhi-store-json-store", PluginTypeStore, "json-store", true},
+		{"no prefix", "pokedex", "", "", false},
+		{"zhi only", "zhi-", "", "", false},
+		{"unknown type", "zhi-unknown-foo", "", "", false},
+		{"missing name", "zhi-config-", "", "", false},
+		{"just zhi prefix no type", "zhi-foo", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pt, pn, ok := parseFlatName(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("parseFlatName(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if pt != tt.wantType {
+				t.Errorf("parseFlatName(%q) type = %v, want %v", tt.input, pt, tt.wantType)
+			}
+			if pn != tt.wantName {
+				t.Errorf("parseFlatName(%q) name = %v, want %v", tt.input, pn, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestDiscoverFlatLayout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: executable permissions not supported")
+	}
+
+	dir := t.TempDir()
+
+	// Create executable plugin binaries.
+	createExecutable(t, filepath.Join(dir, "zhi-config-pokedex"))
+	createExecutable(t, filepath.Join(dir, "zhi-transform-evolve"))
+	createExecutable(t, filepath.Join(dir, "zhi-store-vault"))
+
+	// Create a non-executable file (should be skipped).
+	if err := os.WriteFile(filepath.Join(dir, "zhi-config-skipped"), []byte("not executable"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file without the zhi- prefix (should be skipped).
+	createExecutable(t, filepath.Join(dir, "other-binary"))
+
+	plugins, err := Discover(DiscoveryConfig{Directories: []string{dir}})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	if len(plugins) != 3 {
+		t.Fatalf("got %d plugins, want 3: %v", len(plugins), plugins)
+	}
+
+	// Check each plugin was found.
+	assertPluginFound(t, plugins, "pokedex", PluginTypeConfig)
+	assertPluginFound(t, plugins, "evolve", PluginTypeTransform)
+	assertPluginFound(t, plugins, "vault", PluginTypeStore)
+}
+
+func TestDiscoverSubdirectoryLayout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: executable permissions not supported")
+	}
+
+	dir := t.TempDir()
+
+	// Create type subdirectories.
+	for _, subdir := range []string{"config", "transform", "store"} {
+		if err := os.MkdirAll(filepath.Join(dir, subdir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	createExecutable(t, filepath.Join(dir, "config", "pokedex"))
+	createExecutable(t, filepath.Join(dir, "transform", "evolve"))
+	createExecutable(t, filepath.Join(dir, "store", "vault"))
+
+	plugins, err := Discover(DiscoveryConfig{Directories: []string{dir}})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	if len(plugins) != 3 {
+		t.Fatalf("got %d plugins, want 3: %v", len(plugins), plugins)
+	}
+
+	assertPluginFound(t, plugins, "pokedex", PluginTypeConfig)
+	assertPluginFound(t, plugins, "evolve", PluginTypeTransform)
+	assertPluginFound(t, plugins, "vault", PluginTypeStore)
+}
+
+func TestDiscoverFlatTakesPrecedence(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: executable permissions not supported")
+	}
+
+	dir := t.TempDir()
+
+	// Create both flat and subdirectory entries for the same plugin.
+	flatPath := filepath.Join(dir, "zhi-config-pokedex")
+	createExecutable(t, flatPath)
+
+	if err := os.MkdirAll(filepath.Join(dir, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createExecutable(t, filepath.Join(dir, "config", "pokedex"))
+
+	plugins, err := Discover(DiscoveryConfig{Directories: []string{dir}})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	// Should only have one entry (flat takes precedence).
+	count := 0
+	for _, p := range plugins {
+		if p.Name == "pokedex" && p.Type == PluginTypeConfig {
+			count++
+			if p.Path != flatPath {
+				t.Errorf("expected flat path %s, got %s", flatPath, p.Path)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 pokedex config plugin, got %d", count)
+	}
+}
+
+func TestDiscoverEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	plugins, err := Discover(DiscoveryConfig{Directories: []string{dir}})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	if len(plugins) != 0 {
+		t.Errorf("got %d plugins from empty dir, want 0", len(plugins))
+	}
+}
+
+func TestDiscoverNonexistentDirectory(t *testing.T) {
+	plugins, err := Discover(DiscoveryConfig{Directories: []string{"/nonexistent/path"}})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(plugins) != 0 {
+		t.Errorf("got %d plugins from nonexistent dir, want 0", len(plugins))
+	}
+}
+
+func TestDiscoverMultipleDirectories(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: executable permissions not supported")
+	}
+
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	createExecutable(t, filepath.Join(dir1, "zhi-config-alpha"))
+	createExecutable(t, filepath.Join(dir2, "zhi-store-beta"))
+
+	plugins, err := Discover(DiscoveryConfig{Directories: []string{dir1, dir2}})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	if len(plugins) != 2 {
+		t.Fatalf("got %d plugins, want 2: %v", len(plugins), plugins)
+	}
+
+	assertPluginFound(t, plugins, "alpha", PluginTypeConfig)
+	assertPluginFound(t, plugins, "beta", PluginTypeStore)
+}
+
+func TestDiscoverSkipsNonExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: executable permissions not supported")
+	}
+
+	dir := t.TempDir()
+
+	// Create a non-executable file with valid name.
+	if err := os.WriteFile(filepath.Join(dir, "zhi-config-noexec"), []byte("#!/bin/sh"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	plugins, err := Discover(DiscoveryConfig{Directories: []string{dir}})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	if len(plugins) != 0 {
+		t.Errorf("got %d plugins, want 0 (non-executable should be skipped)", len(plugins))
+	}
+}
+
+func TestDiscoverSkipsDirectories(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: executable permissions not supported")
+	}
+
+	dir := t.TempDir()
+
+	// Create a directory named like a plugin.
+	if err := os.MkdirAll(filepath.Join(dir, "zhi-config-isdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	plugins, err := Discover(DiscoveryConfig{Directories: []string{dir}})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	// The directory itself should not be treated as a plugin.
+	for _, p := range plugins {
+		if p.Name == "isdir" {
+			t.Error("directory named like a plugin should not be discovered")
+		}
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
+	}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"/absolute/path", "/absolute/path"},
+		{"relative/path", "relative/path"},
+		{"~", home},
+		{"~/plugins", filepath.Join(home, "plugins")},
+		{"~other", "~other"}, // tilde not followed by / should not expand
+	}
+
+	for _, tt := range tests {
+		got := expandHome(tt.input)
+		if got != tt.want {
+			t.Errorf("expandHome(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestPluginInfoString(t *testing.T) {
+	p := PluginInfo{Name: "pokedex", Type: PluginTypeConfig, Path: "/usr/local/bin/zhi-config-pokedex"}
+	got := p.String()
+	want := "config/pokedex (/usr/local/bin/zhi-config-pokedex)"
+	if got != want {
+		t.Errorf("PluginInfo.String() = %q, want %q", got, want)
+	}
+}
+
+func TestDiscoverDuplicateAcrossDirectories(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: executable permissions not supported")
+	}
+
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	// Same plugin in both directories; first directory wins.
+	createExecutable(t, filepath.Join(dir1, "zhi-config-pokedex"))
+	createExecutable(t, filepath.Join(dir2, "zhi-config-pokedex"))
+
+	plugins, err := Discover(DiscoveryConfig{Directories: []string{dir1, dir2}})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	count := 0
+	for _, p := range plugins {
+		if p.Name == "pokedex" && p.Type == PluginTypeConfig {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 pokedex plugin (dedup), got %d", count)
+	}
+}
+
+// --- helpers ---
+
+func createExecutable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertPluginFound(t *testing.T, plugins []PluginInfo, name string, pt PluginType) {
+	t.Helper()
+	found := slices.ContainsFunc(plugins, func(p PluginInfo) bool {
+		return p.Name == name && p.Type == pt
+	})
+	if !found {
+		t.Errorf("plugin %s/%s not found in %v", pt, name, plugins)
+	}
+}

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -168,6 +168,13 @@ func (e *Engine) ListTrees(ctx context.Context) ([]string, error) {
 	return e.storePlugin.ListTrees(ctx)
 }
 
+// Close shuts down the engine, killing all external plugin processes.
+func (e *Engine) Close() {
+	if e.registry != nil {
+		e.registry.Close()
+	}
+}
+
 // Components returns the component manager for UI and CLI access.
 func (e *Engine) Components() *ComponentManager {
 	return e.components

--- a/internal/core/launcher.go
+++ b/internal/core/launcher.go
@@ -1,0 +1,107 @@
+package core
+
+import (
+	"fmt"
+	"os/exec"
+
+	goplugin "github.com/hashicorp/go-plugin"
+
+	"github.com/MrWong99/zhi/pkg/zhiplugin"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/store"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/transform"
+)
+
+// LaunchConfig launches an external config plugin binary and returns the
+// config.Plugin interface along with a cleanup function that kills the
+// plugin process. The caller must call cleanup when done.
+func LaunchConfig(path string) (config.Plugin, func(), error) {
+	client := goplugin.NewClient(&goplugin.ClientConfig{
+		HandshakeConfig:  zhiplugin.Handshake,
+		Plugins:          config.PluginMap,
+		Cmd:              exec.Command(path),
+		AllowedProtocols: []goplugin.Protocol{goplugin.ProtocolGRPC},
+	})
+
+	rpcClient, err := client.Client()
+	if err != nil {
+		client.Kill()
+		return nil, nil, fmt.Errorf("connecting to config plugin %s: %w", path, err)
+	}
+
+	raw, err := rpcClient.Dispense("config")
+	if err != nil {
+		client.Kill()
+		return nil, nil, fmt.Errorf("dispensing config plugin %s: %w", path, err)
+	}
+
+	p, ok := raw.(config.Plugin)
+	if !ok {
+		client.Kill()
+		return nil, nil, fmt.Errorf("config plugin %s: dispensed value does not implement config.Plugin", path)
+	}
+
+	return p, client.Kill, nil
+}
+
+// LaunchTransform launches an external transform plugin binary and returns
+// the transform.Plugin interface along with a cleanup function.
+func LaunchTransform(path string) (transform.Plugin, func(), error) {
+	client := goplugin.NewClient(&goplugin.ClientConfig{
+		HandshakeConfig:  zhiplugin.Handshake,
+		Plugins:          transform.PluginMap,
+		Cmd:              exec.Command(path),
+		AllowedProtocols: []goplugin.Protocol{goplugin.ProtocolGRPC},
+	})
+
+	rpcClient, err := client.Client()
+	if err != nil {
+		client.Kill()
+		return nil, nil, fmt.Errorf("connecting to transform plugin %s: %w", path, err)
+	}
+
+	raw, err := rpcClient.Dispense("transform")
+	if err != nil {
+		client.Kill()
+		return nil, nil, fmt.Errorf("dispensing transform plugin %s: %w", path, err)
+	}
+
+	p, ok := raw.(transform.Plugin)
+	if !ok {
+		client.Kill()
+		return nil, nil, fmt.Errorf("transform plugin %s: dispensed value does not implement transform.Plugin", path)
+	}
+
+	return p, client.Kill, nil
+}
+
+// LaunchStore launches an external store plugin binary and returns the
+// store.Plugin interface along with a cleanup function.
+func LaunchStore(path string) (store.Plugin, func(), error) {
+	client := goplugin.NewClient(&goplugin.ClientConfig{
+		HandshakeConfig:  zhiplugin.Handshake,
+		Plugins:          store.PluginMap,
+		Cmd:              exec.Command(path),
+		AllowedProtocols: []goplugin.Protocol{goplugin.ProtocolGRPC},
+	})
+
+	rpcClient, err := client.Client()
+	if err != nil {
+		client.Kill()
+		return nil, nil, fmt.Errorf("connecting to store plugin %s: %w", path, err)
+	}
+
+	raw, err := rpcClient.Dispense("store")
+	if err != nil {
+		client.Kill()
+		return nil, nil, fmt.Errorf("dispensing store plugin %s: %w", path, err)
+	}
+
+	p, ok := raw.(store.Plugin)
+	if !ok {
+		client.Kill()
+		return nil, nil, fmt.Errorf("store plugin %s: dispensed value does not implement store.Plugin", path)
+	}
+
+	return p, client.Kill, nil
+}

--- a/internal/core/launcher_test.go
+++ b/internal/core/launcher_test.go
@@ -1,0 +1,190 @@
+package core
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// findProjectRoot walks up from the current directory to find the go.mod file.
+func findProjectRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find project root (no go.mod found)")
+		}
+		dir = parent
+	}
+}
+
+// buildPlugin builds a Go plugin binary from the given source directory
+// and returns the path to the built binary.
+func buildPlugin(t *testing.T, srcDir, binaryName string) string {
+	t.Helper()
+	outDir := t.TempDir()
+	out := filepath.Join(outDir, binaryName)
+	cmd := exec.Command("go", "build", "-o", out, srcDir)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("building plugin %s: %v\n%s", srcDir, err, output)
+	}
+	return out
+}
+
+func TestLaunchConfigPlugin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping launcher test in short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	root := findProjectRoot(t)
+	bin := buildPlugin(t, filepath.Join(root, "examples", "pokedex-config"), "zhi-config-pokedex")
+
+	p, cleanup, err := LaunchConfig(bin)
+	if err != nil {
+		t.Fatalf("LaunchConfig: %v", err)
+	}
+	defer cleanup()
+
+	// Test List().
+	paths, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("List returned empty paths")
+	}
+
+	// Test Get().
+	v, ok, err := p.Get(context.Background(), "pokedex/trainer.name")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok {
+		t.Fatal("Get: not found")
+	}
+	if v.Val != "Ash" {
+		t.Errorf("Val = %v, want %q", v.Val, "Ash")
+	}
+}
+
+func TestLaunchTransformPlugin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping launcher test in short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	root := findProjectRoot(t)
+	bin := buildPlugin(t, filepath.Join(root, "examples", "pokedex-transform"), "zhi-transform-pokedex")
+
+	p, cleanup, err := LaunchTransform(bin)
+	if err != nil {
+		t.Fatalf("LaunchTransform: %v", err)
+	}
+	defer cleanup()
+
+	// Test ValidatePolicy().
+	policy, err := p.ValidatePolicy(context.Background())
+	if err != nil {
+		t.Fatalf("ValidatePolicy: %v", err)
+	}
+	// The pokedex-transform plugin returns ValidateBeforeTransform.
+	if policy != 0 { // ValidateBeforeTransform = 0
+		t.Errorf("ValidatePolicy = %v, want 0 (ValidateBeforeTransform)", policy)
+	}
+}
+
+func TestLaunchStorePlugin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping launcher test in short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	root := findProjectRoot(t)
+	bin := buildPlugin(t, filepath.Join(root, "examples", "memory-store"), "zhi-store-memory")
+
+	p, cleanup, err := LaunchStore(bin)
+	if err != nil {
+		t.Fatalf("LaunchStore: %v", err)
+	}
+	defer cleanup()
+
+	// Test ListTrees (should be empty initially).
+	trees, err := p.ListTrees(context.Background())
+	if err != nil {
+		t.Fatalf("ListTrees: %v", err)
+	}
+	if len(trees) != 0 {
+		t.Errorf("ListTrees = %v, want empty", trees)
+	}
+
+	// Test SupportsVersioning.
+	versioning, err := p.SupportsVersioning(context.Background())
+	if err != nil {
+		t.Fatalf("SupportsVersioning: %v", err)
+	}
+	if versioning {
+		t.Error("memory-store should not support versioning")
+	}
+}
+
+func TestLaunchConfigInvalidPath(t *testing.T) {
+	_, _, err := LaunchConfig("/nonexistent/binary")
+	if err == nil {
+		t.Fatal("expected error for nonexistent binary")
+	}
+}
+
+func TestLaunchTransformInvalidPath(t *testing.T) {
+	_, _, err := LaunchTransform("/nonexistent/binary")
+	if err == nil {
+		t.Fatal("expected error for nonexistent binary")
+	}
+}
+
+func TestLaunchStoreInvalidPath(t *testing.T) {
+	_, _, err := LaunchStore("/nonexistent/binary")
+	if err == nil {
+		t.Fatal("expected error for nonexistent binary")
+	}
+}
+
+func TestCleanupKillsProcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping launcher test in short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	root := findProjectRoot(t)
+	bin := buildPlugin(t, filepath.Join(root, "examples", "memory-store"), "zhi-store-memory")
+
+	_, cleanup, err := LaunchStore(bin)
+	if err != nil {
+		t.Fatalf("LaunchStore: %v", err)
+	}
+
+	// Calling cleanup should not panic.
+	cleanup()
+	// Calling cleanup again should also not panic (Kill is idempotent).
+	cleanup()
+}

--- a/internal/core/registry.go
+++ b/internal/core/registry.go
@@ -5,6 +5,7 @@ package core
 import (
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
 	"github.com/MrWong99/zhi/pkg/zhiplugin/store"
@@ -21,21 +22,41 @@ type TransformFactory func(options map[string]any) (transform.Plugin, error)
 // StoreFactory constructs a store provider.
 type StoreFactory func(options map[string]any) (store.Plugin, error)
 
+// ProviderInfo describes a registered provider for display purposes.
+type ProviderInfo struct {
+	Name   string // provider name
+	Source string // "built-in" or path to external binary
+}
+
 // Registry maps provider names to factory functions for each plugin type.
 // It is populated at startup with compiled-in providers and used by the
-// engine to resolve workspace provider references.
+// engine to resolve workspace provider references. It also supports lazy
+// loading of external plugins discovered on disk.
 type Registry struct {
 	config    map[string]ConfigFactory
 	transform map[string]TransformFactory
 	store     map[string]StoreFactory
+
+	// External plugin discovery.
+	externalPlugins []PluginInfo
+
+	// Cached external plugin instances (lazy-loaded).
+	mu              sync.Mutex
+	cachedConfig    map[string]config.Plugin
+	cachedTransform map[string]transform.Plugin
+	cachedStore     map[string]store.Plugin
+	cleanups        []func()
 }
 
 // NewRegistry returns an empty provider registry.
 func NewRegistry() *Registry {
 	return &Registry{
-		config:    make(map[string]ConfigFactory),
-		transform: make(map[string]TransformFactory),
-		store:     make(map[string]StoreFactory),
+		config:          make(map[string]ConfigFactory),
+		transform:       make(map[string]TransformFactory),
+		store:           make(map[string]StoreFactory),
+		cachedConfig:    make(map[string]config.Plugin),
+		cachedTransform: make(map[string]transform.Plugin),
+		cachedStore:     make(map[string]store.Plugin),
 	}
 }
 
@@ -70,45 +91,244 @@ func (r *Registry) RegisterStore(name string, factory StoreFactory) error {
 }
 
 // ConfigProvider resolves and instantiates a config provider by name.
+// Built-in providers take precedence. If no built-in is found, discovered
+// external plugins are checked and launched lazily.
 func (r *Registry) ConfigProvider(name string, options map[string]any) (config.Plugin, error) {
-	factory, ok := r.config[name]
-	if !ok {
-		return nil, fmt.Errorf("unknown config provider: %q", name)
+	if factory, ok := r.config[name]; ok {
+		return factory(options)
 	}
-	return factory(options)
+	return r.launchExternalConfig(name)
 }
 
 // TransformProvider resolves and instantiates a transform provider by name.
 func (r *Registry) TransformProvider(name string, options map[string]any) (transform.Plugin, error) {
-	factory, ok := r.transform[name]
-	if !ok {
-		return nil, fmt.Errorf("unknown transform provider: %q", name)
+	if factory, ok := r.transform[name]; ok {
+		return factory(options)
 	}
-	return factory(options)
+	return r.launchExternalTransform(name)
 }
 
 // StoreProvider resolves and instantiates a store provider by name.
 func (r *Registry) StoreProvider(name string, options map[string]any) (store.Plugin, error) {
-	factory, ok := r.store[name]
+	if factory, ok := r.store[name]; ok {
+		return factory(options)
+	}
+	return r.launchExternalStore(name)
+}
+
+// ListConfig returns the sorted names of all registered config providers
+// (built-in and external).
+func (r *Registry) ListConfig() []string {
+	names := sortedKeys(r.config)
+	for _, p := range r.externalPlugins {
+		if p.Type == PluginTypeConfig && !contains(names, p.Name) {
+			names = append(names, p.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ListTransform returns the sorted names of all registered transform
+// providers (built-in and external).
+func (r *Registry) ListTransform() []string {
+	names := sortedKeys(r.transform)
+	for _, p := range r.externalPlugins {
+		if p.Type == PluginTypeTransform && !contains(names, p.Name) {
+			names = append(names, p.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ListStore returns the sorted names of all registered store providers
+// (built-in and external).
+func (r *Registry) ListStore() []string {
+	names := sortedKeys(r.store)
+	for _, p := range r.externalPlugins {
+		if p.Type == PluginTypeStore && !contains(names, p.Name) {
+			names = append(names, p.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ListConfigProviders returns detailed provider info including source.
+func (r *Registry) ListConfigProviders() []ProviderInfo {
+	var infos []ProviderInfo
+	for _, name := range sortedKeys(r.config) {
+		infos = append(infos, ProviderInfo{Name: name, Source: "built-in"})
+	}
+	for _, p := range r.externalPlugins {
+		if p.Type == PluginTypeConfig && !r.isBuiltinConfig(p.Name) {
+			infos = append(infos, ProviderInfo{Name: p.Name, Source: p.Path})
+		}
+	}
+	return infos
+}
+
+// ListTransformProviders returns detailed provider info including source.
+func (r *Registry) ListTransformProviders() []ProviderInfo {
+	var infos []ProviderInfo
+	for _, name := range sortedKeys(r.transform) {
+		infos = append(infos, ProviderInfo{Name: name, Source: "built-in"})
+	}
+	for _, p := range r.externalPlugins {
+		if p.Type == PluginTypeTransform && !r.isBuiltinTransform(p.Name) {
+			infos = append(infos, ProviderInfo{Name: p.Name, Source: p.Path})
+		}
+	}
+	return infos
+}
+
+// ListStoreProviders returns detailed provider info including source.
+func (r *Registry) ListStoreProviders() []ProviderInfo {
+	var infos []ProviderInfo
+	for _, name := range sortedKeys(r.store) {
+		infos = append(infos, ProviderInfo{Name: name, Source: "built-in"})
+	}
+	for _, p := range r.externalPlugins {
+		if p.Type == PluginTypeStore && !r.isBuiltinStore(p.Name) {
+			infos = append(infos, ProviderInfo{Name: p.Name, Source: p.Path})
+		}
+	}
+	return infos
+}
+
+// RefreshExternal re-scans plugin directories and updates the list of
+// discovered external plugins.
+func (r *Registry) RefreshExternal(cfg DiscoveryConfig) error {
+	plugins, err := Discover(cfg)
+	if err != nil {
+		return fmt.Errorf("discovering external plugins: %w", err)
+	}
+	r.mu.Lock()
+	r.externalPlugins = plugins
+	r.mu.Unlock()
+	return nil
+}
+
+// SetExternalPlugins sets the discovered external plugins directly.
+// This is useful when discovery has already been performed.
+func (r *Registry) SetExternalPlugins(plugins []PluginInfo) {
+	r.mu.Lock()
+	r.externalPlugins = plugins
+	r.mu.Unlock()
+}
+
+// Close kills all launched external plugin processes and clears caches.
+func (r *Registry) Close() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, cleanup := range r.cleanups {
+		cleanup()
+	}
+	r.cleanups = nil
+	r.cachedConfig = make(map[string]config.Plugin)
+	r.cachedTransform = make(map[string]transform.Plugin)
+	r.cachedStore = make(map[string]store.Plugin)
+}
+
+// launchExternalConfig finds and launches an external config plugin.
+func (r *Registry) launchExternalConfig(name string) (config.Plugin, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Check cache first.
+	if p, ok := r.cachedConfig[name]; ok {
+		return p, nil
+	}
+
+	// Find the plugin in discovered list.
+	info, ok := r.findExternal(name, PluginTypeConfig)
+	if !ok {
+		return nil, fmt.Errorf("unknown config provider: %q", name)
+	}
+
+	p, cleanup, err := LaunchConfig(info.Path)
+	if err != nil {
+		return nil, fmt.Errorf("launching external config plugin %q: %w", name, err)
+	}
+
+	r.cachedConfig[name] = p
+	r.cleanups = append(r.cleanups, cleanup)
+	return p, nil
+}
+
+// launchExternalTransform finds and launches an external transform plugin.
+func (r *Registry) launchExternalTransform(name string) (transform.Plugin, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if p, ok := r.cachedTransform[name]; ok {
+		return p, nil
+	}
+
+	info, ok := r.findExternal(name, PluginTypeTransform)
+	if !ok {
+		return nil, fmt.Errorf("unknown transform provider: %q", name)
+	}
+
+	p, cleanup, err := LaunchTransform(info.Path)
+	if err != nil {
+		return nil, fmt.Errorf("launching external transform plugin %q: %w", name, err)
+	}
+
+	r.cachedTransform[name] = p
+	r.cleanups = append(r.cleanups, cleanup)
+	return p, nil
+}
+
+// launchExternalStore finds and launches an external store plugin.
+func (r *Registry) launchExternalStore(name string) (store.Plugin, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if p, ok := r.cachedStore[name]; ok {
+		return p, nil
+	}
+
+	info, ok := r.findExternal(name, PluginTypeStore)
 	if !ok {
 		return nil, fmt.Errorf("unknown store provider: %q", name)
 	}
-	return factory(options)
+
+	p, cleanup, err := LaunchStore(info.Path)
+	if err != nil {
+		return nil, fmt.Errorf("launching external store plugin %q: %w", name, err)
+	}
+
+	r.cachedStore[name] = p
+	r.cleanups = append(r.cleanups, cleanup)
+	return p, nil
 }
 
-// ListConfig returns the sorted names of all registered config providers.
-func (r *Registry) ListConfig() []string {
-	return sortedKeys(r.config)
+// findExternal searches the discovered plugins for a match. Must be called
+// with r.mu held.
+func (r *Registry) findExternal(name string, pt PluginType) (PluginInfo, bool) {
+	for _, p := range r.externalPlugins {
+		if p.Name == name && p.Type == pt {
+			return p, true
+		}
+	}
+	return PluginInfo{}, false
 }
 
-// ListTransform returns the sorted names of all registered transform providers.
-func (r *Registry) ListTransform() []string {
-	return sortedKeys(r.transform)
+func (r *Registry) isBuiltinConfig(name string) bool {
+	_, ok := r.config[name]
+	return ok
 }
 
-// ListStore returns the sorted names of all registered store providers.
-func (r *Registry) ListStore() []string {
-	return sortedKeys(r.store)
+func (r *Registry) isBuiltinTransform(name string) bool {
+	_, ok := r.transform[name]
+	return ok
+}
+
+func (r *Registry) isBuiltinStore(name string) bool {
+	_, ok := r.store[name]
+	return ok
 }
 
 func sortedKeys[V any](m map[string]V) []string {
@@ -118,4 +338,13 @@ func sortedKeys[V any](m map[string]V) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/core/registry_test.go
+++ b/internal/core/registry_test.go
@@ -179,3 +179,201 @@ func TestDefaultRegistryHasStructuredfile(t *testing.T) {
 		t.Errorf("DefaultRegistry ListConfig() = %v, want %v", got, want)
 	}
 }
+
+func TestRegistryListIncludesExternal(t *testing.T) {
+	r := NewRegistry()
+	_ = r.RegisterConfig("builtin", func(map[string]any) (config.Plugin, error) {
+		return &stubConfig{}, nil
+	})
+
+	r.SetExternalPlugins([]PluginInfo{
+		{Name: "ext-config", Type: PluginTypeConfig, Path: "/fake/zhi-config-ext"},
+		{Name: "ext-transform", Type: PluginTypeTransform, Path: "/fake/zhi-transform-ext"},
+		{Name: "ext-store", Type: PluginTypeStore, Path: "/fake/zhi-store-ext"},
+	})
+
+	configs := r.ListConfig()
+	if !slices.Contains(configs, "builtin") {
+		t.Error("ListConfig missing built-in provider")
+	}
+	if !slices.Contains(configs, "ext-config") {
+		t.Error("ListConfig missing external provider")
+	}
+
+	transforms := r.ListTransform()
+	if !slices.Contains(transforms, "ext-transform") {
+		t.Error("ListTransform missing external provider")
+	}
+
+	stores := r.ListStore()
+	if !slices.Contains(stores, "ext-store") {
+		t.Error("ListStore missing external provider")
+	}
+}
+
+func TestRegistryListExternalDoesNotDuplicate(t *testing.T) {
+	r := NewRegistry()
+	_ = r.RegisterConfig("shared", func(map[string]any) (config.Plugin, error) {
+		return &stubConfig{}, nil
+	})
+
+	// External plugin with same name as built-in.
+	r.SetExternalPlugins([]PluginInfo{
+		{Name: "shared", Type: PluginTypeConfig, Path: "/fake/zhi-config-shared"},
+	})
+
+	configs := r.ListConfig()
+	count := 0
+	for _, name := range configs {
+		if name == "shared" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 'shared' in ListConfig, got %d", count)
+	}
+}
+
+func TestRegistryListProviderInfos(t *testing.T) {
+	r := NewRegistry()
+	_ = r.RegisterConfig("builtin", func(map[string]any) (config.Plugin, error) {
+		return &stubConfig{}, nil
+	})
+
+	r.SetExternalPlugins([]PluginInfo{
+		{Name: "ext", Type: PluginTypeConfig, Path: "/plugins/zhi-config-ext"},
+	})
+
+	infos := r.ListConfigProviders()
+	if len(infos) != 2 {
+		t.Fatalf("got %d infos, want 2", len(infos))
+	}
+
+	// First should be built-in (sorted).
+	if infos[0].Name != "builtin" || infos[0].Source != "built-in" {
+		t.Errorf("infos[0] = %+v, want builtin/built-in", infos[0])
+	}
+	if infos[1].Name != "ext" || infos[1].Source != "/plugins/zhi-config-ext" {
+		t.Errorf("infos[1] = %+v, want ext/external-path", infos[1])
+	}
+}
+
+func TestRegistryListProviderInfosExternalSameNameAsBuiltin(t *testing.T) {
+	r := NewRegistry()
+	_ = r.RegisterConfig("shared", func(map[string]any) (config.Plugin, error) {
+		return &stubConfig{}, nil
+	})
+
+	r.SetExternalPlugins([]PluginInfo{
+		{Name: "shared", Type: PluginTypeConfig, Path: "/plugins/zhi-config-shared"},
+	})
+
+	// Built-in takes precedence; external with same name should not appear.
+	infos := r.ListConfigProviders()
+	if len(infos) != 1 {
+		t.Fatalf("got %d infos, want 1 (external duplicate should be filtered)", len(infos))
+	}
+	if infos[0].Source != "built-in" {
+		t.Errorf("expected built-in source, got %q", infos[0].Source)
+	}
+}
+
+func TestRegistryBuiltinTakesPrecedenceOverExternal(t *testing.T) {
+	r := NewRegistry()
+	_ = r.RegisterConfig("test", func(map[string]any) (config.Plugin, error) {
+		return &stubConfig{}, nil
+	})
+
+	r.SetExternalPlugins([]PluginInfo{
+		{Name: "test", Type: PluginTypeConfig, Path: "/fake/zhi-config-test"},
+	})
+
+	// Should resolve the built-in, not the external.
+	p, err := r.ConfigProvider("test", nil)
+	if err != nil {
+		t.Fatalf("ConfigProvider: %v", err)
+	}
+	if p == nil {
+		t.Fatal("ConfigProvider returned nil")
+	}
+}
+
+func TestRegistryExternalFallbackUnknown(t *testing.T) {
+	r := NewRegistry()
+
+	// No external plugins set, should fail.
+	_, err := r.ConfigProvider("nonexistent", nil)
+	if err == nil {
+		t.Error("expected error for unknown config provider without externals")
+	}
+}
+
+func TestRegistryClose(t *testing.T) {
+	r := NewRegistry()
+
+	cleanupCalled := 0
+	r.mu.Lock()
+	r.cleanups = append(r.cleanups, func() { cleanupCalled++ })
+	r.cleanups = append(r.cleanups, func() { cleanupCalled++ })
+	r.cachedConfig["test"] = &stubConfig{}
+	r.mu.Unlock()
+
+	r.Close()
+
+	if cleanupCalled != 2 {
+		t.Errorf("cleanup called %d times, want 2", cleanupCalled)
+	}
+
+	r.mu.Lock()
+	if len(r.cachedConfig) != 0 {
+		t.Error("cachedConfig not cleared after Close")
+	}
+	if len(r.cleanups) != 0 {
+		t.Error("cleanups not cleared after Close")
+	}
+	r.mu.Unlock()
+}
+
+func TestRegistryCloseIdempotent(t *testing.T) {
+	r := NewRegistry()
+
+	cleanupCalled := 0
+	r.mu.Lock()
+	r.cleanups = append(r.cleanups, func() { cleanupCalled++ })
+	r.mu.Unlock()
+
+	r.Close()
+	r.Close() // should not panic or call cleanup again
+
+	if cleanupCalled != 1 {
+		t.Errorf("cleanup called %d times, want 1", cleanupCalled)
+	}
+}
+
+func TestRegistryRefreshExternal(t *testing.T) {
+	r := NewRegistry()
+
+	// RefreshExternal with a non-existent dir should succeed (empty result).
+	err := r.RefreshExternal(DiscoveryConfig{Directories: []string{"/nonexistent"}})
+	if err != nil {
+		t.Fatalf("RefreshExternal: %v", err)
+	}
+
+	if len(r.externalPlugins) != 0 {
+		t.Errorf("expected 0 external plugins, got %d", len(r.externalPlugins))
+	}
+}
+
+func TestRegistrySetExternalPlugins(t *testing.T) {
+	r := NewRegistry()
+
+	plugins := []PluginInfo{
+		{Name: "a", Type: PluginTypeConfig, Path: "/a"},
+		{Name: "b", Type: PluginTypeStore, Path: "/b"},
+	}
+	r.SetExternalPlugins(plugins)
+
+	if len(r.externalPlugins) != 2 {
+		t.Errorf("expected 2 external plugins, got %d", len(r.externalPlugins))
+	}
+}

--- a/internal/core/workspace.go
+++ b/internal/core/workspace.go
@@ -106,6 +106,11 @@ func (ac *ApplyConfig) ResolveTarget(name string) (ApplyTargetConfig, error) {
 	}, nil
 }
 
+// PluginsConfig holds the optional plugin discovery configuration.
+type PluginsConfig struct {
+	Directories []string `yaml:"directories,omitempty" json:"directories,omitempty"`
+}
+
 // WorkspaceConfig is the parsed representation of a zhi.yaml (or zhi.json)
 // workspace configuration file.
 type WorkspaceConfig struct {
@@ -116,10 +121,23 @@ type WorkspaceConfig struct {
 	Components []ComponentDef `yaml:"components,omitempty" json:"components,omitempty"`
 	Export     ExportConfig   `yaml:"export,omitempty" json:"export,omitempty"`
 	Apply      ApplyConfig    `yaml:"apply,omitempty" json:"apply,omitempty"`
+	Plugins    PluginsConfig  `yaml:"plugins,omitempty" json:"plugins,omitempty"`
 
 	// Dir is the absolute directory containing the workspace config file.
 	// It is set during loading and not part of the config file itself.
 	Dir string `yaml:"-" json:"-"`
+}
+
+// PluginDirectories returns the configured plugin directories, falling
+// back to the default (~/.zhi/plugins/) if none are specified.
+func (ws *WorkspaceConfig) PluginDirectories() []string {
+	if len(ws.Plugins.Directories) > 0 {
+		return ws.Plugins.Directories
+	}
+	if d := DefaultPluginDir(); d != "" {
+		return []string{d}
+	}
+	return nil
 }
 
 // LoadWorkspace finds and parses a zhi.yaml (or zhi.json) in dir or any


### PR DESCRIPTION
Extend the provider registry to discover and launch external plugins
from ~/.zhi/plugins/ (and user-configured directories). External plugins
are separate binaries communicating via hashicorp/go-plugin over gRPC.

- Add plugin discovery (internal/core/discovery.go) supporting flat
  naming (zhi-<type>-<name>) and subdirectory layouts
- Add plugin launcher (internal/core/launcher.go) with LaunchConfig,
  LaunchTransform, and LaunchStore functions
- Extend Registry with external plugin fallback, lazy loading, caching,
  Close() cleanup, RefreshExternal(), and provider info listing
- Add PluginsConfig section to workspace config for custom plugin dirs
- Add Engine.Close() for shutdown cleanup
- Update CLI list providers to show built-in vs external sources
- Update CLI root to discover external plugins on startup

https://claude.ai/code/session_0184gap8Bdnft1jfiDuSiV8b