### PR TITLE
Add security hardening, logging, and polish (MVP step 8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,53 @@ past the tall grass into production.
 
 ## Getting Started
 
-*Coming soon...*
+### Prerequisites
+
+- Go 1.24+
+- protoc (optional, for regenerating gRPC stubs)
+
+### Installation
+
+```sh
+git clone https://github.com/MrWong99/zhi.git
+cd zhi
+make build
+```
+
+The `zhi` binary will be placed in `bin/`.
+
+### Quick Start
+
+```sh
+# Initialize a new workspace
+zhi init
+
+# View all configuration paths
+zhi list paths
+
+# Get a specific value
+zhi get database/host
+
+# Set a value
+zhi set database/host mydb.example.com
+
+# Validate the configuration
+zhi validate
+
+# Export as JSON
+zhi export --format json
+
+# Launch the interactive TUI editor
+zhi edit
+```
+
+### Verbose / Debug Logging
+
+Pass `--verbose` to any command to enable debug-level logging to stderr:
+
+```sh
+zhi validate --verbose
+```
 
 ---
 

--- a/internal/cli/component.go
+++ b/internal/cli/component.go
@@ -11,7 +11,17 @@ import (
 var componentCmd = &cobra.Command{
 	Use:   "component",
 	Short: "Manage components",
-	Long:  "Manage component state: enable, disable, list, and inspect components.",
+	Long: `Manage component state: enable, disable, list, and inspect components.
+
+Components are logical groups of configuration paths. Enabling a component
+makes its paths visible; disabling it hides them from exports and the TUI.
+
+Mandatory components cannot be disabled. Dependencies are automatically
+enabled when a component that depends on them is enabled.`,
+	Example: `  zhi component list
+  zhi component enable monitoring
+  zhi component disable monitoring
+  zhi component info database`,
 }
 
 var (

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -20,7 +20,7 @@ Examples:
   zhi export --template ./tmpl/app.tmpl -o out   # render template to file
   zhi export                                     # export all templates from zhi.yaml`,
 	PersistentPreRunE: withEngine,
-	RunE:             runExport,
+	RunE:              runExport,
 }
 
 var (

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -8,9 +8,15 @@ import (
 )
 
 var getCmd = &cobra.Command{
-	Use:               "get <path>",
-	Short:             "Get a configuration value",
-	Long:              "Get a single value from the configuration tree at the specified path.",
+	Use:   "get <path>",
+	Short: "Get a configuration value",
+	Long: `Get a single value from the configuration tree at the specified path.
+
+By default, prints the value with its metadata. Use --raw for just the
+value, or --json for structured JSON output including metadata.`,
+	Example: `  zhi get database/host
+  zhi get database/port --raw
+  zhi get app/name --json`,
 	Args:              cobra.ExactArgs(1),
 	PersistentPreRunE: withEngine,
 	RunE:              runGet,

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -24,16 +24,18 @@ func parseComponentState(data []byte) (map[string]bool, error) {
 }
 
 // saveComponentState persists component state to the state file.
+// The .zhi directory is created with 0700 (user-only) and state files
+// are written with 0600 permissions.
 func saveComponentState(wsDir string, state map[string]bool) error {
 	path := stateFilePath(wsDir)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	return os.WriteFile(path, data, 0o600)
 }
 
 // padRight pads a string to the given width.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -11,8 +11,23 @@ import (
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize a new zhi workspace",
-	Long:  "Scaffold a new zhi workspace in the current (or specified) directory.",
-	RunE:  runInit,
+	Long: `Initialize a new zhi workspace by scaffolding the directory structure
+and configuration files needed to get started.
+
+This creates:
+  - zhi.yaml                 Workspace configuration
+  - config/app.yaml          Starter configuration values
+  - templates/sample.tmpl    Example export template
+  - .zhi/                    Internal data directory
+
+Examples:
+  zhi init                        # initialize in the current directory
+  zhi init --workspace ./myapp    # initialize in ./myapp
+  zhi init --force                # overwrite existing zhi.yaml`,
+	Example: `  zhi init
+  zhi init --config-provider structuredfile --store-provider json-store
+  zhi init --force`,
+	RunE: runInit,
 }
 
 var (
@@ -146,22 +161,28 @@ monitoring:
 	}
 	created = append(created, "templates/sample.tmpl")
 
-	// 4. Create ./.zhi/store/ directory
-	storeDir := filepath.Join(absDir, ".zhi", "store")
-	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+	// 4. Create ./.zhi/ directory with user-only permissions (0700)
+	zhiDir := filepath.Join(absDir, ".zhi")
+	if err := os.MkdirAll(zhiDir, 0o700); err != nil {
+		return fmt.Errorf("creating .zhi directory: %w", err)
+	}
+
+	// Create .zhi/store/ subdirectory
+	storeDir := filepath.Join(zhiDir, "store")
+	if err := os.MkdirAll(storeDir, 0o700); err != nil {
 		return fmt.Errorf("creating .zhi/store directory: %w", err)
 	}
 	created = append(created, ".zhi/store/")
 
-	// 5. Create ./.zhi/components.json with default component state
+	// 5. Create ./.zhi/components.json with default component state (0600 permissions)
 	componentState := `{
   "app": true,
   "database": true,
   "monitoring": false
 }
 `
-	componentsFile := filepath.Join(absDir, ".zhi", "components.json")
-	if err := os.WriteFile(componentsFile, []byte(componentState), 0o644); err != nil {
+	componentsFile := filepath.Join(zhiDir, "components.json")
+	if err := os.WriteFile(componentsFile, []byte(componentState), 0o600); err != nil {
 		return fmt.Errorf("writing .zhi/components.json: %w", err)
 	}
 	created = append(created, ".zhi/components.json")
@@ -171,6 +192,17 @@ monitoring:
 	for _, f := range created {
 		fmt.Fprintf(w, "  %s\n", f)
 	}
+
+	// 7. Print what's next message
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "What's next?")
+	fmt.Fprintln(w, "  Edit configuration values:   zhi edit")
+	fmt.Fprintln(w, "  Export configuration:         zhi export --format json")
+	fmt.Fprintln(w, "  Validate configuration:       zhi validate")
+	fmt.Fprintln(w, "  List config paths:            zhi list paths")
+	fmt.Fprintln(w, "  Manage components:            zhi component list")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Add .zhi/ to your .gitignore to keep internal state out of version control.")
 
 	return nil
 }

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -14,7 +14,17 @@ import (
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List workspace information",
-	Long:  "List available information about the workspace (providers, trees, paths, components).",
+	Long: `List available information about the workspace.
+
+Subcommands:
+  providers    List all registered config, transform, and store providers
+  trees        List all stored tree IDs
+  paths        List all configuration paths in the current tree
+  components   List all defined components with their status`,
+	Example: `  zhi list providers
+  zhi list paths --json
+  zhi list trees
+  zhi list components`,
 }
 
 var listJSON bool

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,7 +4,10 @@ package cli
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -29,19 +32,55 @@ var rootCmd = &cobra.Command{
 	Use:   "zhi",
 	Short: "Security-first configuration management and provisioning",
 	Long: `zhi is a security-first platform for configuration management and provisioning.
-It uses an extensible plugin system with config, transform, and store providers.`,
+
+It uses an extensible plugin system over gRPC with three plugin types:
+  - config: provides and validates configuration values
+  - transform: mutates configuration before display or after save
+  - store: persists configuration trees with optional encryption
+
+Common workflow:
+  zhi init          Initialize a new workspace
+  zhi edit          Launch the interactive TUI editor
+  zhi export        Export configuration using templates or formats
+  zhi apply         Run the configured provisioning command
+  zhi validate      Check configuration for errors
+
+Use "zhi <command> --help" for more information about a command.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&workspace, "workspace", ".", "workspace directory")
-	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "enable verbose output")
+	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "enable debug logging to stderr")
 }
 
 // Execute runs the root command. It is called from main().
 func Execute() error {
-	return rootCmd.Execute()
+	// Set up signal handling for graceful shutdown.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	rootCmd.SetContext(ctx)
+
+	// Configure logging level based on --verbose flag. We use a
+	// PersistentPreRun on the root command to set this early.
+	origPreRun := rootCmd.PersistentPreRun
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if verbose {
+			core.SetLogLevel(slog.LevelDebug)
+			core.Logger().Debug("verbose logging enabled")
+		}
+		if origPreRun != nil {
+			origPreRun(cmd, args)
+		}
+	}
+
+	err := rootCmd.Execute()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+	}
+	return err
 }
 
 // engineFromCmd returns the Engine stored in the command's context.
@@ -74,6 +113,8 @@ func registryFromCmd(cmd *cobra.Command) (*core.Registry, error) {
 // withEngine is a PersistentPreRunE that loads the workspace config,
 // creates a registry and engine, and stores them in the command context.
 func withEngine(cmd *cobra.Command, _ []string) error {
+	log := core.Logger()
+
 	dir := workspace
 	if dir == "" {
 		dir = "."
@@ -90,6 +131,7 @@ func withEngine(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("loading workspace: %w", err)
 	}
+	log.Debug("workspace loaded", "dir", ws.Dir, "version", ws.Version)
 
 	// Discover external plugins from workspace-configured directories.
 	_ = reg.RefreshExternal(core.DiscoveryConfig{
@@ -101,12 +143,22 @@ func withEngine(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("initializing engine: %w", err)
 	}
 
+	// Register cleanup to kill plugin processes on shutdown.
+	go func() {
+		<-cmd.Context().Done()
+		log.Debug("shutting down engine, killing plugin processes")
+		eng.Close()
+	}()
+
 	// Load component state if available.
 	statePath := stateFilePath(ws.Dir)
 	if data, err := os.ReadFile(statePath); err == nil {
 		state, err := parseComponentState(data)
 		if err == nil {
 			eng.Components().LoadState(state)
+			log.Debug("component state loaded", "path", statePath)
+		} else {
+			log.Warn("failed to parse component state", "path", statePath, "error", err)
 		}
 	}
 

--- a/internal/cli/set.go
+++ b/internal/cli/set.go
@@ -11,9 +11,20 @@ import (
 )
 
 var setCmd = &cobra.Command{
-	Use:               "set <path> <value>",
-	Short:             "Set a configuration value",
-	Long:              "Set a single value in the configuration tree at the specified path.",
+	Use:   "set <path> <value>",
+	Short: "Set a configuration value",
+	Long: `Set a single value in the configuration tree at the specified path.
+
+The path must be a valid slash-delimited configuration path where each
+segment matches [a-z][a-z0-9._-]*[a-z0-9].
+
+Values are parsed as JSON objects/arrays, booleans, numbers, or strings
+(in that order of precedence).`,
+	Example: `  zhi set database/host localhost
+  zhi set database/port 5432
+  zhi set app/debug true
+  zhi set app/tags '["web","api"]'
+  zhi set database/host myhost --validate`,
 	Args:              cobra.ExactArgs(2),
 	PersistentPreRunE: withEngine,
 	RunE:              runSet,

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -12,9 +12,18 @@ import (
 )
 
 var validateCmd = &cobra.Command{
-	Use:               "validate",
-	Short:             "Validate the current configuration tree",
-	Long:              "Validate the current configuration tree and print results grouped by severity.",
+	Use:   "validate",
+	Short: "Validate the current configuration tree",
+	Long: `Validate the current configuration tree and print results grouped by severity.
+
+Runs config provider validation for all paths and checks component dependency
+constraints. Results are grouped by severity: blocking errors prevent deployment,
+warnings signal potential issues, and info messages are informational.
+
+The exit code is 1 if any blocking errors are found.`,
+	Example: `  zhi validate
+  zhi validate --path database/host
+  zhi validate --json`,
 	PersistentPreRunE: withEngine,
 	RunE:              runValidate,
 }

--- a/internal/core/discovery.go
+++ b/internal/core/discovery.go
@@ -56,10 +56,19 @@ func Discover(cfg DiscoveryConfig) ([]PluginInfo, error) {
 	seen := make(map[string]bool)
 	var plugins []PluginInfo
 
+	log := Logger()
+
 	for _, dir := range dirs {
+		// Reject directories containing path traversal.
+		if containsPathTraversal(dir) {
+			log.Warn("skipping plugin directory with path traversal", "dir", dir)
+			continue
+		}
+
 		expanded := expandHome(dir)
 		flat, err := discoverFlat(expanded)
 		if err != nil {
+			log.Debug("skipping plugin directory", "dir", expanded, "error", err)
 			continue // skip directories that don't exist or can't be read
 		}
 		for _, p := range flat {
@@ -67,6 +76,7 @@ func Discover(cfg DiscoveryConfig) ([]PluginInfo, error) {
 			if !seen[key] {
 				seen[key] = true
 				plugins = append(plugins, p)
+				log.Debug("discovered plugin", "type", p.Type, "name", p.Name, "path", p.Path)
 			}
 		}
 
@@ -79,10 +89,12 @@ func Discover(cfg DiscoveryConfig) ([]PluginInfo, error) {
 			if !seen[key] {
 				seen[key] = true
 				plugins = append(plugins, p)
+				log.Debug("discovered plugin", "type", p.Type, "name", p.Name, "path", p.Path)
 			}
 		}
 	}
 
+	log.Debug("plugin discovery complete", "count", len(plugins))
 	return plugins, nil
 }
 

--- a/internal/core/discovery_test.go
+++ b/internal/core/discovery_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestParseFlatName(t *testing.T) {
 	tests := []struct {
-		name       string
-		input      string
-		wantType   PluginType
-		wantName   string
-		wantOK     bool
+		name     string
+		input    string
+		wantType PluginType
+		wantName string
+		wantOK   bool
 	}{
 		{"config plugin", "zhi-config-pokedex", PluginTypeConfig, "pokedex", true},
 		{"transform plugin", "zhi-transform-evolve", PluginTypeTransform, "evolve", true},

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -137,7 +137,11 @@ func (e *Engine) Validate(ctx context.Context, tree *config.Tree) ([]config.Vali
 }
 
 // SetValue stores a value at the given path via the config provider.
+// The path is validated before being sent to the plugin.
 func (e *Engine) SetValue(ctx context.Context, path string, value config.Value) error {
+	if err := config.ValidatePath(path); err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
 	return e.configPlugin.Set(ctx, path, value)
 }
 
@@ -205,7 +209,11 @@ func (e *Engine) WorkspaceDir() string {
 }
 
 // ValidatePath runs config provider validation for a single path in the tree.
+// If the path does not exist in the tree, an empty result is returned.
 func (e *Engine) ValidatePath(ctx context.Context, path string, tree *config.Tree) ([]config.ValidationResult, error) {
+	if _, ok := tree.Get(path); !ok {
+		return nil, nil
+	}
 	return e.configPlugin.Validate(ctx, path, tree)
 }
 

--- a/internal/core/export.go
+++ b/internal/core/export.go
@@ -79,12 +79,10 @@ func Export(_ context.Context, tree *TreeData, cfg ExportRunConfig) (*ExportResu
 
 	// Write output if not dry-run and output is a file path.
 	if !cfg.DryRun && cfg.OutputPath != "" && cfg.OutputPath != "-" {
-		if err := os.MkdirAll(filepath.Dir(cfg.OutputPath), 0o755); err != nil {
-			return nil, fmt.Errorf("creating output directory: %w", err)
+		if err := writeExportFile(cfg.OutputPath, []byte(content)); err != nil {
+			return nil, err
 		}
-		if err := os.WriteFile(cfg.OutputPath, []byte(content), 0o644); err != nil {
-			return nil, fmt.Errorf("writing output file: %w", err)
-		}
+		Logger().Debug("export written", "path", cfg.OutputPath)
 	}
 
 	return result, nil
@@ -304,4 +302,59 @@ func indentStr(n int, s string) string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// writeExportFile writes data to outputPath with security hardening:
+//   - Rejects paths containing ".." traversal
+//   - Resolves symlinks to determine the real destination
+//   - Uses atomic writes (temp file + rename) to prevent partial writes
+//   - Sets 0644 permissions on the output file and 0755 on directories
+func writeExportFile(outputPath string, data []byte) error {
+	// Reject path traversal.
+	if containsPathTraversal(outputPath) {
+		return fmt.Errorf("export output path %q: path traversal (.. segments) is not allowed", outputPath)
+	}
+
+	// Resolve the directory, creating it if needed.
+	dir := filepath.Dir(outputPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	// Resolve symlinks in the output path to determine real destination.
+	realDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return fmt.Errorf("resolving output directory: %w", err)
+	}
+	realPath := filepath.Join(realDir, filepath.Base(outputPath))
+
+	// Atomic write: write to temp file, then rename.
+	tmp, err := os.CreateTemp(realDir, ".zhi-export-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file for export: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("writing export temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("closing export temp file: %w", err)
+	}
+
+	// Set permissions before rename.
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("setting export file permissions: %w", err)
+	}
+
+	if err := os.Rename(tmpName, realPath); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("renaming export temp file: %w", err)
+	}
+
+	return nil
 }

--- a/internal/core/launcher.go
+++ b/internal/core/launcher.go
@@ -1,7 +1,10 @@
 package core
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 
 	goplugin "github.com/hashicorp/go-plugin"
@@ -12,10 +15,46 @@ import (
 	"github.com/MrWong99/zhi/pkg/zhiplugin/transform"
 )
 
+// auditPluginBinary logs the SHA-256 hash of the plugin binary and warns
+// if the file is world-writable. This helps with audit trailing and
+// detecting potentially tampered binaries.
+func auditPluginBinary(path string) {
+	log := Logger()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		log.Warn("cannot stat plugin binary", "path", path, "error", err)
+		return
+	}
+
+	// Warn if world-writable.
+	if info.Mode()&0o002 != 0 {
+		log.Warn("plugin binary is world-writable", "path", path, "permissions", info.Mode().String())
+	}
+
+	// Compute SHA-256 hash.
+	f, err := os.Open(path)
+	if err != nil {
+		log.Warn("cannot open plugin binary for hashing", "path", path, "error", err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		log.Warn("cannot hash plugin binary", "path", path, "error", err)
+		return
+	}
+
+	log.Info("launching plugin", "path", path, "sha256", fmt.Sprintf("%x", h.Sum(nil)))
+}
+
 // LaunchConfig launches an external config plugin binary and returns the
 // config.Plugin interface along with a cleanup function that kills the
 // plugin process. The caller must call cleanup when done.
 func LaunchConfig(path string) (config.Plugin, func(), error) {
+	auditPluginBinary(path)
+
 	client := goplugin.NewClient(&goplugin.ClientConfig{
 		HandshakeConfig:  zhiplugin.Handshake,
 		Plugins:          config.PluginMap,
@@ -47,6 +86,8 @@ func LaunchConfig(path string) (config.Plugin, func(), error) {
 // LaunchTransform launches an external transform plugin binary and returns
 // the transform.Plugin interface along with a cleanup function.
 func LaunchTransform(path string) (transform.Plugin, func(), error) {
+	auditPluginBinary(path)
+
 	client := goplugin.NewClient(&goplugin.ClientConfig{
 		HandshakeConfig:  zhiplugin.Handshake,
 		Plugins:          transform.PluginMap,
@@ -78,6 +119,8 @@ func LaunchTransform(path string) (transform.Plugin, func(), error) {
 // LaunchStore launches an external store plugin binary and returns the
 // store.Plugin interface along with a cleanup function.
 func LaunchStore(path string) (store.Plugin, func(), error) {
+	auditPluginBinary(path)
+
 	client := goplugin.NewClient(&goplugin.ClientConfig{
 		HandshakeConfig:  zhiplugin.Handshake,
 		Plugins:          store.PluginMap,

--- a/internal/core/logging.go
+++ b/internal/core/logging.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"io"
+	"log/slog"
+	"os"
+)
+
+// logger is the package-level structured logger. It defaults to WARN level
+// and writes to stderr so that stdout remains clean for piped output.
+var logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+	Level: slog.LevelWarn,
+}))
+
+// SetLogLevel configures the global logger with the given level.
+// Call this early (e.g. from CLI flag handling) before any logging occurs.
+func SetLogLevel(level slog.Level) {
+	logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: level,
+	}))
+}
+
+// SetLogOutput configures the logger to write to a custom writer.
+// This is primarily useful in tests.
+func SetLogOutput(w io.Writer, level slog.Level) {
+	logger = slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{
+		Level: level,
+	}))
+}
+
+// Logger returns the package-level logger for use in core functions.
+func Logger() *slog.Logger {
+	return logger
+}

--- a/internal/core/security_test.go
+++ b/internal/core/security_test.go
@@ -1,0 +1,522 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+)
+
+// --- 8.1: Input Validation Tests ---
+
+func TestSetValueRejectsInvalidPaths(t *testing.T) {
+	mc := newMockConfig()
+	eng := &Engine{
+		configPlugin: mc,
+		components:   mustComponents(t, nil),
+		workspace:    &WorkspaceConfig{},
+	}
+
+	tests := []struct {
+		path string
+	}{
+		{""},             // empty path
+		{"/leading"},     // leading slash
+		{"has space/ok"}, // space in segment
+		{"UPPER/case"},   // uppercase
+		{"../escape"},    // path traversal
+		{"foo//bar"},     // empty segment
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			err := eng.SetValue(context.Background(), tt.path, config.Value{Val: "test"})
+			if err == nil {
+				t.Errorf("SetValue(%q) should return an error for invalid path", tt.path)
+			}
+		})
+	}
+}
+
+func TestSetValueAcceptsValidPaths(t *testing.T) {
+	mc := newMockConfig()
+	eng := &Engine{
+		configPlugin: mc,
+		components:   mustComponents(t, nil),
+		workspace:    &WorkspaceConfig{},
+	}
+
+	tests := []string{
+		"database/host",
+		"app/name",
+		"a",
+		"app/tls/cert.pem",
+		"my-app/log-level",
+	}
+
+	for _, path := range tests {
+		t.Run(path, func(t *testing.T) {
+			err := eng.SetValue(context.Background(), path, config.Value{Val: "test"})
+			if err != nil {
+				t.Errorf("SetValue(%q) unexpected error: %v", path, err)
+			}
+		})
+	}
+}
+
+// --- 8.1: Workspace Validation Tests ---
+
+func TestValidateWorkspaceRejectsInvalidComponentNames(t *testing.T) {
+	ws := &WorkspaceConfig{
+		Version: "1",
+		Config:  ProviderRef{Provider: "structuredfile"},
+		Components: []ComponentDef{
+			{Name: "valid-name", Paths: []string{"valid/"}},
+			{Name: "Invalid", Paths: []string{"invalid/"}},
+		},
+	}
+
+	reg := NewRegistry()
+	_ = reg.RegisterConfig("structuredfile", func(opts map[string]any) (config.Plugin, error) {
+		return newMockConfig(), nil
+	})
+
+	err := ValidateWorkspace(ws, reg)
+	if err == nil {
+		t.Fatal("ValidateWorkspace should reject invalid component names")
+	}
+	if !strings.Contains(err.Error(), "Invalid") {
+		t.Errorf("error should mention the invalid name, got: %v", err)
+	}
+}
+
+func TestValidateWorkspaceAcceptsValidComponentNames(t *testing.T) {
+	ws := &WorkspaceConfig{
+		Version: "1",
+		Config:  ProviderRef{Provider: "structuredfile"},
+		Components: []ComponentDef{
+			{Name: "app", Paths: []string{"app/"}},
+			{Name: "my-database", Paths: []string{"db/"}},
+			{Name: "redis2", Paths: []string{"redis/"}},
+		},
+	}
+
+	reg := NewRegistry()
+	_ = reg.RegisterConfig("structuredfile", func(opts map[string]any) (config.Plugin, error) {
+		return newMockConfig(), nil
+	})
+
+	err := ValidateWorkspace(ws, reg)
+	if err != nil {
+		t.Fatalf("ValidateWorkspace should accept valid component names, got: %v", err)
+	}
+}
+
+func TestValidateWorkspaceRejectsPluginDirTraversal(t *testing.T) {
+	ws := &WorkspaceConfig{
+		Version: "1",
+		Config:  ProviderRef{Provider: "structuredfile"},
+		Plugins: PluginsConfig{
+			Directories: []string{"../../etc/evil"},
+		},
+	}
+
+	reg := NewRegistry()
+	_ = reg.RegisterConfig("structuredfile", func(opts map[string]any) (config.Plugin, error) {
+		return newMockConfig(), nil
+	})
+
+	err := ValidateWorkspace(ws, reg)
+	if err == nil {
+		t.Fatal("ValidateWorkspace should reject plugin directories with path traversal")
+	}
+	if !strings.Contains(err.Error(), "path traversal") {
+		t.Errorf("error should mention path traversal, got: %v", err)
+	}
+}
+
+func TestValidateWorkspaceAcceptsNormalPluginDirs(t *testing.T) {
+	ws := &WorkspaceConfig{
+		Version: "1",
+		Config:  ProviderRef{Provider: "structuredfile"},
+		Plugins: PluginsConfig{
+			Directories: []string{"~/.zhi/plugins", "./local-plugins", "/opt/zhi/plugins"},
+		},
+	}
+
+	reg := NewRegistry()
+	_ = reg.RegisterConfig("structuredfile", func(opts map[string]any) (config.Plugin, error) {
+		return newMockConfig(), nil
+	})
+
+	err := ValidateWorkspace(ws, reg)
+	if err != nil {
+		t.Fatalf("ValidateWorkspace should accept normal plugin dirs, got: %v", err)
+	}
+}
+
+// --- 8.2: Plugin Execution Security Tests ---
+
+func TestAuditPluginBinaryWorldWritable(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "test-plugin")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\necho hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Explicitly set world-writable permissions (os.WriteFile applies umask).
+	if err := os.Chmod(binPath, 0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	SetLogOutput(&buf, slog.LevelWarn)
+	defer SetLogLevel(slog.LevelWarn) // restore
+
+	auditPluginBinary(binPath)
+
+	if !strings.Contains(buf.String(), "world-writable") {
+		t.Errorf("should warn about world-writable binary, got: %s", buf.String())
+	}
+}
+
+func TestAuditPluginBinaryNonWorldWritable(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "test-plugin")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\necho hi"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	SetLogOutput(&buf, slog.LevelWarn)
+	defer SetLogLevel(slog.LevelWarn) // restore
+
+	auditPluginBinary(binPath)
+
+	if strings.Contains(buf.String(), "world-writable") {
+		t.Errorf("should not warn about non-world-writable binary, got: %s", buf.String())
+	}
+}
+
+func TestAuditPluginBinaryLogsHash(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "test-plugin")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\necho hi"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	SetLogOutput(&buf, slog.LevelInfo)
+	defer SetLogLevel(slog.LevelWarn) // restore
+
+	auditPluginBinary(binPath)
+
+	if !strings.Contains(buf.String(), "sha256") {
+		t.Errorf("should log SHA-256 hash, got: %s", buf.String())
+	}
+}
+
+// --- 8.3: File System Security Tests ---
+
+func TestWriteExportFileRejectsTraversal(t *testing.T) {
+	err := writeExportFile("/tmp/../../../etc/passwd", []byte("test"))
+	if err == nil {
+		t.Fatal("writeExportFile should reject path traversal")
+	}
+	if !strings.Contains(err.Error(), "path traversal") {
+		t.Errorf("error should mention path traversal, got: %v", err)
+	}
+}
+
+func TestWriteExportFileAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "output.json")
+
+	err := writeExportFile(outPath, []byte(`{"key":"value"}`))
+	if err != nil {
+		t.Fatalf("writeExportFile: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != `{"key":"value"}` {
+		t.Errorf("content = %q, want %q", string(data), `{"key":"value"}`)
+	}
+
+	// Check permissions: should be 0644.
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	// Mask to get the last 9 bits (rwx permissions).
+	perm := info.Mode().Perm()
+	if perm != 0o644 {
+		t.Errorf("permissions = %o, want 0644", perm)
+	}
+}
+
+func TestWriteExportFileCreatesDirs(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "subdir", "deep", "output.txt")
+
+	err := writeExportFile(outPath, []byte("hello"))
+	if err != nil {
+		t.Fatalf("writeExportFile: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("content = %q, want %q", string(data), "hello")
+	}
+}
+
+func TestWriteExportFileResolvesSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create symlink to real directory.
+	linkDir := filepath.Join(dir, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlinks not supported: %v", err)
+	}
+
+	outPath := filepath.Join(linkDir, "output.txt")
+	err := writeExportFile(outPath, []byte("content"))
+	if err != nil {
+		t.Fatalf("writeExportFile: %v", err)
+	}
+
+	// The file should exist at the real path.
+	realPath := filepath.Join(realDir, "output.txt")
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatalf("ReadFile real path: %v", err)
+	}
+	if string(data) != "content" {
+		t.Errorf("content = %q, want %q", string(data), "content")
+	}
+}
+
+// --- 8.3: .zhi Directory Permissions ---
+
+func TestContainsPathTraversal(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"./local-plugins", false},
+		{"~/.zhi/plugins", false},
+		{"/opt/zhi/plugins", false},
+		{"../evil", true},
+		{"some/../path", true},
+		{"../../etc/evil", true},
+		{"foo/bar/../baz", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := containsPathTraversal(tt.path)
+			if got != tt.want {
+				t.Errorf("containsPathTraversal(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- 8.9: Edge Case Tests ---
+
+func TestValidatePathMissingFromTree(t *testing.T) {
+	mc := newMockConfig()
+	eng := &Engine{
+		configPlugin: mc,
+		components:   mustComponents(t, nil),
+		workspace:    &WorkspaceConfig{},
+	}
+
+	tree := config.NewTree()
+
+	// Validating a non-existent path should return nil, not error.
+	results, err := eng.ValidatePath(context.Background(), "nonexistent/path", tree)
+	if err != nil {
+		t.Fatalf("ValidatePath should not error for missing path: %v", err)
+	}
+	if results != nil {
+		t.Errorf("ValidatePath should return nil for missing path, got %v", results)
+	}
+}
+
+func TestEngineWithEmptyTree(t *testing.T) {
+	mc := &mockConfig{tree: config.NewTree()}
+	eng := &Engine{
+		configPlugin: mc,
+		components:   mustComponents(t, nil),
+		workspace:    &WorkspaceConfig{},
+	}
+
+	ctx := context.Background()
+	tree, err := eng.LoadTree(ctx)
+	if err != nil {
+		t.Fatalf("LoadTree: %v", err)
+	}
+	if len(tree.List()) != 0 {
+		t.Errorf("tree should be empty, got %d paths", len(tree.List()))
+	}
+
+	// Validate empty tree should not error.
+	results, err := eng.Validate(ctx, tree)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("validation of empty tree should produce no results, got %d", len(results))
+	}
+}
+
+func TestEngineNoStoreConfigured(t *testing.T) {
+	mc := newMockConfig()
+	eng := &Engine{
+		configPlugin: mc,
+		components:   mustComponents(t, nil),
+		workspace:    &WorkspaceConfig{},
+		storePlugin:  nil,
+	}
+
+	ctx := context.Background()
+
+	// Save should fail gracefully.
+	err := eng.SaveTree(ctx, "test", config.NewTree())
+	if err == nil {
+		t.Fatal("SaveTree should error when no store is configured")
+	}
+	if !strings.Contains(err.Error(), "no store provider") {
+		t.Errorf("error should mention no store provider, got: %v", err)
+	}
+
+	// Load should fail gracefully.
+	_, _, err = eng.LoadStoredTree(ctx, "test")
+	if err == nil {
+		t.Fatal("LoadStoredTree should error when no store is configured")
+	}
+
+	// ListTrees should fail gracefully.
+	_, err = eng.ListTrees(ctx)
+	if err == nil {
+		t.Fatal("ListTrees should error when no store is configured")
+	}
+}
+
+func TestExportPathTraversalInConfig(t *testing.T) {
+	tree := config.NewTree()
+	_ = tree.Set("app/name", &config.Value{Val: "test"})
+	td := NewTreeData(tree, nil)
+
+	cfg := ExportRunConfig{
+		Format:     "json",
+		OutputPath: "/tmp/safe/../../../etc/evil",
+		DryRun:     false,
+	}
+
+	_, err := Export(context.Background(), td, cfg)
+	if err == nil {
+		t.Fatal("Export should reject path traversal in output path")
+	}
+	if !strings.Contains(err.Error(), "path traversal") {
+		t.Errorf("error should mention path traversal, got: %v", err)
+	}
+}
+
+func TestExportDryRunDoesNotWriteSecurityCheck(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "should-not-exist.json")
+
+	tree := config.NewTree()
+	_ = tree.Set("app/name", &config.Value{Val: "test"})
+	td := NewTreeData(tree, nil)
+
+	cfg := ExportRunConfig{
+		Format:     "json",
+		OutputPath: outPath,
+		DryRun:     true,
+	}
+
+	result, err := Export(context.Background(), td, cfg)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if result.Content == "" {
+		t.Error("dry-run should still produce content")
+	}
+
+	if _, err := os.Stat(outPath); err == nil {
+		t.Error("dry-run should not create the output file")
+	}
+}
+
+// --- 8.6: Logging Tests ---
+
+func TestSetLogLevel(t *testing.T) {
+	// Just verify it doesn't panic.
+	SetLogLevel(slog.LevelDebug)
+	Logger().Debug("test debug")
+	SetLogLevel(slog.LevelWarn) // restore
+}
+
+func TestSetLogOutput(t *testing.T) {
+	var buf bytes.Buffer
+	SetLogOutput(&buf, slog.LevelInfo)
+	Logger().Info("test message")
+	if !strings.Contains(buf.String(), "test message") {
+		t.Errorf("expected log output to contain 'test message', got: %s", buf.String())
+	}
+	SetLogLevel(slog.LevelWarn) // restore
+}
+
+// --- Discovery Path Traversal Tests ---
+
+func TestDiscoveryRejectsPathTraversal(t *testing.T) {
+	var buf bytes.Buffer
+	SetLogOutput(&buf, slog.LevelWarn)
+	defer SetLogLevel(slog.LevelWarn) // restore
+
+	plugins, err := Discover(DiscoveryConfig{
+		Directories: []string{"../../etc/evil"},
+	})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	// Should skip the traversal directory and return no plugins.
+	if len(plugins) != 0 {
+		t.Errorf("expected 0 plugins, got %d", len(plugins))
+	}
+
+	if !strings.Contains(buf.String(), "path traversal") {
+		t.Errorf("should log a warning about path traversal, got: %s", buf.String())
+	}
+}
+
+// --- Helper ---
+
+func mustComponents(t *testing.T, defs []ComponentDef) *ComponentManager {
+	t.Helper()
+	if defs == nil {
+		defs = []ComponentDef{}
+	}
+	cm, err := NewComponentManager(defs)
+	if err != nil {
+		t.Fatalf("NewComponentManager: %v", err)
+	}
+	return cm
+}

--- a/internal/core/workspace.go
+++ b/internal/core/workspace.go
@@ -6,9 +6,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+// componentNamePattern defines valid component names: starts with a lowercase
+// letter, may contain lowercase letters, digits, and hyphens.
+var componentNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
 // ProviderRef identifies a provider and its options in a workspace config.
 type ProviderRef struct {
@@ -240,8 +246,22 @@ func ValidateWorkspace(ws *WorkspaceConfig, reg *Registry) error {
 	}
 
 	// Validate component definitions.
+	for i, c := range ws.Components {
+		if c.Name == "" {
+			errs = append(errs, fmt.Errorf("components[%d]: name is required", i))
+		} else if !componentNamePattern.MatchString(c.Name) {
+			errs = append(errs, fmt.Errorf("components[%d]: invalid name %q (must match [a-z][a-z0-9-]*)", i, c.Name))
+		}
+	}
 	if _, err := NewComponentManager(ws.Components); err != nil {
 		errs = append(errs, fmt.Errorf("components: %w", err))
+	}
+
+	// Validate plugin directories: reject paths containing ".." traversal.
+	for _, dir := range ws.Plugins.Directories {
+		if containsPathTraversal(dir) {
+			errs = append(errs, fmt.Errorf("plugin directory %q: path traversal (.. segments) is not allowed", dir))
+		}
 	}
 
 	// Check that template files exist on disk (only for templates with a file, not built-in formats).
@@ -260,4 +280,14 @@ func ValidateWorkspace(ws *WorkspaceConfig, reg *Registry) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// containsPathTraversal reports whether a path contains ".." segments.
+func containsPathTraversal(path string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(path), "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/ui/driver_test.go
+++ b/internal/ui/driver_test.go
@@ -46,7 +46,7 @@ func (m *mockConfig) Validate(_ context.Context, _ string, _ config.TreeReader) 
 type mockTransform struct{}
 
 func (m *mockTransform) BeforeDisplay(_ context.Context, _ *config.Tree) error { return nil }
-func (m *mockTransform) AfterSave(_ context.Context, _ *config.Tree) error    { return nil }
+func (m *mockTransform) AfterSave(_ context.Context, _ *config.Tree) error     { return nil }
 func (m *mockTransform) ValidatePolicy(_ context.Context) (transform.ValidatePolicy, error) {
 	return 0, nil
 }

--- a/internal/ui/tui/app_test.go
+++ b/internal/ui/tui/app_test.go
@@ -54,7 +54,7 @@ func (m *mockConfig) Validate(_ context.Context, path string, _ config.TreeReade
 type mockTransform struct{}
 
 func (m *mockTransform) BeforeDisplay(_ context.Context, _ *config.Tree) error { return nil }
-func (m *mockTransform) AfterSave(_ context.Context, _ *config.Tree) error    { return nil }
+func (m *mockTransform) AfterSave(_ context.Context, _ *config.Tree) error     { return nil }
 func (m *mockTransform) ValidatePolicy(_ context.Context) (transform.ValidatePolicy, error) {
 	return 0, nil
 }
@@ -97,8 +97,8 @@ func (m *mockStore) ListTrees(_ context.Context) ([]string, error) {
 	return ids, nil
 }
 
-func (m *mockStore) SupportsVersioning(_ context.Context) (bool, error)           { return false, nil }
-func (m *mockStore) ListVersions(_ context.Context, _ string) ([]string, error)   { return nil, nil }
+func (m *mockStore) SupportsVersioning(_ context.Context) (bool, error)         { return false, nil }
+func (m *mockStore) ListVersions(_ context.Context, _ string) ([]string, error) { return nil, nil }
 func (m *mockStore) LoadVersion(_ context.Context, _, _ string) (*config.Tree, bool, error) {
 	return nil, false, nil
 }

--- a/internal/ui/tui/apply_view.go
+++ b/internal/ui/tui/apply_view.go
@@ -26,18 +26,18 @@ type ApplyDoneMsg struct {
 
 // ApplyView streams apply command output in a scrollable viewport.
 type ApplyView struct {
-	output    []core.ApplyOutput
-	lines     []string
-	running   bool
-	result    *core.ApplyResult
-	err       error
-	spinner   spinner.Model
-	cursor    int
-	offset    int
-	follow    bool
-	cancelFn  context.CancelFunc
-	width     int
-	height    int
+	output   []core.ApplyOutput
+	lines    []string
+	running  bool
+	result   *core.ApplyResult
+	err      error
+	spinner  spinner.Model
+	cursor   int
+	offset   int
+	follow   bool
+	cancelFn context.CancelFunc
+	width    int
+	height   int
 }
 
 // NewApplyView creates a new apply view.

--- a/internal/ui/tui/validation_view.go
+++ b/internal/ui/tui/validation_view.go
@@ -11,13 +11,13 @@ import (
 
 // ValidationView displays validation results grouped by severity.
 type ValidationView struct {
-	results  []config.ValidationResult
-	lines    []string
-	cursor   int
-	offset   int
-	summary  string
-	width    int
-	height   int
+	results []config.ValidationResult
+	lines   []string
+	cursor  int
+	offset  int
+	summary string
+	width   int
+	height  int
 }
 
 // NewValidationView creates an empty validation view.


### PR DESCRIPTION
Security:
- Input validation on Engine.SetValue with path format checking
- Workspace config validation: component name format, plugin dir traversal rejection
- Plugin execution security: SHA-256 hash logging, world-writable binary warnings
- Export file security: path traversal rejection, atomic writes (temp+rename),
  symlink resolution, proper file permissions (0644)
- .zhi directory permissions hardened to 0700, state files to 0600
- Plugin discovery rejects directories with ".." path traversal

Infrastructure:
- Structured logging via log/slog with --verbose flag for debug output
- Graceful shutdown with SIGINT/SIGTERM signal handling via signal.NotifyContext
- Engine cleanup goroutine kills plugin processes on context cancellation
- Edge case handling: ValidatePath returns nil for missing paths, empty tree validation

Polish:
- All cobra commands have Long descriptions and Examples
- README.md has Getting Started section with install/quickstart instructions
- zhi init prints "What's next?" guidance after workspace creation
- Root command help shows common workflow summary

Tests:
- Path validation: invalid/valid path acceptance and rejection
- Workspace validation: component names, plugin directory traversal
- Plugin audit: world-writable detection, SHA-256 hash logging
- Export security: path traversal rejection, atomic writes, symlink resolution,
  directory creation, permissions verification
- Edge cases: empty trees, missing paths, no store configured, dry-run safety
- Logging: SetLogLevel/SetLogOutput configuration
- Discovery: path traversal rejection with warning

https://claude.ai/code/session_01DzQyKhs6isKiMiGrFQA4TG