### PR TITLE
Restructure store plugin API for granular value-level operations

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,24 +1,106 @@
-# Future Improvements
+# Future Work for Store Plugin Ecosystem
 
-## Store Plugin: Check-and-Set (CAS) / Optimistic Concurrency
+This file tracks remaining work needed after the store API restructure.
+The core API (`store.Plugin` interface, proto definitions, gRPC client/server,
+and engine integration) has been implemented and all tests pass.
 
-The `Save` method currently has no mechanism for optimistic concurrency control.
-If two hosts call `Save` concurrently for the same tree ID, the last write wins
-silently. Backends like HashiCorp Vault KV v2 support Check-and-Set (CAS) where
-a write must specify the expected current version to succeed, preventing
-accidental overwrites.
+## Vault Store Plugin Implementation
 
-A future revision could extend `Save` with an optional expected version parameter
-(e.g. `Save(ctx, id, tree, expectedVersion)`) or introduce a separate
-`SaveWithCAS` method to surface version conflicts back to the caller.
+### Authentication & Session Management
 
-## Store Plugin: Tree-Level Metadata
+- [ ] Implement `AuthMethods` returning Vault auth backends (token, userpass,
+  OIDC, LDAP, AppRole, Kubernetes, etc.)
+- [ ] Implement `Login` that calls `vault.Auth().Login()` and stores the
+  resulting client token internally for subsequent API calls
+- [ ] Handle token renewal / lease management in a background goroutine
+- [ ] Support Vault namespace isolation if applicable
 
-The store plugin currently has no concept of metadata attached to a tree ID
-itself (as opposed to per-value metadata within the tree). Backends like
-HashiCorp Vault KV v2 support custom metadata on the key level, separate from
-version data — for example, ownership info, labels, or access policies.
+### Value Operations (KV v2)
 
-A future revision could add methods like `GetTreeMetadata(ctx, id)` and
-`SetTreeMetadata(ctx, id, metadata)` to allow plugins to expose and manage
-tree-level metadata.
+- [ ] Implement `GetValues` using per-path `vault.KVv2().Get()` calls
+  (one Vault secret per tree path, e.g. `secret/data/zhi/<id>/<path>`)
+- [ ] Implement `PutValues` using per-path `vault.KVv2().Put()` calls
+- [ ] Implement `DeleteValues` using per-path `vault.KVv2().Delete()` (soft
+  delete) or `vault.KVv2().DeleteMetadata()` (permanent)
+- [ ] Implement `DeleteTree` that lists and removes all secrets under the
+  tree prefix
+
+### Check-and-Set (CAS)
+
+- [ ] Wire `PutOptions.CASVersions` to Vault KV v2 CAS: each per-path write
+  should include `cas=<expected_version>` to prevent lost updates
+- [ ] Surface Vault 412 (Precondition Failed) errors as a structured CAS
+  conflict error type that the engine/UI can present to the user
+
+### Value-Level Versioning
+
+- [ ] Implement `ListValueVersions` using `vault.KVv2().GetVersionsAsList()`
+- [ ] Implement `GetValueVersion` using `vault.KVv2().GetVersion()`
+- [ ] Implement `RollbackValue` by reading the target version and writing it
+  as a new version
+- [ ] Implement `DeleteValueVersion` using `vault.KVv2().DeleteVersions()`
+
+### Encryption
+
+- [ ] Vault handles encryption transparently via its barrier; `InitEncryption`
+  and `RotateEncryption` may map to Vault Transit or be no-ops
+- [ ] Consider whether encryption passphrase maps to Vault unseal keys or
+  Transit key rotation
+
+### Access Control & Policies
+
+- [ ] Implement `GrantAccess` by writing/updating Vault ACL policies that
+  grant per-path capabilities (read, create, update, delete)
+- [ ] Implement `RevokeAccess` by removing path rules from policies
+- [ ] Implement `ListAccess` by reading policies and mapping them back to
+  `Permission` structs
+- [ ] Auto-generate policy names following a convention (e.g.
+  `zhi-<tree_id>-<user>`)
+- [ ] Consider Vault identity entities/groups for user representation
+
+### Tree Listing / Discovery
+
+- [ ] Implement `ListTrees` by listing secret mount prefixes or a dedicated
+  metadata path; Vault LIST on `secret/metadata/zhi/` returns tree IDs
+
+## Engine & UI Integration
+
+- [ ] Add engine methods for tree-level and value-level version operations
+  (currently only `SaveTree`/`LoadStoredTree`/`ListTrees` are wired)
+- [ ] Expose Capabilities in the UI so users see versioning/encryption/auth
+  status
+- [ ] Wire authentication flow into the UI (prompt for auth method + credentials
+  before accessing a tree)
+- [ ] Add CAS conflict resolution UI (show diff, let user choose)
+- [ ] Wire version browsing and rollback into the TUI
+- [ ] Wire access control management into the TUI (grant/revoke for admin users)
+
+## Documentation
+
+- [ ] Update `docs/plugin-development/store-plugin.md` to reflect the new API
+  (the current docs still reference the old `Save`/`Load`/`Delete`/
+  `SupportsVersioning` interface)
+- [ ] Add a Vault-specific plugin development guide with examples
+- [ ] Document the CAS workflow and error handling patterns
+- [ ] Document auth method registration and credential flow
+
+## Error Handling
+
+- [ ] Define structured error types for common store failures:
+  - CAS conflict (version mismatch)
+  - Authentication required / session expired
+  - Access denied (insufficient permissions)
+  - Path not found
+  - Encryption not initialized
+- [ ] Ensure gRPC status codes map cleanly to these error types so the engine
+  and UI can present meaningful feedback
+
+## Testing
+
+- [ ] Add integration tests for the Vault plugin against a real Vault dev
+  server (use `t.Skip` for CI environments without Vault)
+- [ ] Add CAS conflict test cases in the store package test suite
+- [ ] Add value-level versioning test plugin and tests (analogous to the
+  existing `versionedTreePlugin` for tree-level versioning)
+- [ ] Add auth flow test cases (mock auth method, login, token expiry)
+- [ ] Add access control test cases

--- a/api/proto/zhiplugin/v1/store.proto
+++ b/api/proto/zhiplugin/v1/store.proto
@@ -10,132 +10,281 @@ import "zhiplugin/v1/config.proto";
 option go_package = "github.com/MrWong99/zhi/pkg/zhiplugin/store/proto";
 
 // StoreService is the gRPC interface every zhi store plugin must implement.
-// Store plugins persist, retrieve, and delete configuration trees.
+// Store plugins persist, retrieve, and delete configuration values within
+// named trees with granular, value-level operations.
 service StoreService {
-  // Save persists a configuration tree under the given ID.
-  // If versioning is supported, this creates a new version.
-  rpc Save(SaveRequest) returns (SaveResponse);
-  // Load retrieves the latest version of the configuration tree with the
-  // given ID.
-  rpc Load(LoadRequest) returns (LoadResponse);
-  // Delete removes the configuration tree and all its versions.
-  rpc Delete(DeleteRequest) returns (DeleteResponse);
-  // ListTrees returns all stored tree IDs.
+  // Capabilities reports the store's supported features.
+  rpc Capabilities(StoreCapabilitiesRequest) returns (StoreCapabilitiesResponse);
+
+  // AuthMethods returns the authentication methods supported by this store.
+  rpc AuthMethods(AuthMethodsRequest) returns (AuthMethodsResponse);
+  // Login authenticates with the store using the given method and credentials.
+  rpc Login(LoginRequest) returns (LoginResponse);
+
+  // ListTrees returns all tree IDs the current identity has access to.
   rpc ListTrees(ListTreesRequest) returns (ListTreesResponse);
-  // SupportsVersioning reports whether this store keeps older versions of
-  // trees.
-  rpc SupportsVersioning(SupportsVersioningRequest) returns (SupportsVersioningResponse);
-  // ListVersions returns version identifiers for a given tree ID, ordered
-  // newest first. Returns an error if versioning is not supported.
-  rpc ListVersions(ListVersionsRequest) returns (ListVersionsResponse);
-  // LoadVersion retrieves a specific version of the configuration tree.
-  // Returns an error if versioning is not supported.
-  rpc LoadVersion(LoadVersionRequest) returns (LoadVersionResponse);
-  // DeleteVersion permanently removes a single version of a configuration
-  // tree. Returns an error if versioning is not supported.
-  rpc DeleteVersion(DeleteVersionRequest) returns (DeleteVersionResponse);
-  // EncryptionStatus reports the current encryption state of the store.
-  rpc EncryptionStatus(EncryptionStatusRequest) returns (EncryptionStatusResponse);
-  // InitEncryption initializes encryption for the store with the given
-  // passphrase. Returns an error if encryption is not supported or is
-  // already active.
+  // DeleteTree removes an entire tree and all its versions/values.
+  rpc DeleteTree(DeleteTreeRequest) returns (DeleteTreeResponse);
+
+  // GetValues retrieves specific values from a tree by their paths.
+  rpc GetValues(GetValuesRequest) returns (GetValuesResponse);
+  // PutValues writes specific values to a tree.
+  rpc PutValues(PutValuesRequest) returns (PutValuesResponse);
+  // DeleteValues removes specific values from a tree.
+  rpc DeleteValues(DeleteValuesRequest) returns (DeleteValuesResponse);
+
+  // ListTreeVersions returns version identifiers for a tree (VersioningTree).
+  rpc ListTreeVersions(ListTreeVersionsRequest) returns (ListTreeVersionsResponse);
+  // GetTreeVersion retrieves specific values from a specific tree version.
+  rpc GetTreeVersion(GetTreeVersionRequest) returns (GetTreeVersionResponse);
+  // RollbackTree restores a tree to a previous version.
+  rpc RollbackTree(RollbackTreeRequest) returns (RollbackTreeResponse);
+  // DeleteTreeVersion permanently removes a single tree version.
+  rpc DeleteTreeVersion(DeleteTreeVersionRequest) returns (DeleteTreeVersionResponse);
+
+  // ListValueVersions returns version identifiers for a specific value (VersioningValue).
+  rpc ListValueVersions(ListValueVersionsRequest) returns (ListValueVersionsResponse);
+  // GetValueVersion retrieves a specific version of a single value.
+  rpc GetValueVersion(GetValueVersionRequest) returns (GetValueVersionResponse);
+  // RollbackValue restores a value to a previous version.
+  rpc RollbackValue(RollbackValueRequest) returns (RollbackValueResponse);
+  // DeleteValueVersion permanently removes a single value version.
+  rpc DeleteValueVersion(DeleteValueVersionRequest) returns (DeleteValueVersionResponse);
+
+  // InitEncryption initializes encryption for the store.
   rpc InitEncryption(InitEncryptionRequest) returns (InitEncryptionResponse);
-  // RotateEncryption re-encrypts all stored data with a new passphrase.
-  // Returns an error if encryption is not supported or not active.
+  // RotateEncryption re-encrypts stored data with a new passphrase.
   rpc RotateEncryption(RotateEncryptionRequest) returns (RotateEncryptionResponse);
+
+  // GrantAccess grants a user access to specific paths within a tree.
+  rpc GrantAccess(GrantAccessRequest) returns (GrantAccessResponse);
+  // RevokeAccess removes a user's access to specific paths within a tree.
+  rpc RevokeAccess(RevokeAccessRequest) returns (RevokeAccessResponse);
+  // ListAccess returns the current access permissions for a tree.
+  rpc ListAccess(ListAccessRequest) returns (ListAccessResponse);
 }
 
-message SaveRequest {
-  // The identifier for this configuration tree.
-  string id = 1;
-  // The full configuration tree to persist.
-  repeated TreeEntry tree = 2;
+// --- Enums ---
+
+enum VersioningMode {
+  VERSIONING_NONE = 0;
+  VERSIONING_TREE = 1;
+  VERSIONING_VALUE = 2;
 }
 
-// SaveResponse is intentionally empty.
-message SaveResponse {}
-
-message LoadRequest {
-  string id = 1;
+enum ActionType {
+  ACTION_READ = 0;
+  ACTION_WRITE = 1;
+  ACTION_DELETE = 2;
 }
 
-message LoadResponse {
-  bool found = 1;
-  // The configuration tree entries. Empty when found is false.
-  repeated TreeEntry tree = 2;
+// --- Capabilities ---
+
+message StoreCapabilitiesRequest {}
+
+message StoreCapabilitiesResponse {
+  VersioningMode versioning = 1;
+  // 0 = EncryptionNone, 1 = EncryptionSupported, 2 = EncryptionActive.
+  int32 encryption = 2;
+  bool auth = 3;
+  bool access_control = 4;
 }
 
-message DeleteRequest {
-  string id = 1;
+// --- Authentication ---
+
+message AuthFieldMsg {
+  string name = 1;
+  string description = 2;
+  bool required = 3;
+  bool secret = 4;
 }
 
-// DeleteResponse is intentionally empty.
-message DeleteResponse {}
+message AuthMethodMsg {
+  string type = 1;
+  string description = 2;
+  repeated AuthFieldMsg fields = 3;
+}
 
-// ListTreesRequest is intentionally empty.
+message AuthMethodsRequest {}
+
+message AuthMethodsResponse {
+  repeated AuthMethodMsg methods = 1;
+}
+
+message LoginRequest {
+  string method = 1;
+  map<string, string> credentials = 2;
+}
+
+message LoginResponse {
+  string token = 1;
+  string expires_at = 2;
+  map<string, string> metadata = 3;
+}
+
+// --- Tree management ---
+
 message ListTreesRequest {}
 
 message ListTreesResponse {
   repeated string ids = 1;
 }
 
-// SupportsVersioningRequest is intentionally empty.
-message SupportsVersioningRequest {}
-
-message SupportsVersioningResponse {
-  bool supported = 1;
-}
-
-message ListVersionsRequest {
+message DeleteTreeRequest {
   string id = 1;
 }
 
-message ListVersionsResponse {
-  // Version identifiers, ordered newest first.
+message DeleteTreeResponse {}
+
+// --- Value operations ---
+
+message GetValuesRequest {
+  string id = 1;
+  repeated string paths = 2;
+}
+
+message GetValuesResponse {
+  // Values keyed by path.
+  repeated TreeEntry values = 1;
+}
+
+message PutValuesRequest {
+  string id = 1;
+  repeated TreeEntry values = 2;
+  // Optional CAS fields.
+  string cas_version = 3;
+  map<string, string> cas_versions = 4;
+}
+
+message PutValuesResponse {}
+
+message DeleteValuesRequest {
+  string id = 1;
+  repeated string paths = 2;
+}
+
+message DeleteValuesResponse {}
+
+// --- Tree-level versioning ---
+
+message ListTreeVersionsRequest {
+  string id = 1;
+}
+
+message ListTreeVersionsResponse {
   repeated string versions = 1;
 }
 
-message LoadVersionRequest {
+message GetTreeVersionRequest {
+  string id = 1;
+  string version = 2;
+  repeated string paths = 3;
+}
+
+message GetTreeVersionResponse {
+  repeated TreeEntry values = 1;
+}
+
+message RollbackTreeRequest {
   string id = 1;
   string version = 2;
 }
 
-message LoadVersionResponse {
+message RollbackTreeResponse {}
+
+message DeleteTreeVersionRequest {
+  string id = 1;
+  string version = 2;
+}
+
+message DeleteTreeVersionResponse {}
+
+// --- Value-level versioning ---
+
+message ListValueVersionsRequest {
+  string id = 1;
+  string path = 2;
+}
+
+message ListValueVersionsResponse {
+  repeated string versions = 1;
+}
+
+message GetValueVersionRequest {
+  string id = 1;
+  string path = 2;
+  string version = 3;
+}
+
+message GetValueVersionResponse {
   bool found = 1;
-  // The configuration tree entries. Empty when found is false.
-  repeated TreeEntry tree = 2;
+  bytes value_json = 2;
+  bytes metadata_json = 3;
 }
 
-message DeleteVersionRequest {
+message RollbackValueRequest {
   string id = 1;
-  string version = 2;
+  string path = 2;
+  string version = 3;
 }
 
-// DeleteVersionResponse is intentionally empty.
-message DeleteVersionResponse {}
+message RollbackValueResponse {}
 
-// EncryptionStatusRequest is intentionally empty.
-message EncryptionStatusRequest {}
-
-message EncryptionStatusResponse {
-  // 0 = EncryptionNone, 1 = EncryptionSupported, 2 = EncryptionActive.
-  int32 status = 1;
+message DeleteValueVersionRequest {
+  string id = 1;
+  string path = 2;
+  string version = 3;
 }
+
+message DeleteValueVersionResponse {}
+
+// --- Encryption ---
 
 message InitEncryptionRequest {
-  // The passphrase or key material to initialize encryption with.
   bytes passphrase = 1;
 }
 
-// InitEncryptionResponse is intentionally empty.
 message InitEncryptionResponse {}
 
 message RotateEncryptionRequest {
-  // The current passphrase.
   bytes old_passphrase = 1;
-  // The new passphrase to rotate to.
   bytes new_passphrase = 2;
 }
 
-// RotateEncryptionResponse is intentionally empty.
 message RotateEncryptionResponse {}
+
+// --- Access control ---
+
+message PermissionMsg {
+  string path = 1;
+  repeated ActionType actions = 2;
+}
+
+message GrantAccessRequest {
+  string id = 1;
+  string user = 2;
+  repeated PermissionMsg permissions = 3;
+}
+
+message GrantAccessResponse {}
+
+message RevokeAccessRequest {
+  string id = 1;
+  string user = 2;
+  repeated string paths = 3;
+}
+
+message RevokeAccessResponse {}
+
+message ListAccessRequest {
+  string id = 1;
+}
+
+message UserPermissions {
+  repeated PermissionMsg permissions = 1;
+}
+
+message ListAccessResponse {
+  // Access permissions keyed by user.
+  map<string, UserPermissions> access = 1;
+}

--- a/examples/zhi-store-json/main.go
+++ b/examples/zhi-store-json/main.go
@@ -6,7 +6,8 @@
 // variable; if unset it defaults to a "zhi-pokedex" directory inside
 // the OS temp directory.
 //
-// This example does not support versioning or encryption.
+// This example does not support versioning, authentication, encryption, or
+// access control.
 package main
 
 import (
@@ -43,67 +44,58 @@ func (s *jsonStore) filePath(id string) string {
 	return filepath.Join(s.dir, id+".json")
 }
 
-func (s *jsonStore) Save(_ context.Context, id string, tree config.TreeReader) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	entries := make(map[string]*config.Value, len(tree.List()))
-	for _, path := range tree.List() {
-		v, ok := tree.Get(path)
-		if !ok {
-			continue
+// readFile reads and unmarshals the JSON file for the given tree ID.
+// Returns nil (not an error) if the file does not exist.
+func (s *jsonStore) readFile(id string) (map[string]*config.Value, error) {
+	data, err := os.ReadFile(s.filePath(id))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
 		}
-		cp := v // copy
-		entries[path] = &cp
+		return nil, err
 	}
+	var entries map[string]*config.Value
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
 
+// writeFile marshals and writes the entries to the JSON file for the
+// given tree ID.
+func (s *jsonStore) writeFile(id string, entries map[string]*config.Value) error {
 	data, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
 		return err
 	}
-
 	if err := os.MkdirAll(s.dir, 0o755); err != nil {
 		return err
 	}
 	return os.WriteFile(s.filePath(id), data, 0o644)
 }
 
-func (s *jsonStore) Load(_ context.Context, id string) (*config.Tree, bool, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+// --- Capabilities ---
 
-	data, err := os.ReadFile(s.filePath(id))
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, false, nil
-		}
-		return nil, false, err
-	}
-
-	var entries map[string]*config.Value
-	if err := json.Unmarshal(data, &entries); err != nil {
-		return nil, false, err
-	}
-
-	tree := config.NewTree()
-	for path, v := range entries {
-		if err := tree.Set(path, v); err != nil {
-			return nil, false, err
-		}
-	}
-	return tree, true, nil
+func (s *jsonStore) Capabilities(_ context.Context) (*store.Capabilities, error) {
+	return &store.Capabilities{
+		Versioning:    store.VersioningNone,
+		Encryption:    store.EncryptionNone,
+		Auth:          false,
+		AccessControl: false,
+	}, nil
 }
 
-func (s *jsonStore) Delete(_ context.Context, id string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+// --- Authentication ---
 
-	err := os.Remove(s.filePath(id))
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	return err
+func (s *jsonStore) AuthMethods(_ context.Context) ([]store.AuthMethod, error) {
+	return nil, nil
 }
+
+func (s *jsonStore) Login(_ context.Context, _ string, _ map[string]string) (*store.Credential, error) {
+	return nil, errors.New("authentication not supported")
+}
+
+// --- Tree management ---
 
 func (s *jsonStore) ListTrees(_ context.Context) ([]string, error) {
 	s.mu.RLock()
@@ -122,25 +114,116 @@ func (s *jsonStore) ListTrees(_ context.Context) ([]string, error) {
 	return ids, nil
 }
 
-func (s *jsonStore) SupportsVersioning(_ context.Context) (bool, error) {
-	return false, nil
+func (s *jsonStore) DeleteTree(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	err := os.Remove(s.filePath(id))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }
 
-func (s *jsonStore) ListVersions(_ context.Context, _ string) ([]string, error) {
+// --- Value operations ---
+
+func (s *jsonStore) GetValues(_ context.Context, id string, paths []string) (map[string]config.Value, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entries, err := s.readFile(id)
+	if err != nil {
+		return nil, err
+	}
+	if entries == nil {
+		return nil, nil
+	}
+
+	result := make(map[string]config.Value, len(paths))
+	for _, p := range paths {
+		if v, ok := entries[p]; ok && v != nil {
+			result[p] = *v
+		}
+	}
+	return result, nil
+}
+
+func (s *jsonStore) PutValues(_ context.Context, id string, values map[string]config.Value, _ *store.PutOptions) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, err := s.readFile(id)
+	if err != nil {
+		return err
+	}
+	if entries == nil {
+		entries = make(map[string]*config.Value, len(values))
+	}
+
+	for p, v := range values {
+		cp := v // copy
+		entries[p] = &cp
+	}
+
+	return s.writeFile(id, entries)
+}
+
+func (s *jsonStore) DeleteValues(_ context.Context, id string, paths []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, err := s.readFile(id)
+	if err != nil {
+		return err
+	}
+	if entries == nil {
+		return nil
+	}
+
+	for _, p := range paths {
+		delete(entries, p)
+	}
+
+	return s.writeFile(id, entries)
+}
+
+// --- Tree-level versioning ---
+
+func (s *jsonStore) ListTreeVersions(_ context.Context, _ string) ([]string, error) {
 	return nil, errors.New("versioning not supported")
 }
 
-func (s *jsonStore) LoadVersion(_ context.Context, _ string, _ string) (*config.Tree, bool, error) {
-	return nil, false, errors.New("versioning not supported")
+func (s *jsonStore) GetTreeVersion(_ context.Context, _ string, _ string, _ []string) (map[string]config.Value, error) {
+	return nil, errors.New("versioning not supported")
 }
 
-func (s *jsonStore) DeleteVersion(_ context.Context, _ string, _ string) error {
+func (s *jsonStore) RollbackTree(_ context.Context, _ string, _ string) error {
 	return errors.New("versioning not supported")
 }
 
-func (s *jsonStore) EncryptionStatus(_ context.Context) (store.EncryptionStatus, error) {
-	return store.EncryptionNone, nil
+func (s *jsonStore) DeleteTreeVersion(_ context.Context, _ string, _ string) error {
+	return errors.New("versioning not supported")
 }
+
+// --- Value-level versioning ---
+
+func (s *jsonStore) ListValueVersions(_ context.Context, _ string, _ string) ([]string, error) {
+	return nil, errors.New("versioning not supported")
+}
+
+func (s *jsonStore) GetValueVersion(_ context.Context, _ string, _ string, _ string) (config.Value, bool, error) {
+	return config.Value{}, false, errors.New("versioning not supported")
+}
+
+func (s *jsonStore) RollbackValue(_ context.Context, _ string, _ string, _ string) error {
+	return errors.New("versioning not supported")
+}
+
+func (s *jsonStore) DeleteValueVersion(_ context.Context, _ string, _ string, _ string) error {
+	return errors.New("versioning not supported")
+}
+
+// --- Encryption ---
 
 func (s *jsonStore) InitEncryption(_ context.Context, _ []byte) error {
 	return errors.New("encryption not supported")
@@ -148,6 +231,20 @@ func (s *jsonStore) InitEncryption(_ context.Context, _ []byte) error {
 
 func (s *jsonStore) RotateEncryption(_ context.Context, _, _ []byte) error {
 	return errors.New("encryption not supported")
+}
+
+// --- Access control ---
+
+func (s *jsonStore) GrantAccess(_ context.Context, _ string, _ string, _ []store.Permission) error {
+	return errors.New("access control not supported")
+}
+
+func (s *jsonStore) RevokeAccess(_ context.Context, _ string, _ string, _ []string) error {
+	return errors.New("access control not supported")
+}
+
+func (s *jsonStore) ListAccess(_ context.Context, _ string) (map[string][]store.Permission, error) {
+	return nil, errors.New("access control not supported")
 }
 
 func main() {

--- a/examples/zhi-store-json/main_test.go
+++ b/examples/zhi-store-json/main_test.go
@@ -37,61 +37,112 @@ func dispense(t *testing.T) (store.Plugin, string) {
 	return raw.(store.Plugin), s.dir
 }
 
-func TestSaveAndLoad(t *testing.T) {
+func TestPutAndGetValues(t *testing.T) {
 	p, _ := dispense(t)
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("db/host", &config.Value{Val: "localhost"})
-	_ = tree.Set("db/port", &config.Value{Val: float64(5432)})
-
-	if err := p.Save(ctx, "prod", tree); err != nil {
-		t.Fatalf("Save: %v", err)
+	values := map[string]config.Value{
+		"db/host": {Val: "localhost"},
+		"db/port": {Val: float64(5432)},
 	}
 
-	loaded, found, err := p.Load(ctx, "prod")
+	if err := p.PutValues(ctx, "prod", values, nil); err != nil {
+		t.Fatalf("PutValues: %v", err)
+	}
+
+	got, err := p.GetValues(ctx, "prod", []string{"db/host", "db/port"})
 	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if !found {
-		t.Fatal("Load: not found")
+		t.Fatalf("GetValues: %v", err)
 	}
 
-	v, ok := loaded.Get("db/host")
-	if !ok {
-		t.Fatal("db/host missing")
+	if got["db/host"].Val != "localhost" {
+		t.Errorf("db/host = %v, want %q", got["db/host"].Val, "localhost")
 	}
-	if v.Val != "localhost" {
-		t.Errorf("Val = %v, want %q", v.Val, "localhost")
+	if got["db/port"].Val != float64(5432) {
+		t.Errorf("db/port = %v, want %v", got["db/port"].Val, float64(5432))
 	}
 }
 
-func TestLoadMissing(t *testing.T) {
+func TestGetValuesMissing(t *testing.T) {
 	p, _ := dispense(t)
-	_, found, err := p.Load(context.Background(), "nope")
+	got, err := p.GetValues(context.Background(), "nope", []string{"a/b"})
 	if err != nil {
-		t.Fatalf("Load: %v", err)
+		t.Fatalf("GetValues: %v", err)
 	}
-	if found {
-		t.Error("found should be false for missing tree")
+	if len(got) != 0 {
+		t.Errorf("expected empty map, got %v", got)
 	}
 }
 
-func TestDelete(t *testing.T) {
+func TestGetValuesFilters(t *testing.T) {
 	p, _ := dispense(t)
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("a/b", &config.Value{Val: "x"})
-	_ = p.Save(ctx, "temp", tree)
+	values := map[string]config.Value{
+		"a/b": {Val: "1"},
+		"a/c": {Val: "2"},
+		"a/d": {Val: "3"},
+	}
+	_ = p.PutValues(ctx, "t", values, nil)
 
-	if err := p.Delete(ctx, "temp"); err != nil {
-		t.Fatalf("Delete: %v", err)
+	got, err := p.GetValues(ctx, "t", []string{"a/b", "a/d"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 values, got %d", len(got))
+	}
+	if got["a/b"].Val != "1" {
+		t.Errorf("a/b = %v, want %q", got["a/b"].Val, "1")
+	}
+	if got["a/d"].Val != "3" {
+		t.Errorf("a/d = %v, want %q", got["a/d"].Val, "3")
+	}
+}
+
+func TestDeleteTree(t *testing.T) {
+	p, _ := dispense(t)
+	ctx := context.Background()
+
+	_ = p.PutValues(ctx, "temp", map[string]config.Value{
+		"a/b": {Val: "x"},
+	}, nil)
+
+	if err := p.DeleteTree(ctx, "temp"); err != nil {
+		t.Fatalf("DeleteTree: %v", err)
 	}
 
-	_, found, _ := p.Load(ctx, "temp")
-	if found {
-		t.Error("tree still found after Delete")
+	got, err := p.GetValues(ctx, "temp", []string{"a/b"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
+	}
+	if len(got) != 0 {
+		t.Error("values still found after DeleteTree")
+	}
+}
+
+func TestDeleteValues(t *testing.T) {
+	p, _ := dispense(t)
+	ctx := context.Background()
+
+	_ = p.PutValues(ctx, "t", map[string]config.Value{
+		"a/b": {Val: "1"},
+		"a/c": {Val: "2"},
+	}, nil)
+
+	if err := p.DeleteValues(ctx, "t", []string{"a/b"}); err != nil {
+		t.Fatalf("DeleteValues: %v", err)
+	}
+
+	got, err := p.GetValues(ctx, "t", []string{"a/b", "a/c"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
+	}
+	if _, exists := got["a/b"]; exists {
+		t.Error("a/b still found after DeleteValues")
+	}
+	if got["a/c"].Val != "2" {
+		t.Errorf("a/c = %v, want %q", got["a/c"].Val, "2")
 	}
 }
 
@@ -99,11 +150,8 @@ func TestListTrees(t *testing.T) {
 	p, _ := dispense(t)
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("a/b", &config.Value{Val: "x"})
-
-	_ = p.Save(ctx, "one", tree)
-	_ = p.Save(ctx, "two", tree)
+	_ = p.PutValues(ctx, "one", map[string]config.Value{"a/b": {Val: "x"}}, nil)
+	_ = p.PutValues(ctx, "two", map[string]config.Value{"a/b": {Val: "x"}}, nil)
 
 	ids, err := p.ListTrees(ctx)
 	if err != nil {
@@ -115,25 +163,24 @@ func TestListTrees(t *testing.T) {
 	}
 }
 
-func TestSaveOverwrites(t *testing.T) {
+func TestPutValuesMerges(t *testing.T) {
 	p, _ := dispense(t)
 	ctx := context.Background()
 
-	tree1 := config.NewTree()
-	_ = tree1.Set("app/name", &config.Value{Val: "old"})
-	_ = p.Save(ctx, "app", tree1)
+	_ = p.PutValues(ctx, "app", map[string]config.Value{
+		"app/name": {Val: "old"},
+	}, nil)
 
-	tree2 := config.NewTree()
-	_ = tree2.Set("app/name", &config.Value{Val: "new"})
-	_ = p.Save(ctx, "app", tree2)
+	_ = p.PutValues(ctx, "app", map[string]config.Value{
+		"app/name": {Val: "new"},
+	}, nil)
 
-	loaded, found, _ := p.Load(ctx, "app")
-	if !found {
-		t.Fatal("not found")
+	got, err := p.GetValues(ctx, "app", []string{"app/name"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
 	}
-	v, _ := loaded.Get("app/name")
-	if v.Val != "new" {
-		t.Errorf("Val = %v, want %q", v.Val, "new")
+	if got["app/name"].Val != "new" {
+		t.Errorf("Val = %v, want %q", got["app/name"].Val, "new")
 	}
 }
 
@@ -141,9 +188,9 @@ func TestJSONFileCreatedOnDisk(t *testing.T) {
 	p, dir := dispense(t)
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("key", &config.Value{Val: "value"})
-	_ = p.Save(ctx, "disk-check", tree)
+	_ = p.PutValues(ctx, "disk-check", map[string]config.Value{
+		"key": {Val: "value"},
+	}, nil)
 
 	path := filepath.Join(dir, "disk-check.json")
 	data, err := os.ReadFile(path)
@@ -159,20 +206,45 @@ func TestMetadataPreserved(t *testing.T) {
 	p, _ := dispense(t)
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("key", &config.Value{
-		Val:      "value",
-		Metadata: map[string]any{"description": "test key"},
-	})
-	_ = p.Save(ctx, "meta", tree)
+	_ = p.PutValues(ctx, "meta", map[string]config.Value{
+		"key": {
+			Val:      "value",
+			Metadata: map[string]any{"description": "test key"},
+		},
+	}, nil)
 
-	loaded, found, _ := p.Load(ctx, "meta")
-	if !found {
-		t.Fatal("not found")
+	got, err := p.GetValues(ctx, "meta", []string{"key"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
 	}
-	v, _ := loaded.Get("key")
+	v, ok := got["key"]
+	if !ok {
+		t.Fatal("key missing")
+	}
 	if v.Metadata["description"] != "test key" {
 		t.Errorf("description = %v, want %q", v.Metadata["description"], "test key")
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	p, _ := dispense(t)
+	ctx := context.Background()
+
+	caps, err := p.Capabilities(ctx)
+	if err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
+	if caps.Versioning != store.VersioningNone {
+		t.Errorf("Versioning = %v, want VersioningNone", caps.Versioning)
+	}
+	if caps.Encryption != store.EncryptionNone {
+		t.Errorf("Encryption = %v, want EncryptionNone", caps.Encryption)
+	}
+	if caps.Auth {
+		t.Error("Auth should be false")
+	}
+	if caps.AccessControl {
+		t.Error("AccessControl should be false")
 	}
 }
 
@@ -180,27 +252,40 @@ func TestVersioningNotSupported(t *testing.T) {
 	p, _ := dispense(t)
 	ctx := context.Background()
 
-	supported, err := p.SupportsVersioning(ctx)
-	if err != nil {
-		t.Fatalf("SupportsVersioning: %v", err)
-	}
-	if supported {
-		t.Error("json store should not support versioning")
+	_, err := p.ListTreeVersions(ctx, "any")
+	if err == nil {
+		t.Error("ListTreeVersions should return error")
 	}
 
-	_, err = p.ListVersions(ctx, "any")
+	_, err = p.GetTreeVersion(ctx, "any", "v1", []string{"a/b"})
 	if err == nil {
-		t.Error("ListVersions should return error")
+		t.Error("GetTreeVersion should return error")
 	}
 
-	_, _, err = p.LoadVersion(ctx, "any", "v1")
-	if err == nil {
-		t.Error("LoadVersion should return error")
+	if err := p.RollbackTree(ctx, "any", "v1"); err == nil {
+		t.Error("RollbackTree should return error")
 	}
 
-	err = p.DeleteVersion(ctx, "any", "v1")
+	if err := p.DeleteTreeVersion(ctx, "any", "v1"); err == nil {
+		t.Error("DeleteTreeVersion should return error")
+	}
+
+	_, err = p.ListValueVersions(ctx, "any", "a/b")
 	if err == nil {
-		t.Error("DeleteVersion should return error")
+		t.Error("ListValueVersions should return error")
+	}
+
+	_, _, err = p.GetValueVersion(ctx, "any", "a/b", "v1")
+	if err == nil {
+		t.Error("GetValueVersion should return error")
+	}
+
+	if err := p.RollbackValue(ctx, "any", "a/b", "v1"); err == nil {
+		t.Error("RollbackValue should return error")
+	}
+
+	if err := p.DeleteValueVersion(ctx, "any", "a/b", "v1"); err == nil {
+		t.Error("DeleteValueVersion should return error")
 	}
 }
 
@@ -208,19 +293,29 @@ func TestEncryptionNotSupported(t *testing.T) {
 	p, _ := dispense(t)
 	ctx := context.Background()
 
-	status, err := p.EncryptionStatus(ctx)
-	if err != nil {
-		t.Fatalf("EncryptionStatus: %v", err)
-	}
-	if status != store.EncryptionNone {
-		t.Errorf("EncryptionStatus() = %v, want EncryptionNone", status)
-	}
-
 	if err := p.InitEncryption(ctx, []byte("pass")); err == nil {
 		t.Error("InitEncryption should return error")
 	}
 
 	if err := p.RotateEncryption(ctx, []byte("old"), []byte("new")); err == nil {
 		t.Error("RotateEncryption should return error")
+	}
+}
+
+func TestAccessControlNotSupported(t *testing.T) {
+	p, _ := dispense(t)
+	ctx := context.Background()
+
+	if err := p.GrantAccess(ctx, "t", "alice", []store.Permission{{Path: "a/b", Actions: []store.Action{store.ActionRead}}}); err == nil {
+		t.Error("GrantAccess should return error")
+	}
+
+	if err := p.RevokeAccess(ctx, "t", "alice", []string{"a/b"}); err == nil {
+		t.Error("RevokeAccess should return error")
+	}
+
+	_, err := p.ListAccess(ctx, "t")
+	if err == nil {
+		t.Error("ListAccess should return error")
 	}
 }

--- a/examples/zhi-store-memory/main.go
+++ b/examples/zhi-store-memory/main.go
@@ -2,7 +2,8 @@
 // trees in memory. It demonstrates how to implement store.Plugin with the
 // simplest possible storage backend: a Go map.
 //
-// This example does not support versioning or encryption.
+// This example does not support versioning, authentication, encryption, or
+// access control.
 package main
 
 import (
@@ -19,44 +20,35 @@ import (
 
 type memoryStore struct {
 	mu    sync.RWMutex
-	trees map[string]*config.Tree
+	trees map[string]map[string]config.Value // tree id -> path -> value
 }
 
 func newMemoryStore() *memoryStore {
-	return &memoryStore{trees: make(map[string]*config.Tree)}
+	return &memoryStore{trees: make(map[string]map[string]config.Value)}
 }
 
-func (m *memoryStore) Save(_ context.Context, id string, tree config.TreeReader) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	cp := config.NewTree()
-	for _, path := range tree.List() {
-		v, ok := tree.Get(path)
-		if !ok {
-			continue
-		}
-		_ = cp.Set(path, &v)
-	}
-	m.trees[id] = cp
-	return nil
+// --- Capabilities ---
+
+func (m *memoryStore) Capabilities(_ context.Context) (*store.Capabilities, error) {
+	return &store.Capabilities{
+		Versioning:    store.VersioningNone,
+		Encryption:    store.EncryptionNone,
+		Auth:          false,
+		AccessControl: false,
+	}, nil
 }
 
-func (m *memoryStore) Load(_ context.Context, id string) (*config.Tree, bool, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	t, ok := m.trees[id]
-	if !ok {
-		return nil, false, nil
-	}
-	return t, true, nil
+// --- Authentication ---
+
+func (m *memoryStore) AuthMethods(_ context.Context) ([]store.AuthMethod, error) {
+	return nil, nil
 }
 
-func (m *memoryStore) Delete(_ context.Context, id string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	delete(m.trees, id)
-	return nil
+func (m *memoryStore) Login(_ context.Context, _ string, _ map[string]string) (*store.Credential, error) {
+	return nil, errors.New("authentication not supported")
 }
+
+// --- Tree management ---
 
 func (m *memoryStore) ListTrees(_ context.Context) ([]string, error) {
 	m.mu.RLock()
@@ -68,25 +60,95 @@ func (m *memoryStore) ListTrees(_ context.Context) ([]string, error) {
 	return ids, nil
 }
 
-func (m *memoryStore) SupportsVersioning(_ context.Context) (bool, error) {
-	return false, nil
+func (m *memoryStore) DeleteTree(_ context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.trees, id)
+	return nil
 }
 
-func (m *memoryStore) ListVersions(_ context.Context, _ string) ([]string, error) {
+// --- Value operations ---
+
+func (m *memoryStore) GetValues(_ context.Context, id string, paths []string) (map[string]config.Value, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	tree, ok := m.trees[id]
+	if !ok {
+		return nil, nil
+	}
+	result := make(map[string]config.Value, len(paths))
+	for _, p := range paths {
+		if v, exists := tree[p]; exists {
+			result[p] = v
+		}
+	}
+	return result, nil
+}
+
+func (m *memoryStore) PutValues(_ context.Context, id string, values map[string]config.Value, _ *store.PutOptions) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	tree, ok := m.trees[id]
+	if !ok {
+		tree = make(map[string]config.Value, len(values))
+		m.trees[id] = tree
+	}
+	for p, v := range values {
+		tree[p] = v
+	}
+	return nil
+}
+
+func (m *memoryStore) DeleteValues(_ context.Context, id string, paths []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	tree, ok := m.trees[id]
+	if !ok {
+		return nil
+	}
+	for _, p := range paths {
+		delete(tree, p)
+	}
+	return nil
+}
+
+// --- Tree-level versioning ---
+
+func (m *memoryStore) ListTreeVersions(_ context.Context, _ string) ([]string, error) {
 	return nil, errors.New("versioning not supported")
 }
 
-func (m *memoryStore) LoadVersion(_ context.Context, _ string, _ string) (*config.Tree, bool, error) {
-	return nil, false, errors.New("versioning not supported")
+func (m *memoryStore) GetTreeVersion(_ context.Context, _ string, _ string, _ []string) (map[string]config.Value, error) {
+	return nil, errors.New("versioning not supported")
 }
 
-func (m *memoryStore) DeleteVersion(_ context.Context, _ string, _ string) error {
+func (m *memoryStore) RollbackTree(_ context.Context, _ string, _ string) error {
 	return errors.New("versioning not supported")
 }
 
-func (m *memoryStore) EncryptionStatus(_ context.Context) (store.EncryptionStatus, error) {
-	return store.EncryptionNone, nil
+func (m *memoryStore) DeleteTreeVersion(_ context.Context, _ string, _ string) error {
+	return errors.New("versioning not supported")
 }
+
+// --- Value-level versioning ---
+
+func (m *memoryStore) ListValueVersions(_ context.Context, _ string, _ string) ([]string, error) {
+	return nil, errors.New("versioning not supported")
+}
+
+func (m *memoryStore) GetValueVersion(_ context.Context, _ string, _ string, _ string) (config.Value, bool, error) {
+	return config.Value{}, false, errors.New("versioning not supported")
+}
+
+func (m *memoryStore) RollbackValue(_ context.Context, _ string, _ string, _ string) error {
+	return errors.New("versioning not supported")
+}
+
+func (m *memoryStore) DeleteValueVersion(_ context.Context, _ string, _ string, _ string) error {
+	return errors.New("versioning not supported")
+}
+
+// --- Encryption ---
 
 func (m *memoryStore) InitEncryption(_ context.Context, _ []byte) error {
 	return errors.New("encryption not supported")
@@ -94,6 +156,20 @@ func (m *memoryStore) InitEncryption(_ context.Context, _ []byte) error {
 
 func (m *memoryStore) RotateEncryption(_ context.Context, _, _ []byte) error {
 	return errors.New("encryption not supported")
+}
+
+// --- Access control ---
+
+func (m *memoryStore) GrantAccess(_ context.Context, _ string, _ string, _ []store.Permission) error {
+	return errors.New("access control not supported")
+}
+
+func (m *memoryStore) RevokeAccess(_ context.Context, _ string, _ string, _ []string) error {
+	return errors.New("access control not supported")
+}
+
+func (m *memoryStore) ListAccess(_ context.Context, _ string) (map[string][]store.Permission, error) {
+	return nil, errors.New("access control not supported")
 }
 
 func main() {

--- a/examples/zhi-store-memory/main_test.go
+++ b/examples/zhi-store-memory/main_test.go
@@ -25,61 +25,112 @@ func dispense(t *testing.T) store.Plugin {
 	return raw.(store.Plugin)
 }
 
-func TestSaveAndLoad(t *testing.T) {
+func TestPutAndGetValues(t *testing.T) {
 	p := dispense(t)
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("db/host", &config.Value{Val: "localhost"})
-	_ = tree.Set("db/port", &config.Value{Val: float64(5432)})
-
-	if err := p.Save(ctx, "prod", tree); err != nil {
-		t.Fatalf("Save: %v", err)
+	values := map[string]config.Value{
+		"db/host": {Val: "localhost"},
+		"db/port": {Val: float64(5432)},
 	}
 
-	loaded, found, err := p.Load(ctx, "prod")
+	if err := p.PutValues(ctx, "prod", values, nil); err != nil {
+		t.Fatalf("PutValues: %v", err)
+	}
+
+	got, err := p.GetValues(ctx, "prod", []string{"db/host", "db/port"})
 	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if !found {
-		t.Fatal("Load: not found")
+		t.Fatalf("GetValues: %v", err)
 	}
 
-	v, ok := loaded.Get("db/host")
-	if !ok {
-		t.Fatal("db/host missing")
+	if got["db/host"].Val != "localhost" {
+		t.Errorf("db/host = %v, want %q", got["db/host"].Val, "localhost")
 	}
-	if v.Val != "localhost" {
-		t.Errorf("Val = %v, want %q", v.Val, "localhost")
+	if got["db/port"].Val != float64(5432) {
+		t.Errorf("db/port = %v, want %v", got["db/port"].Val, float64(5432))
 	}
 }
 
-func TestLoadMissing(t *testing.T) {
+func TestGetValuesMissing(t *testing.T) {
 	p := dispense(t)
-	_, found, err := p.Load(context.Background(), "nope")
+	got, err := p.GetValues(context.Background(), "nope", []string{"a/b"})
 	if err != nil {
-		t.Fatalf("Load: %v", err)
+		t.Fatalf("GetValues: %v", err)
 	}
-	if found {
-		t.Error("found should be false for missing tree")
+	if len(got) != 0 {
+		t.Errorf("expected empty map, got %v", got)
 	}
 }
 
-func TestDelete(t *testing.T) {
+func TestGetValuesFilters(t *testing.T) {
 	p := dispense(t)
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("a/b", &config.Value{Val: "x"})
-	_ = p.Save(ctx, "temp", tree)
+	values := map[string]config.Value{
+		"a/b": {Val: "1"},
+		"a/c": {Val: "2"},
+		"a/d": {Val: "3"},
+	}
+	_ = p.PutValues(ctx, "t", values, nil)
 
-	if err := p.Delete(ctx, "temp"); err != nil {
-		t.Fatalf("Delete: %v", err)
+	got, err := p.GetValues(ctx, "t", []string{"a/b", "a/d"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 values, got %d", len(got))
+	}
+	if got["a/b"].Val != "1" {
+		t.Errorf("a/b = %v, want %q", got["a/b"].Val, "1")
+	}
+	if got["a/d"].Val != "3" {
+		t.Errorf("a/d = %v, want %q", got["a/d"].Val, "3")
+	}
+}
+
+func TestDeleteTree(t *testing.T) {
+	p := dispense(t)
+	ctx := context.Background()
+
+	_ = p.PutValues(ctx, "temp", map[string]config.Value{
+		"a/b": {Val: "x"},
+	}, nil)
+
+	if err := p.DeleteTree(ctx, "temp"); err != nil {
+		t.Fatalf("DeleteTree: %v", err)
 	}
 
-	_, found, _ := p.Load(ctx, "temp")
-	if found {
-		t.Error("tree still found after Delete")
+	got, err := p.GetValues(ctx, "temp", []string{"a/b"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
+	}
+	if len(got) != 0 {
+		t.Error("values still found after DeleteTree")
+	}
+}
+
+func TestDeleteValues(t *testing.T) {
+	p := dispense(t)
+	ctx := context.Background()
+
+	_ = p.PutValues(ctx, "t", map[string]config.Value{
+		"a/b": {Val: "1"},
+		"a/c": {Val: "2"},
+	}, nil)
+
+	if err := p.DeleteValues(ctx, "t", []string{"a/b"}); err != nil {
+		t.Fatalf("DeleteValues: %v", err)
+	}
+
+	got, err := p.GetValues(ctx, "t", []string{"a/b", "a/c"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
+	}
+	if _, exists := got["a/b"]; exists {
+		t.Error("a/b still found after DeleteValues")
+	}
+	if got["a/c"].Val != "2" {
+		t.Errorf("a/c = %v, want %q", got["a/c"].Val, "2")
 	}
 }
 
@@ -87,11 +138,8 @@ func TestListTrees(t *testing.T) {
 	p := dispense(t)
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("a/b", &config.Value{Val: "x"})
-
-	_ = p.Save(ctx, "one", tree)
-	_ = p.Save(ctx, "two", tree)
+	_ = p.PutValues(ctx, "one", map[string]config.Value{"a/b": {Val: "x"}}, nil)
+	_ = p.PutValues(ctx, "two", map[string]config.Value{"a/b": {Val: "x"}}, nil)
 
 	ids, err := p.ListTrees(ctx)
 	if err != nil {
@@ -103,25 +151,46 @@ func TestListTrees(t *testing.T) {
 	}
 }
 
-func TestSaveOverwrites(t *testing.T) {
+func TestPutValuesMerges(t *testing.T) {
 	p := dispense(t)
 	ctx := context.Background()
 
-	tree1 := config.NewTree()
-	_ = tree1.Set("app/name", &config.Value{Val: "old"})
-	_ = p.Save(ctx, "app", tree1)
+	_ = p.PutValues(ctx, "app", map[string]config.Value{
+		"app/name": {Val: "old"},
+	}, nil)
 
-	tree2 := config.NewTree()
-	_ = tree2.Set("app/name", &config.Value{Val: "new"})
-	_ = p.Save(ctx, "app", tree2)
+	_ = p.PutValues(ctx, "app", map[string]config.Value{
+		"app/name": {Val: "new"},
+	}, nil)
 
-	loaded, found, _ := p.Load(ctx, "app")
-	if !found {
-		t.Fatal("not found")
+	got, err := p.GetValues(ctx, "app", []string{"app/name"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
 	}
-	v, _ := loaded.Get("app/name")
-	if v.Val != "new" {
-		t.Errorf("Val = %v, want %q", v.Val, "new")
+	if got["app/name"].Val != "new" {
+		t.Errorf("Val = %v, want %q", got["app/name"].Val, "new")
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	p := dispense(t)
+	ctx := context.Background()
+
+	caps, err := p.Capabilities(ctx)
+	if err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
+	if caps.Versioning != store.VersioningNone {
+		t.Errorf("Versioning = %v, want VersioningNone", caps.Versioning)
+	}
+	if caps.Encryption != store.EncryptionNone {
+		t.Errorf("Encryption = %v, want EncryptionNone", caps.Encryption)
+	}
+	if caps.Auth {
+		t.Error("Auth should be false")
+	}
+	if caps.AccessControl {
+		t.Error("AccessControl should be false")
 	}
 }
 
@@ -129,41 +198,46 @@ func TestVersioningNotSupported(t *testing.T) {
 	p := dispense(t)
 	ctx := context.Background()
 
-	supported, err := p.SupportsVersioning(ctx)
-	if err != nil {
-		t.Fatalf("SupportsVersioning: %v", err)
-	}
-	if supported {
-		t.Error("memory store should not support versioning")
+	_, err := p.ListTreeVersions(ctx, "any")
+	if err == nil {
+		t.Error("ListTreeVersions should return error")
 	}
 
-	_, err = p.ListVersions(ctx, "any")
+	_, err = p.GetTreeVersion(ctx, "any", "v1", []string{"a/b"})
 	if err == nil {
-		t.Error("ListVersions should return error")
+		t.Error("GetTreeVersion should return error")
 	}
 
-	_, _, err = p.LoadVersion(ctx, "any", "v1")
-	if err == nil {
-		t.Error("LoadVersion should return error")
+	if err := p.RollbackTree(ctx, "any", "v1"); err == nil {
+		t.Error("RollbackTree should return error")
 	}
 
-	err = p.DeleteVersion(ctx, "any", "v1")
+	if err := p.DeleteTreeVersion(ctx, "any", "v1"); err == nil {
+		t.Error("DeleteTreeVersion should return error")
+	}
+
+	_, err = p.ListValueVersions(ctx, "any", "a/b")
 	if err == nil {
-		t.Error("DeleteVersion should return error")
+		t.Error("ListValueVersions should return error")
+	}
+
+	_, _, err = p.GetValueVersion(ctx, "any", "a/b", "v1")
+	if err == nil {
+		t.Error("GetValueVersion should return error")
+	}
+
+	if err := p.RollbackValue(ctx, "any", "a/b", "v1"); err == nil {
+		t.Error("RollbackValue should return error")
+	}
+
+	if err := p.DeleteValueVersion(ctx, "any", "a/b", "v1"); err == nil {
+		t.Error("DeleteValueVersion should return error")
 	}
 }
 
 func TestEncryptionNotSupported(t *testing.T) {
 	p := dispense(t)
 	ctx := context.Background()
-
-	status, err := p.EncryptionStatus(ctx)
-	if err != nil {
-		t.Fatalf("EncryptionStatus: %v", err)
-	}
-	if status != store.EncryptionNone {
-		t.Errorf("EncryptionStatus() = %v, want EncryptionNone", status)
-	}
 
 	if err := p.InitEncryption(ctx, []byte("pass")); err == nil {
 		t.Error("InitEncryption should return error")
@@ -174,22 +248,43 @@ func TestEncryptionNotSupported(t *testing.T) {
 	}
 }
 
+func TestAccessControlNotSupported(t *testing.T) {
+	p := dispense(t)
+	ctx := context.Background()
+
+	if err := p.GrantAccess(ctx, "t", "alice", []store.Permission{{Path: "a/b", Actions: []store.Action{store.ActionRead}}}); err == nil {
+		t.Error("GrantAccess should return error")
+	}
+
+	if err := p.RevokeAccess(ctx, "t", "alice", []string{"a/b"}); err == nil {
+		t.Error("RevokeAccess should return error")
+	}
+
+	_, err := p.ListAccess(ctx, "t")
+	if err == nil {
+		t.Error("ListAccess should return error")
+	}
+}
+
 func TestMetadataPreserved(t *testing.T) {
 	p := dispense(t)
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("key", &config.Value{
-		Val:      "value",
-		Metadata: map[string]any{"description": "test key"},
-	})
-	_ = p.Save(ctx, "meta", tree)
+	_ = p.PutValues(ctx, "meta", map[string]config.Value{
+		"key": {
+			Val:      "value",
+			Metadata: map[string]any{"description": "test key"},
+		},
+	}, nil)
 
-	loaded, found, _ := p.Load(ctx, "meta")
-	if !found {
-		t.Fatal("not found")
+	got, err := p.GetValues(ctx, "meta", []string{"key"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
 	}
-	v, _ := loaded.Get("key")
+	v, ok := got["key"]
+	if !ok {
+		t.Fatal("key missing")
+	}
 	if v.Metadata["description"] != "test key" {
 		t.Errorf("description = %v, want %q", v.Metadata["description"], "test key")
 	}

--- a/internal/cli/testhelper_test.go
+++ b/internal/cli/testhelper_test.go
@@ -75,36 +75,25 @@ func (m *mockTransform) ValidatePolicy(context.Context) (transform.ValidatePolic
 
 // mockStore is a store.Plugin backed by an in-memory map for testing.
 type mockStore struct {
-	trees map[string]*config.Tree
+	trees map[string]map[string]config.Value
 }
 
 func newMockStore() *mockStore {
-	return &mockStore{trees: make(map[string]*config.Tree)}
+	return &mockStore{trees: make(map[string]map[string]config.Value)}
 }
 
-func (m *mockStore) Save(_ context.Context, id string, tree config.TreeReader) error {
-	t := config.NewTree()
-	for _, path := range tree.List() {
-		v, ok := tree.Get(path)
-		if ok {
-			_ = t.Set(path, &v)
-		}
-	}
-	m.trees[id] = t
-	return nil
+func (m *mockStore) Capabilities(context.Context) (*store.Capabilities, error) {
+	return &store.Capabilities{
+		Versioning: store.VersioningNone,
+		Encryption: store.EncryptionNone,
+	}, nil
 }
 
-func (m *mockStore) Load(_ context.Context, id string) (*config.Tree, bool, error) {
-	t, ok := m.trees[id]
-	if !ok {
-		return nil, false, nil
-	}
-	return t, true, nil
+func (m *mockStore) AuthMethods(context.Context) ([]store.AuthMethod, error) {
+	return nil, fmt.Errorf("auth not supported")
 }
-
-func (m *mockStore) Delete(_ context.Context, id string) error {
-	delete(m.trees, id)
-	return nil
+func (m *mockStore) Login(context.Context, string, map[string]string) (*store.Credential, error) {
+	return nil, fmt.Errorf("auth not supported")
 }
 
 func (m *mockStore) ListTrees(context.Context) ([]string, error) {
@@ -116,21 +105,81 @@ func (m *mockStore) ListTrees(context.Context) ([]string, error) {
 	return ids, nil
 }
 
-func (m *mockStore) SupportsVersioning(context.Context) (bool, error) { return false, nil }
-func (m *mockStore) ListVersions(context.Context, string) ([]string, error) {
+func (m *mockStore) DeleteTree(_ context.Context, id string) error {
+	delete(m.trees, id)
+	return nil
+}
+
+func (m *mockStore) GetValues(_ context.Context, id string, paths []string) (map[string]config.Value, error) {
+	vals, ok := m.trees[id]
+	if !ok {
+		return nil, nil
+	}
+	result := make(map[string]config.Value)
+	for _, p := range paths {
+		if v, exists := vals[p]; exists {
+			result[p] = v
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStore) PutValues(_ context.Context, id string, values map[string]config.Value, _ *store.PutOptions) error {
+	if m.trees[id] == nil {
+		m.trees[id] = make(map[string]config.Value)
+	}
+	for p, v := range values {
+		m.trees[id][p] = v
+	}
+	return nil
+}
+
+func (m *mockStore) DeleteValues(_ context.Context, id string, paths []string) error {
+	vals := m.trees[id]
+	if vals == nil {
+		return nil
+	}
+	for _, p := range paths {
+		delete(vals, p)
+	}
+	return nil
+}
+
+func (m *mockStore) ListTreeVersions(context.Context, string) ([]string, error) {
 	return nil, fmt.Errorf("versioning not supported")
 }
-func (m *mockStore) LoadVersion(context.Context, string, string) (*config.Tree, bool, error) {
-	return nil, false, fmt.Errorf("versioning not supported")
+func (m *mockStore) GetTreeVersion(context.Context, string, string, []string) (map[string]config.Value, error) {
+	return nil, fmt.Errorf("versioning not supported")
 }
-func (m *mockStore) DeleteVersion(context.Context, string, string) error {
+func (m *mockStore) RollbackTree(context.Context, string, string) error {
 	return fmt.Errorf("versioning not supported")
 }
-func (m *mockStore) EncryptionStatus(context.Context) (store.EncryptionStatus, error) {
-	return store.EncryptionNone, nil
+func (m *mockStore) DeleteTreeVersion(context.Context, string, string) error {
+	return fmt.Errorf("versioning not supported")
+}
+func (m *mockStore) ListValueVersions(context.Context, string, string) ([]string, error) {
+	return nil, fmt.Errorf("versioning not supported")
+}
+func (m *mockStore) GetValueVersion(context.Context, string, string, string) (config.Value, bool, error) {
+	return config.Value{}, false, fmt.Errorf("versioning not supported")
+}
+func (m *mockStore) RollbackValue(context.Context, string, string, string) error {
+	return fmt.Errorf("versioning not supported")
+}
+func (m *mockStore) DeleteValueVersion(context.Context, string, string, string) error {
+	return fmt.Errorf("versioning not supported")
 }
 func (m *mockStore) InitEncryption(context.Context, []byte) error           { return nil }
 func (m *mockStore) RotateEncryption(context.Context, []byte, []byte) error { return nil }
+func (m *mockStore) GrantAccess(context.Context, string, string, []store.Permission) error {
+	return fmt.Errorf("access control not supported")
+}
+func (m *mockStore) RevokeAccess(context.Context, string, string, []string) error {
+	return fmt.Errorf("access control not supported")
+}
+func (m *mockStore) ListAccess(context.Context, string) (map[string][]store.Permission, error) {
+	return nil, fmt.Errorf("access control not supported")
+}
 
 // setupTestEngine creates a test engine with mock providers and the given components.
 func setupTestEngine(t *testing.T, components []core.ComponentDef) *core.Engine {

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -145,22 +145,49 @@ func (e *Engine) SetValue(ctx context.Context, path string, value config.Value) 
 	return e.configPlugin.Set(ctx, path, value)
 }
 
-// SaveTree persists a tree to the store provider. It also persists the
-// current component state. Returns an error if no store is configured.
+// SaveTree persists a tree to the store provider by extracting all values
+// and writing them with PutValues. Returns an error if no store is configured.
 func (e *Engine) SaveTree(ctx context.Context, id string, tree *config.Tree) error {
 	if e.storePlugin == nil {
 		return fmt.Errorf("no store provider configured")
 	}
-	return e.storePlugin.Save(ctx, id, tree)
+	values := make(map[string]config.Value)
+	for _, path := range tree.List() {
+		v, ok := tree.Get(path)
+		if ok {
+			values[path] = v
+		}
+	}
+	return e.storePlugin.PutValues(ctx, id, values, nil)
 }
 
-// LoadStoredTree loads a tree from the store provider. Returns an error if
-// no store is configured.
+// LoadStoredTree loads a tree from the store provider. The config plugin's
+// path list is used so the store knows exactly which values to fetch.
+// Returns an error if no store is configured.
 func (e *Engine) LoadStoredTree(ctx context.Context, id string) (*config.Tree, bool, error) {
 	if e.storePlugin == nil {
 		return nil, false, fmt.Errorf("no store provider configured")
 	}
-	return e.storePlugin.Load(ctx, id)
+	// Obtain the expected paths from the config plugin.
+	paths, err := e.configPlugin.List(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("listing config paths for store load: %w", err)
+	}
+	values, err := e.storePlugin.GetValues(ctx, id, paths)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(values) == 0 {
+		return nil, false, nil
+	}
+	tree := config.NewTree()
+	for path, v := range values {
+		cp := v
+		if err := tree.Set(path, &cp); err != nil {
+			return nil, false, fmt.Errorf("setting stored value at %q: %w", path, err)
+		}
+	}
+	return tree, true, nil
 }
 
 // ListTrees returns all tree IDs from the store provider. Returns an error

--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -76,36 +76,25 @@ func (m *mockTransform) ValidatePolicy(context.Context) (transform.ValidatePolic
 
 // mockStore is a store.Plugin backed by an in-memory map for testing.
 type mockStore struct {
-	trees map[string]*config.Tree
+	trees map[string]map[string]config.Value
 }
 
 func newMockStore() *mockStore {
-	return &mockStore{trees: make(map[string]*config.Tree)}
+	return &mockStore{trees: make(map[string]map[string]config.Value)}
 }
 
-func (m *mockStore) Save(_ context.Context, id string, tree config.TreeReader) error {
-	t := config.NewTree()
-	for _, path := range tree.List() {
-		v, ok := tree.Get(path)
-		if ok {
-			_ = t.Set(path, &v)
-		}
-	}
-	m.trees[id] = t
-	return nil
+func (m *mockStore) Capabilities(context.Context) (*store.Capabilities, error) {
+	return &store.Capabilities{
+		Versioning: store.VersioningNone,
+		Encryption: store.EncryptionNone,
+	}, nil
 }
 
-func (m *mockStore) Load(_ context.Context, id string) (*config.Tree, bool, error) {
-	t, ok := m.trees[id]
-	if !ok {
-		return nil, false, nil
-	}
-	return t, true, nil
+func (m *mockStore) AuthMethods(context.Context) ([]store.AuthMethod, error) {
+	return nil, fmt.Errorf("auth not supported")
 }
-
-func (m *mockStore) Delete(_ context.Context, id string) error {
-	delete(m.trees, id)
-	return nil
+func (m *mockStore) Login(context.Context, string, map[string]string) (*store.Credential, error) {
+	return nil, fmt.Errorf("auth not supported")
 }
 
 func (m *mockStore) ListTrees(context.Context) ([]string, error) {
@@ -117,21 +106,81 @@ func (m *mockStore) ListTrees(context.Context) ([]string, error) {
 	return ids, nil
 }
 
-func (m *mockStore) SupportsVersioning(context.Context) (bool, error) { return false, nil }
-func (m *mockStore) ListVersions(context.Context, string) ([]string, error) {
+func (m *mockStore) DeleteTree(_ context.Context, id string) error {
+	delete(m.trees, id)
+	return nil
+}
+
+func (m *mockStore) GetValues(_ context.Context, id string, paths []string) (map[string]config.Value, error) {
+	vals, ok := m.trees[id]
+	if !ok {
+		return nil, nil
+	}
+	result := make(map[string]config.Value)
+	for _, p := range paths {
+		if v, exists := vals[p]; exists {
+			result[p] = v
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStore) PutValues(_ context.Context, id string, values map[string]config.Value, _ *store.PutOptions) error {
+	if m.trees[id] == nil {
+		m.trees[id] = make(map[string]config.Value)
+	}
+	for p, v := range values {
+		m.trees[id][p] = v
+	}
+	return nil
+}
+
+func (m *mockStore) DeleteValues(_ context.Context, id string, paths []string) error {
+	vals := m.trees[id]
+	if vals == nil {
+		return nil
+	}
+	for _, p := range paths {
+		delete(vals, p)
+	}
+	return nil
+}
+
+func (m *mockStore) ListTreeVersions(context.Context, string) ([]string, error) {
 	return nil, fmt.Errorf("versioning not supported")
 }
-func (m *mockStore) LoadVersion(context.Context, string, string) (*config.Tree, bool, error) {
-	return nil, false, fmt.Errorf("versioning not supported")
+func (m *mockStore) GetTreeVersion(context.Context, string, string, []string) (map[string]config.Value, error) {
+	return nil, fmt.Errorf("versioning not supported")
 }
-func (m *mockStore) DeleteVersion(context.Context, string, string) error {
+func (m *mockStore) RollbackTree(context.Context, string, string) error {
 	return fmt.Errorf("versioning not supported")
 }
-func (m *mockStore) EncryptionStatus(context.Context) (store.EncryptionStatus, error) {
-	return store.EncryptionNone, nil
+func (m *mockStore) DeleteTreeVersion(context.Context, string, string) error {
+	return fmt.Errorf("versioning not supported")
+}
+func (m *mockStore) ListValueVersions(context.Context, string, string) ([]string, error) {
+	return nil, fmt.Errorf("versioning not supported")
+}
+func (m *mockStore) GetValueVersion(context.Context, string, string, string) (config.Value, bool, error) {
+	return config.Value{}, false, fmt.Errorf("versioning not supported")
+}
+func (m *mockStore) RollbackValue(context.Context, string, string, string) error {
+	return fmt.Errorf("versioning not supported")
+}
+func (m *mockStore) DeleteValueVersion(context.Context, string, string, string) error {
+	return fmt.Errorf("versioning not supported")
 }
 func (m *mockStore) InitEncryption(context.Context, []byte) error           { return nil }
 func (m *mockStore) RotateEncryption(context.Context, []byte, []byte) error { return nil }
+func (m *mockStore) GrantAccess(context.Context, string, string, []store.Permission) error {
+	return fmt.Errorf("access control not supported")
+}
+func (m *mockStore) RevokeAccess(context.Context, string, string, []string) error {
+	return fmt.Errorf("access control not supported")
+}
+func (m *mockStore) ListAccess(context.Context, string) (map[string][]store.Permission, error) {
+	return nil, fmt.Errorf("access control not supported")
+}
 
 func setupTestEngine(t *testing.T) (*Engine, *mockConfig, *mockTransform, *mockStore) {
 	t.Helper()

--- a/internal/core/launcher_test.go
+++ b/internal/core/launcher_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/MrWong99/zhi/pkg/zhiplugin/store"
 )
 
 // findProjectRoot walks up from the current directory to find the go.mod file.
@@ -136,13 +138,13 @@ func TestLaunchStorePlugin(t *testing.T) {
 		t.Errorf("ListTrees = %v, want empty", trees)
 	}
 
-	// Test SupportsVersioning.
-	versioning, err := p.SupportsVersioning(context.Background())
+	// Test Capabilities.
+	caps, err := p.Capabilities(context.Background())
 	if err != nil {
-		t.Fatalf("SupportsVersioning: %v", err)
+		t.Fatalf("Capabilities: %v", err)
 	}
-	if versioning {
-		t.Error("zhi-store-memory should not support versioning")
+	if caps.Versioning != store.VersioningNone {
+		t.Errorf("Capabilities.Versioning = %v, want VersioningNone", caps.Versioning)
 	}
 }
 

--- a/internal/core/registry_test.go
+++ b/internal/core/registry_test.go
@@ -34,21 +34,45 @@ func (s *stubTransform) ValidatePolicy(context.Context) (transform.ValidatePolic
 // stubStore is a minimal store.Plugin for testing.
 type stubStore struct{}
 
-func (s *stubStore) Save(context.Context, string, config.TreeReader) error    { return nil }
-func (s *stubStore) Load(context.Context, string) (*config.Tree, bool, error) { return nil, false, nil }
-func (s *stubStore) Delete(context.Context, string) error                     { return nil }
-func (s *stubStore) ListTrees(context.Context) ([]string, error)              { return nil, nil }
-func (s *stubStore) SupportsVersioning(context.Context) (bool, error)         { return false, nil }
-func (s *stubStore) ListVersions(context.Context, string) ([]string, error)   { return nil, nil }
-func (s *stubStore) LoadVersion(context.Context, string, string) (*config.Tree, bool, error) {
-	return nil, false, nil
+func (s *stubStore) Capabilities(context.Context) (*store.Capabilities, error) {
+	return &store.Capabilities{}, nil
 }
-func (s *stubStore) DeleteVersion(context.Context, string, string) error { return nil }
-func (s *stubStore) EncryptionStatus(context.Context) (store.EncryptionStatus, error) {
-	return store.EncryptionNone, nil
+func (s *stubStore) AuthMethods(context.Context) ([]store.AuthMethod, error) { return nil, nil }
+func (s *stubStore) Login(context.Context, string, map[string]string) (*store.Credential, error) {
+	return nil, nil
 }
-func (s *stubStore) InitEncryption(context.Context, []byte) error           { return nil }
-func (s *stubStore) RotateEncryption(context.Context, []byte, []byte) error { return nil }
+func (s *stubStore) ListTrees(context.Context) ([]string, error) { return nil, nil }
+func (s *stubStore) DeleteTree(context.Context, string) error    { return nil }
+func (s *stubStore) GetValues(context.Context, string, []string) (map[string]config.Value, error) {
+	return nil, nil
+}
+func (s *stubStore) PutValues(context.Context, string, map[string]config.Value, *store.PutOptions) error {
+	return nil
+}
+func (s *stubStore) DeleteValues(context.Context, string, []string) error       { return nil }
+func (s *stubStore) ListTreeVersions(context.Context, string) ([]string, error) { return nil, nil }
+func (s *stubStore) GetTreeVersion(context.Context, string, string, []string) (map[string]config.Value, error) {
+	return nil, nil
+}
+func (s *stubStore) RollbackTree(context.Context, string, string) error      { return nil }
+func (s *stubStore) DeleteTreeVersion(context.Context, string, string) error { return nil }
+func (s *stubStore) ListValueVersions(context.Context, string, string) ([]string, error) {
+	return nil, nil
+}
+func (s *stubStore) GetValueVersion(context.Context, string, string, string) (config.Value, bool, error) {
+	return config.Value{}, false, nil
+}
+func (s *stubStore) RollbackValue(context.Context, string, string, string) error      { return nil }
+func (s *stubStore) DeleteValueVersion(context.Context, string, string, string) error { return nil }
+func (s *stubStore) InitEncryption(context.Context, []byte) error                     { return nil }
+func (s *stubStore) RotateEncryption(context.Context, []byte, []byte) error           { return nil }
+func (s *stubStore) GrantAccess(context.Context, string, string, []store.Permission) error {
+	return nil
+}
+func (s *stubStore) RevokeAccess(context.Context, string, string, []string) error { return nil }
+func (s *stubStore) ListAccess(context.Context, string) (map[string][]store.Permission, error) {
+	return nil, nil
+}
 
 func TestRegistryRegisterAndResolve(t *testing.T) {
 	r := NewRegistry()

--- a/internal/ui/driver_test.go
+++ b/internal/ui/driver_test.go
@@ -52,33 +52,23 @@ func (m *mockTransform) ValidatePolicy(_ context.Context) (transform.ValidatePol
 }
 
 type mockStore struct {
-	trees map[string]*config.Tree
+	trees map[string]map[string]config.Value
 }
 
 func newMockStore() *mockStore {
-	return &mockStore{trees: make(map[string]*config.Tree)}
+	return &mockStore{trees: make(map[string]map[string]config.Value)}
 }
 
-func (m *mockStore) Save(_ context.Context, id string, r config.TreeReader) error {
-	t := config.NewTree()
-	for _, p := range r.List() {
-		v, ok := r.Get(p)
-		if ok {
-			_ = t.Set(p, &v)
-		}
-	}
-	m.trees[id] = t
-	return nil
+func (m *mockStore) Capabilities(_ context.Context) (*store.Capabilities, error) {
+	return &store.Capabilities{
+		Versioning: store.VersioningNone,
+		Encryption: store.EncryptionNone,
+	}, nil
 }
 
-func (m *mockStore) Load(_ context.Context, id string) (*config.Tree, bool, error) {
-	t, ok := m.trees[id]
-	return t, ok, nil
-}
-
-func (m *mockStore) Delete(_ context.Context, id string) error {
-	delete(m.trees, id)
-	return nil
+func (m *mockStore) AuthMethods(_ context.Context) ([]store.AuthMethod, error) { return nil, nil }
+func (m *mockStore) Login(_ context.Context, _ string, _ map[string]string) (*store.Credential, error) {
+	return nil, nil
 }
 
 func (m *mockStore) ListTrees(_ context.Context) ([]string, error) {
@@ -89,19 +79,71 @@ func (m *mockStore) ListTrees(_ context.Context) ([]string, error) {
 	return ids, nil
 }
 
-func (m *mockStore) SupportsVersioning(_ context.Context) (bool, error) { return false, nil }
-func (m *mockStore) ListVersions(_ context.Context, _ string) ([]string, error) {
+func (m *mockStore) DeleteTree(_ context.Context, id string) error {
+	delete(m.trees, id)
+	return nil
+}
+
+func (m *mockStore) GetValues(_ context.Context, id string, paths []string) (map[string]config.Value, error) {
+	vals, ok := m.trees[id]
+	if !ok {
+		return nil, nil
+	}
+	result := make(map[string]config.Value)
+	for _, p := range paths {
+		if v, exists := vals[p]; exists {
+			result[p] = v
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStore) PutValues(_ context.Context, id string, values map[string]config.Value, _ *store.PutOptions) error {
+	if m.trees[id] == nil {
+		m.trees[id] = make(map[string]config.Value)
+	}
+	for p, v := range values {
+		m.trees[id][p] = v
+	}
+	return nil
+}
+
+func (m *mockStore) DeleteValues(_ context.Context, id string, paths []string) error {
+	vals := m.trees[id]
+	if vals == nil {
+		return nil
+	}
+	for _, p := range paths {
+		delete(vals, p)
+	}
+	return nil
+}
+
+func (m *mockStore) ListTreeVersions(_ context.Context, _ string) ([]string, error) { return nil, nil }
+func (m *mockStore) GetTreeVersion(_ context.Context, _, _ string, _ []string) (map[string]config.Value, error) {
 	return nil, nil
 }
-func (m *mockStore) LoadVersion(_ context.Context, _, _ string) (*config.Tree, bool, error) {
-	return nil, false, nil
+func (m *mockStore) RollbackTree(_ context.Context, _, _ string) error      { return nil }
+func (m *mockStore) DeleteTreeVersion(_ context.Context, _, _ string) error { return nil }
+func (m *mockStore) ListValueVersions(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
 }
-func (m *mockStore) DeleteVersion(_ context.Context, _, _ string) error { return nil }
-func (m *mockStore) EncryptionStatus(_ context.Context) (store.EncryptionStatus, error) {
-	return store.EncryptionNone, nil
+func (m *mockStore) GetValueVersion(_ context.Context, _, _, _ string) (config.Value, bool, error) {
+	return config.Value{}, false, nil
 }
-func (m *mockStore) InitEncryption(_ context.Context, _ []byte) error      { return nil }
-func (m *mockStore) RotateEncryption(_ context.Context, _, _ []byte) error { return nil }
+func (m *mockStore) RollbackValue(_ context.Context, _, _, _ string) error      { return nil }
+func (m *mockStore) DeleteValueVersion(_ context.Context, _, _, _ string) error { return nil }
+func (m *mockStore) InitEncryption(_ context.Context, _ []byte) error           { return nil }
+func (m *mockStore) RotateEncryption(_ context.Context, _, _ []byte) error      { return nil }
+func (m *mockStore) GrantAccess(_ context.Context, _ string, _ string, _ []store.Permission) error {
+	return nil
+}
+func (m *mockStore) RevokeAccess(_ context.Context, _ string, _ string, _ []string) error {
+	return nil
+}
+func (m *mockStore) ListAccess(_ context.Context, _ string) (map[string][]store.Permission, error) {
+	return nil, nil
+}
 
 // --- test helpers ---
 

--- a/internal/ui/tui/app_test.go
+++ b/internal/ui/tui/app_test.go
@@ -51,33 +51,23 @@ func (m *mockConfig) Validate(_ context.Context, path string, _ config.TreeReade
 }
 
 type mockStore struct {
-	trees map[string]*config.Tree
+	trees map[string]map[string]config.Value
 }
 
 func newMockStore() *mockStore {
-	return &mockStore{trees: make(map[string]*config.Tree)}
+	return &mockStore{trees: make(map[string]map[string]config.Value)}
 }
 
-func (m *mockStore) Save(_ context.Context, id string, r config.TreeReader) error {
-	t := config.NewTree()
-	for _, p := range r.List() {
-		v, ok := r.Get(p)
-		if ok {
-			_ = t.Set(p, &v)
-		}
-	}
-	m.trees[id] = t
-	return nil
+func (m *mockStore) Capabilities(_ context.Context) (*store.Capabilities, error) {
+	return &store.Capabilities{
+		Versioning: store.VersioningNone,
+		Encryption: store.EncryptionNone,
+	}, nil
 }
 
-func (m *mockStore) Load(_ context.Context, id string) (*config.Tree, bool, error) {
-	t, ok := m.trees[id]
-	return t, ok, nil
-}
-
-func (m *mockStore) Delete(_ context.Context, id string) error {
-	delete(m.trees, id)
-	return nil
+func (m *mockStore) AuthMethods(_ context.Context) ([]store.AuthMethod, error) { return nil, nil }
+func (m *mockStore) Login(_ context.Context, _ string, _ map[string]string) (*store.Credential, error) {
+	return nil, nil
 }
 
 func (m *mockStore) ListTrees(_ context.Context) ([]string, error) {
@@ -88,17 +78,71 @@ func (m *mockStore) ListTrees(_ context.Context) ([]string, error) {
 	return ids, nil
 }
 
-func (m *mockStore) SupportsVersioning(_ context.Context) (bool, error)         { return false, nil }
-func (m *mockStore) ListVersions(_ context.Context, _ string) ([]string, error) { return nil, nil }
-func (m *mockStore) LoadVersion(_ context.Context, _, _ string) (*config.Tree, bool, error) {
-	return nil, false, nil
+func (m *mockStore) DeleteTree(_ context.Context, id string) error {
+	delete(m.trees, id)
+	return nil
 }
-func (m *mockStore) DeleteVersion(_ context.Context, _, _ string) error { return nil }
-func (m *mockStore) EncryptionStatus(_ context.Context) (store.EncryptionStatus, error) {
-	return store.EncryptionNone, nil
+
+func (m *mockStore) GetValues(_ context.Context, id string, paths []string) (map[string]config.Value, error) {
+	vals, ok := m.trees[id]
+	if !ok {
+		return nil, nil
+	}
+	result := make(map[string]config.Value)
+	for _, p := range paths {
+		if v, exists := vals[p]; exists {
+			result[p] = v
+		}
+	}
+	return result, nil
 }
-func (m *mockStore) InitEncryption(_ context.Context, _ []byte) error      { return nil }
-func (m *mockStore) RotateEncryption(_ context.Context, _, _ []byte) error { return nil }
+
+func (m *mockStore) PutValues(_ context.Context, id string, values map[string]config.Value, _ *store.PutOptions) error {
+	if m.trees[id] == nil {
+		m.trees[id] = make(map[string]config.Value)
+	}
+	for p, v := range values {
+		m.trees[id][p] = v
+	}
+	return nil
+}
+
+func (m *mockStore) DeleteValues(_ context.Context, id string, paths []string) error {
+	vals := m.trees[id]
+	if vals == nil {
+		return nil
+	}
+	for _, p := range paths {
+		delete(vals, p)
+	}
+	return nil
+}
+
+func (m *mockStore) ListTreeVersions(_ context.Context, _ string) ([]string, error) { return nil, nil }
+func (m *mockStore) GetTreeVersion(_ context.Context, _, _ string, _ []string) (map[string]config.Value, error) {
+	return nil, nil
+}
+func (m *mockStore) RollbackTree(_ context.Context, _, _ string) error      { return nil }
+func (m *mockStore) DeleteTreeVersion(_ context.Context, _, _ string) error { return nil }
+func (m *mockStore) ListValueVersions(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}
+func (m *mockStore) GetValueVersion(_ context.Context, _, _, _ string) (config.Value, bool, error) {
+	return config.Value{}, false, nil
+}
+func (m *mockStore) RollbackValue(_ context.Context, _, _, _ string) error      { return nil }
+func (m *mockStore) DeleteValueVersion(_ context.Context, _, _, _ string) error { return nil }
+func (m *mockStore) InitEncryption(_ context.Context, _ []byte) error           { return nil }
+func (m *mockStore) RotateEncryption(_ context.Context, _, _ []byte) error      { return nil }
+func (m *mockStore) GrantAccess(_ context.Context, _ string, _ string, _ []store.Permission) error {
+	return nil
+}
+func (m *mockStore) RevokeAccess(_ context.Context, _ string, _ string, _ []string) error {
+	return nil
+}
+func (m *mockStore) ListAccess(_ context.Context, _ string) (map[string][]store.Permission, error) {
+	return nil, nil
+}
 
 func setupTestController(t *testing.T) *ui.UIController {
 	t.Helper()

--- a/pkg/zhiplugin/store/grpc_client.go
+++ b/pkg/zhiplugin/store/grpc_client.go
@@ -2,41 +2,76 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	configpb "github.com/MrWong99/zhi/pkg/zhiplugin/config/proto"
 	pb "github.com/MrWong99/zhi/pkg/zhiplugin/store/proto"
 )
 
-// GRPCClient implements Plugin by talking to the gRPC
-// StoreServiceClient generated from the proto definition.
+// GRPCClient implements Plugin by talking to the gRPC StoreServiceClient
+// generated from the proto definition.
 type GRPCClient struct {
 	client pb.StoreServiceClient
 }
 
-func (c *GRPCClient) Save(ctx context.Context, id string, tree config.TreeReader) error {
-	entries := config.TreeToProto(tree)
-	_, err := c.client.Save(ctx, &pb.SaveRequest{
-		Id:   id,
-		Tree: entries,
-	})
-	return err
-}
+// --- Capabilities ---
 
-func (c *GRPCClient) Load(ctx context.Context, id string) (*config.Tree, bool, error) {
-	resp, err := c.client.Load(ctx, &pb.LoadRequest{Id: id})
+func (c *GRPCClient) Capabilities(ctx context.Context) (*Capabilities, error) {
+	resp, err := c.client.Capabilities(ctx, &pb.StoreCapabilitiesRequest{})
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	if !resp.GetFound() {
-		return nil, false, nil
-	}
-	return config.TreeFromProto(resp.GetTree()), true, nil
+	return &Capabilities{
+		Versioning:    VersioningMode(resp.GetVersioning()),
+		Encryption:    EncryptionStatus(resp.GetEncryption()),
+		Auth:          resp.GetAuth(),
+		AccessControl: resp.GetAccessControl(),
+	}, nil
 }
 
-func (c *GRPCClient) Delete(ctx context.Context, id string) error {
-	_, err := c.client.Delete(ctx, &pb.DeleteRequest{Id: id})
-	return err
+// --- Authentication ---
+
+func (c *GRPCClient) AuthMethods(ctx context.Context) ([]AuthMethod, error) {
+	resp, err := c.client.AuthMethods(ctx, &pb.AuthMethodsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	methods := make([]AuthMethod, 0, len(resp.GetMethods()))
+	for _, m := range resp.GetMethods() {
+		am := AuthMethod{
+			Type:        m.GetType(),
+			Description: m.GetDescription(),
+		}
+		for _, f := range m.GetFields() {
+			am.Fields = append(am.Fields, AuthField{
+				Name:        f.GetName(),
+				Description: f.GetDescription(),
+				Required:    f.GetRequired(),
+				Secret:      f.GetSecret(),
+			})
+		}
+		methods = append(methods, am)
+	}
+	return methods, nil
 }
+
+func (c *GRPCClient) Login(ctx context.Context, method string, credentials map[string]string) (*Credential, error) {
+	resp, err := c.client.Login(ctx, &pb.LoginRequest{
+		Method:      method,
+		Credentials: credentials,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Credential{
+		Token:     resp.GetToken(),
+		ExpiresAt: resp.GetExpiresAt(),
+		Metadata:  resp.GetMetadata(),
+	}, nil
+}
+
+// --- Tree management ---
 
 func (c *GRPCClient) ListTrees(ctx context.Context) ([]string, error) {
 	resp, err := c.client.ListTrees(ctx, &pb.ListTreesRequest{})
@@ -46,51 +81,135 @@ func (c *GRPCClient) ListTrees(ctx context.Context) ([]string, error) {
 	return resp.GetIds(), nil
 }
 
-func (c *GRPCClient) SupportsVersioning(ctx context.Context) (bool, error) {
-	resp, err := c.client.SupportsVersioning(ctx, &pb.SupportsVersioningRequest{})
-	if err != nil {
-		return false, err
-	}
-	return resp.GetSupported(), nil
+func (c *GRPCClient) DeleteTree(ctx context.Context, id string) error {
+	_, err := c.client.DeleteTree(ctx, &pb.DeleteTreeRequest{Id: id})
+	return err
 }
 
-func (c *GRPCClient) ListVersions(ctx context.Context, id string) ([]string, error) {
-	resp, err := c.client.ListVersions(ctx, &pb.ListVersionsRequest{Id: id})
+// --- Value operations ---
+
+func (c *GRPCClient) GetValues(ctx context.Context, id string, paths []string) (map[string]config.Value, error) {
+	resp, err := c.client.GetValues(ctx, &pb.GetValuesRequest{
+		Id:    id,
+		Paths: paths,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entriesFromProto(resp.GetValues())
+}
+
+func (c *GRPCClient) PutValues(ctx context.Context, id string, values map[string]config.Value, opts *PutOptions) error {
+	entries := valuesToProto(values)
+	req := &pb.PutValuesRequest{
+		Id:     id,
+		Values: entries,
+	}
+	if opts != nil {
+		req.CasVersion = opts.CASVersion
+		req.CasVersions = opts.CASVersions
+	}
+	_, err := c.client.PutValues(ctx, req)
+	return err
+}
+
+func (c *GRPCClient) DeleteValues(ctx context.Context, id string, paths []string) error {
+	_, err := c.client.DeleteValues(ctx, &pb.DeleteValuesRequest{
+		Id:    id,
+		Paths: paths,
+	})
+	return err
+}
+
+// --- Tree-level versioning ---
+
+func (c *GRPCClient) ListTreeVersions(ctx context.Context, id string) ([]string, error) {
+	resp, err := c.client.ListTreeVersions(ctx, &pb.ListTreeVersionsRequest{Id: id})
 	if err != nil {
 		return nil, err
 	}
 	return resp.GetVersions(), nil
 }
 
-func (c *GRPCClient) LoadVersion(ctx context.Context, id string, version string) (*config.Tree, bool, error) {
-	resp, err := c.client.LoadVersion(ctx, &pb.LoadVersionRequest{
+func (c *GRPCClient) GetTreeVersion(ctx context.Context, id string, version string, paths []string) (map[string]config.Value, error) {
+	resp, err := c.client.GetTreeVersion(ctx, &pb.GetTreeVersionRequest{
 		Id:      id,
 		Version: version,
+		Paths:   paths,
 	})
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	if !resp.GetFound() {
-		return nil, false, nil
-	}
-	return config.TreeFromProto(resp.GetTree()), true, nil
+	return entriesFromProto(resp.GetValues())
 }
 
-func (c *GRPCClient) DeleteVersion(ctx context.Context, id string, version string) error {
-	_, err := c.client.DeleteVersion(ctx, &pb.DeleteVersionRequest{
+func (c *GRPCClient) RollbackTree(ctx context.Context, id string, version string) error {
+	_, err := c.client.RollbackTree(ctx, &pb.RollbackTreeRequest{
 		Id:      id,
 		Version: version,
 	})
 	return err
 }
 
-func (c *GRPCClient) EncryptionStatus(ctx context.Context) (EncryptionStatus, error) {
-	resp, err := c.client.EncryptionStatus(ctx, &pb.EncryptionStatusRequest{})
-	if err != nil {
-		return 0, err
-	}
-	return EncryptionStatus(resp.GetStatus()), nil
+func (c *GRPCClient) DeleteTreeVersion(ctx context.Context, id string, version string) error {
+	_, err := c.client.DeleteTreeVersion(ctx, &pb.DeleteTreeVersionRequest{
+		Id:      id,
+		Version: version,
+	})
+	return err
 }
+
+// --- Value-level versioning ---
+
+func (c *GRPCClient) ListValueVersions(ctx context.Context, id string, path string) ([]string, error) {
+	resp, err := c.client.ListValueVersions(ctx, &pb.ListValueVersionsRequest{
+		Id:   id,
+		Path: path,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetVersions(), nil
+}
+
+func (c *GRPCClient) GetValueVersion(ctx context.Context, id string, path string, version string) (config.Value, bool, error) {
+	resp, err := c.client.GetValueVersion(ctx, &pb.GetValueVersionRequest{
+		Id:      id,
+		Path:    path,
+		Version: version,
+	})
+	if err != nil {
+		return config.Value{}, false, err
+	}
+	if !resp.GetFound() {
+		return config.Value{}, false, nil
+	}
+	v, err := config.ValueFromProto(resp.GetValueJson(), resp.GetMetadataJson())
+	if err != nil {
+		return config.Value{}, false, err
+	}
+	return v, true, nil
+}
+
+func (c *GRPCClient) RollbackValue(ctx context.Context, id string, path string, version string) error {
+	_, err := c.client.RollbackValue(ctx, &pb.RollbackValueRequest{
+		Id:      id,
+		Path:    path,
+		Version: version,
+	})
+	return err
+}
+
+func (c *GRPCClient) DeleteValueVersion(ctx context.Context, id string, path string, version string) error {
+	_, err := c.client.DeleteValueVersion(ctx, &pb.DeleteValueVersionRequest{
+		Id:      id,
+		Path:    path,
+		Version: version,
+	})
+	return err
+}
+
+// --- Encryption ---
 
 func (c *GRPCClient) InitEncryption(ctx context.Context, passphrase []byte) error {
 	_, err := c.client.InitEncryption(ctx, &pb.InitEncryptionRequest{
@@ -105,4 +224,100 @@ func (c *GRPCClient) RotateEncryption(ctx context.Context, oldPassphrase, newPas
 		NewPassphrase: newPassphrase,
 	})
 	return err
+}
+
+// --- Access control ---
+
+func (c *GRPCClient) GrantAccess(ctx context.Context, id string, user string, permissions []Permission) error {
+	_, err := c.client.GrantAccess(ctx, &pb.GrantAccessRequest{
+		Id:          id,
+		User:        user,
+		Permissions: permissionsToProto(permissions),
+	})
+	return err
+}
+
+func (c *GRPCClient) RevokeAccess(ctx context.Context, id string, user string, paths []string) error {
+	_, err := c.client.RevokeAccess(ctx, &pb.RevokeAccessRequest{
+		Id:    id,
+		User:  user,
+		Paths: paths,
+	})
+	return err
+}
+
+func (c *GRPCClient) ListAccess(ctx context.Context, id string) (map[string][]Permission, error) {
+	resp, err := c.client.ListAccess(ctx, &pb.ListAccessRequest{Id: id})
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string][]Permission, len(resp.GetAccess()))
+	for user, up := range resp.GetAccess() {
+		result[user] = permissionsFromProto(up.GetPermissions())
+	}
+	return result, nil
+}
+
+// --- helpers ---
+
+// valuesToProto serialises a map of path->Value into proto TreeEntry messages.
+func valuesToProto(values map[string]config.Value) []*configpb.TreeEntry {
+	entries := make([]*configpb.TreeEntry, 0, len(values))
+	for path, v := range values {
+		valJSON, err := json.Marshal(v.Val)
+		if err != nil {
+			continue
+		}
+		var metaJSON []byte
+		if v.Metadata != nil {
+			metaJSON, _ = json.Marshal(v.Metadata)
+		}
+		entries = append(entries, &configpb.TreeEntry{
+			Path:         path,
+			ValueJson:    valJSON,
+			MetadataJson: metaJSON,
+		})
+	}
+	return entries
+}
+
+// entriesFromProto converts proto TreeEntry messages back into a map of
+// path->Value.
+func entriesFromProto(entries []*configpb.TreeEntry) (map[string]config.Value, error) {
+	result := make(map[string]config.Value, len(entries))
+	for _, e := range entries {
+		v, err := config.ValueFromProto(e.GetValueJson(), e.GetMetadataJson())
+		if err != nil {
+			return nil, err
+		}
+		result[e.GetPath()] = v
+	}
+	return result, nil
+}
+
+func permissionsToProto(perms []Permission) []*pb.PermissionMsg {
+	msgs := make([]*pb.PermissionMsg, 0, len(perms))
+	for _, p := range perms {
+		actions := make([]pb.ActionType, 0, len(p.Actions))
+		for _, a := range p.Actions {
+			actions = append(actions, pb.ActionType(a))
+		}
+		msgs = append(msgs, &pb.PermissionMsg{
+			Path:    p.Path,
+			Actions: actions,
+		})
+	}
+	return msgs
+}
+
+func permissionsFromProto(msgs []*pb.PermissionMsg) []Permission {
+	perms := make([]Permission, 0, len(msgs))
+	for _, m := range msgs {
+		p := Permission{Path: m.GetPath()}
+		for _, a := range m.GetActions() {
+			p.Actions = append(p.Actions, Action(a))
+		}
+		perms = append(perms, p)
+	}
+	return perms
 }

--- a/pkg/zhiplugin/store/grpc_server.go
+++ b/pkg/zhiplugin/store/grpc_server.go
@@ -2,8 +2,10 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	configpb "github.com/MrWong99/zhi/pkg/zhiplugin/config/proto"
 	pb "github.com/MrWong99/zhi/pkg/zhiplugin/store/proto"
 )
 
@@ -14,34 +16,60 @@ type GRPCServer struct {
 	Impl Plugin
 }
 
-func (s *GRPCServer) Save(ctx context.Context, req *pb.SaveRequest) (*pb.SaveResponse, error) {
-	tree := config.TreeFromProto(req.GetTree())
-	if err := s.Impl.Save(ctx, req.GetId(), tree); err != nil {
-		return nil, err
-	}
-	return &pb.SaveResponse{}, nil
-}
+// --- Capabilities ---
 
-func (s *GRPCServer) Load(ctx context.Context, req *pb.LoadRequest) (*pb.LoadResponse, error) {
-	tree, found, err := s.Impl.Load(ctx, req.GetId())
+func (s *GRPCServer) Capabilities(ctx context.Context, _ *pb.StoreCapabilitiesRequest) (*pb.StoreCapabilitiesResponse, error) {
+	caps, err := s.Impl.Capabilities(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if !found {
-		return &pb.LoadResponse{Found: false}, nil
-	}
-	return &pb.LoadResponse{
-		Found: true,
-		Tree:  config.TreeToProto(tree),
+	return &pb.StoreCapabilitiesResponse{
+		Versioning:    pb.VersioningMode(caps.Versioning),
+		Encryption:    int32(caps.Encryption),
+		Auth:          caps.Auth,
+		AccessControl: caps.AccessControl,
 	}, nil
 }
 
-func (s *GRPCServer) Delete(ctx context.Context, req *pb.DeleteRequest) (*pb.DeleteResponse, error) {
-	if err := s.Impl.Delete(ctx, req.GetId()); err != nil {
+// --- Authentication ---
+
+func (s *GRPCServer) AuthMethods(ctx context.Context, _ *pb.AuthMethodsRequest) (*pb.AuthMethodsResponse, error) {
+	methods, err := s.Impl.AuthMethods(ctx)
+	if err != nil {
 		return nil, err
 	}
-	return &pb.DeleteResponse{}, nil
+	msgs := make([]*pb.AuthMethodMsg, 0, len(methods))
+	for _, m := range methods {
+		msg := &pb.AuthMethodMsg{
+			Type:        m.Type,
+			Description: m.Description,
+		}
+		for _, f := range m.Fields {
+			msg.Fields = append(msg.Fields, &pb.AuthFieldMsg{
+				Name:        f.Name,
+				Description: f.Description,
+				Required:    f.Required,
+				Secret:      f.Secret,
+			})
+		}
+		msgs = append(msgs, msg)
+	}
+	return &pb.AuthMethodsResponse{Methods: msgs}, nil
 }
+
+func (s *GRPCServer) Login(ctx context.Context, req *pb.LoginRequest) (*pb.LoginResponse, error) {
+	cred, err := s.Impl.Login(ctx, req.GetMethod(), req.GetCredentials())
+	if err != nil {
+		return nil, err
+	}
+	return &pb.LoginResponse{
+		Token:     cred.Token,
+		ExpiresAt: cred.ExpiresAt,
+		Metadata:  cred.Metadata,
+	}, nil
+}
+
+// --- Tree management ---
 
 func (s *GRPCServer) ListTrees(ctx context.Context, _ *pb.ListTreesRequest) (*pb.ListTreesResponse, error) {
 	ids, err := s.Impl.ListTrees(ctx)
@@ -51,50 +79,131 @@ func (s *GRPCServer) ListTrees(ctx context.Context, _ *pb.ListTreesRequest) (*pb
 	return &pb.ListTreesResponse{Ids: ids}, nil
 }
 
-func (s *GRPCServer) SupportsVersioning(ctx context.Context, _ *pb.SupportsVersioningRequest) (*pb.SupportsVersioningResponse, error) {
-	supported, err := s.Impl.SupportsVersioning(ctx)
+func (s *GRPCServer) DeleteTree(ctx context.Context, req *pb.DeleteTreeRequest) (*pb.DeleteTreeResponse, error) {
+	if err := s.Impl.DeleteTree(ctx, req.GetId()); err != nil {
+		return nil, err
+	}
+	return &pb.DeleteTreeResponse{}, nil
+}
+
+// --- Value operations ---
+
+func (s *GRPCServer) GetValues(ctx context.Context, req *pb.GetValuesRequest) (*pb.GetValuesResponse, error) {
+	values, err := s.Impl.GetValues(ctx, req.GetId(), req.GetPaths())
 	if err != nil {
 		return nil, err
 	}
-	return &pb.SupportsVersioningResponse{Supported: supported}, nil
+	return &pb.GetValuesResponse{Values: valuesToProto(values)}, nil
 }
 
-func (s *GRPCServer) ListVersions(ctx context.Context, req *pb.ListVersionsRequest) (*pb.ListVersionsResponse, error) {
-	versions, err := s.Impl.ListVersions(ctx, req.GetId())
+func (s *GRPCServer) PutValues(ctx context.Context, req *pb.PutValuesRequest) (*pb.PutValuesResponse, error) {
+	values, err := serverEntriesFromProto(req.GetValues())
 	if err != nil {
 		return nil, err
 	}
-	return &pb.ListVersionsResponse{Versions: versions}, nil
+	var opts *PutOptions
+	if req.GetCasVersion() != "" || len(req.GetCasVersions()) > 0 {
+		opts = &PutOptions{
+			CASVersion:  req.GetCasVersion(),
+			CASVersions: req.GetCasVersions(),
+		}
+	}
+	if err := s.Impl.PutValues(ctx, req.GetId(), values, opts); err != nil {
+		return nil, err
+	}
+	return &pb.PutValuesResponse{}, nil
 }
 
-func (s *GRPCServer) LoadVersion(ctx context.Context, req *pb.LoadVersionRequest) (*pb.LoadVersionResponse, error) {
-	tree, found, err := s.Impl.LoadVersion(ctx, req.GetId(), req.GetVersion())
+func (s *GRPCServer) DeleteValues(ctx context.Context, req *pb.DeleteValuesRequest) (*pb.DeleteValuesResponse, error) {
+	if err := s.Impl.DeleteValues(ctx, req.GetId(), req.GetPaths()); err != nil {
+		return nil, err
+	}
+	return &pb.DeleteValuesResponse{}, nil
+}
+
+// --- Tree-level versioning ---
+
+func (s *GRPCServer) ListTreeVersions(ctx context.Context, req *pb.ListTreeVersionsRequest) (*pb.ListTreeVersionsResponse, error) {
+	versions, err := s.Impl.ListTreeVersions(ctx, req.GetId())
+	if err != nil {
+		return nil, err
+	}
+	return &pb.ListTreeVersionsResponse{Versions: versions}, nil
+}
+
+func (s *GRPCServer) GetTreeVersion(ctx context.Context, req *pb.GetTreeVersionRequest) (*pb.GetTreeVersionResponse, error) {
+	values, err := s.Impl.GetTreeVersion(ctx, req.GetId(), req.GetVersion(), req.GetPaths())
+	if err != nil {
+		return nil, err
+	}
+	return &pb.GetTreeVersionResponse{Values: valuesToProto(values)}, nil
+}
+
+func (s *GRPCServer) RollbackTree(ctx context.Context, req *pb.RollbackTreeRequest) (*pb.RollbackTreeResponse, error) {
+	if err := s.Impl.RollbackTree(ctx, req.GetId(), req.GetVersion()); err != nil {
+		return nil, err
+	}
+	return &pb.RollbackTreeResponse{}, nil
+}
+
+func (s *GRPCServer) DeleteTreeVersion(ctx context.Context, req *pb.DeleteTreeVersionRequest) (*pb.DeleteTreeVersionResponse, error) {
+	if err := s.Impl.DeleteTreeVersion(ctx, req.GetId(), req.GetVersion()); err != nil {
+		return nil, err
+	}
+	return &pb.DeleteTreeVersionResponse{}, nil
+}
+
+// --- Value-level versioning ---
+
+func (s *GRPCServer) ListValueVersions(ctx context.Context, req *pb.ListValueVersionsRequest) (*pb.ListValueVersionsResponse, error) {
+	versions, err := s.Impl.ListValueVersions(ctx, req.GetId(), req.GetPath())
+	if err != nil {
+		return nil, err
+	}
+	return &pb.ListValueVersionsResponse{Versions: versions}, nil
+}
+
+func (s *GRPCServer) GetValueVersion(ctx context.Context, req *pb.GetValueVersionRequest) (*pb.GetValueVersionResponse, error) {
+	v, found, err := s.Impl.GetValueVersion(ctx, req.GetId(), req.GetPath(), req.GetVersion())
 	if err != nil {
 		return nil, err
 	}
 	if !found {
-		return &pb.LoadVersionResponse{Found: false}, nil
+		return &pb.GetValueVersionResponse{Found: false}, nil
 	}
-	return &pb.LoadVersionResponse{
-		Found: true,
-		Tree:  config.TreeToProto(tree),
-	}, nil
-}
-
-func (s *GRPCServer) DeleteVersion(ctx context.Context, req *pb.DeleteVersionRequest) (*pb.DeleteVersionResponse, error) {
-	if err := s.Impl.DeleteVersion(ctx, req.GetId(), req.GetVersion()); err != nil {
-		return nil, err
-	}
-	return &pb.DeleteVersionResponse{}, nil
-}
-
-func (s *GRPCServer) EncryptionStatus(ctx context.Context, _ *pb.EncryptionStatusRequest) (*pb.EncryptionStatusResponse, error) {
-	status, err := s.Impl.EncryptionStatus(ctx)
+	valJSON, err := json.Marshal(v.Val)
 	if err != nil {
 		return nil, err
 	}
-	return &pb.EncryptionStatusResponse{Status: int32(status)}, nil
+	var metaJSON []byte
+	if v.Metadata != nil {
+		metaJSON, err = json.Marshal(v.Metadata)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &pb.GetValueVersionResponse{
+		Found:        true,
+		ValueJson:    valJSON,
+		MetadataJson: metaJSON,
+	}, nil
 }
+
+func (s *GRPCServer) RollbackValue(ctx context.Context, req *pb.RollbackValueRequest) (*pb.RollbackValueResponse, error) {
+	if err := s.Impl.RollbackValue(ctx, req.GetId(), req.GetPath(), req.GetVersion()); err != nil {
+		return nil, err
+	}
+	return &pb.RollbackValueResponse{}, nil
+}
+
+func (s *GRPCServer) DeleteValueVersion(ctx context.Context, req *pb.DeleteValueVersionRequest) (*pb.DeleteValueVersionResponse, error) {
+	if err := s.Impl.DeleteValueVersion(ctx, req.GetId(), req.GetPath(), req.GetVersion()); err != nil {
+		return nil, err
+	}
+	return &pb.DeleteValueVersionResponse{}, nil
+}
+
+// --- Encryption ---
 
 func (s *GRPCServer) InitEncryption(ctx context.Context, req *pb.InitEncryptionRequest) (*pb.InitEncryptionResponse, error) {
 	if err := s.Impl.InitEncryption(ctx, req.GetPassphrase()); err != nil {
@@ -108,4 +217,49 @@ func (s *GRPCServer) RotateEncryption(ctx context.Context, req *pb.RotateEncrypt
 		return nil, err
 	}
 	return &pb.RotateEncryptionResponse{}, nil
+}
+
+// --- Access control ---
+
+func (s *GRPCServer) GrantAccess(ctx context.Context, req *pb.GrantAccessRequest) (*pb.GrantAccessResponse, error) {
+	perms := permissionsFromProto(req.GetPermissions())
+	if err := s.Impl.GrantAccess(ctx, req.GetId(), req.GetUser(), perms); err != nil {
+		return nil, err
+	}
+	return &pb.GrantAccessResponse{}, nil
+}
+
+func (s *GRPCServer) RevokeAccess(ctx context.Context, req *pb.RevokeAccessRequest) (*pb.RevokeAccessResponse, error) {
+	if err := s.Impl.RevokeAccess(ctx, req.GetId(), req.GetUser(), req.GetPaths()); err != nil {
+		return nil, err
+	}
+	return &pb.RevokeAccessResponse{}, nil
+}
+
+func (s *GRPCServer) ListAccess(ctx context.Context, req *pb.ListAccessRequest) (*pb.ListAccessResponse, error) {
+	access, err := s.Impl.ListAccess(ctx, req.GetId())
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]*pb.UserPermissions, len(access))
+	for user, perms := range access {
+		result[user] = &pb.UserPermissions{
+			Permissions: permissionsToProto(perms),
+		}
+	}
+	return &pb.ListAccessResponse{Access: result}, nil
+}
+
+// serverEntriesFromProto converts proto TreeEntry messages into a map on
+// the server side.
+func serverEntriesFromProto(entries []*configpb.TreeEntry) (map[string]config.Value, error) {
+	result := make(map[string]config.Value, len(entries))
+	for _, e := range entries {
+		v, err := config.ValueFromProto(e.GetValueJson(), e.GetMetadataJson())
+		if err != nil {
+			return nil, err
+		}
+		result[e.GetPath()] = v
+	}
+	return result, nil
 }

--- a/pkg/zhiplugin/store/plugin.go
+++ b/pkg/zhiplugin/store/plugin.go
@@ -12,39 +12,103 @@ import (
 
 // Plugin is the interface every zhi store plugin must implement.
 // The host communicates with it over gRPC.
+//
+// Plugins may support different subsets of the interface. Methods that
+// do not apply to a plugin's capabilities should return a descriptive
+// error (e.g. "versioning not supported"). The Capabilities method
+// lets the host discover which features are available.
 type Plugin interface {
-	// Save persists a configuration tree under the given ID.
-	// If versioning is supported, this creates a new version.
-	Save(ctx context.Context, id string, tree config.TreeReader) error
-	// Load retrieves the latest version of the configuration tree with
-	// the given ID. The bool reports whether the tree was found.
-	Load(ctx context.Context, id string) (*config.Tree, bool, error)
-	// Delete removes the configuration tree and all its versions.
-	Delete(ctx context.Context, id string) error
-	// ListTrees returns all stored tree IDs.
+	// --- Capabilities ---
+
+	// Capabilities reports the store's supported features including
+	// versioning mode, encryption state, and auth/access control.
+	Capabilities(ctx context.Context) (*Capabilities, error)
+
+	// --- Authentication ---
+
+	// AuthMethods returns the authentication methods supported by this
+	// store. Returns nil or empty if authentication is not required.
+	AuthMethods(ctx context.Context) ([]AuthMethod, error)
+	// Login authenticates with the store using the given method and
+	// credentials. The plugin stores the resulting session internally;
+	// the returned Credential is informational for the host/UI.
+	Login(ctx context.Context, method string, credentials map[string]string) (*Credential, error)
+
+	// --- Tree management ---
+
+	// ListTrees returns all tree IDs the current identity has access to.
 	ListTrees(ctx context.Context) ([]string, error)
+	// DeleteTree removes an entire tree and all its versions/values.
+	DeleteTree(ctx context.Context, id string) error
 
-	// SupportsVersioning reports whether this store keeps older versions
-	// of trees.
-	SupportsVersioning(ctx context.Context) (bool, error)
-	// ListVersions returns version identifiers for the given tree ID,
-	// ordered newest first. Returns an error if versioning is not
-	// supported.
-	ListVersions(ctx context.Context, id string) ([]string, error)
-	// LoadVersion retrieves a specific version of the configuration tree.
-	// Returns an error if versioning is not supported.
-	LoadVersion(ctx context.Context, id string, version string) (*config.Tree, bool, error)
-	// DeleteVersion permanently removes a single version of a
-	// configuration tree. Returns an error if versioning is not supported.
-	DeleteVersion(ctx context.Context, id string, version string) error
+	// --- Value operations (structure-aware) ---
 
-	// EncryptionStatus reports the current encryption state of the store.
-	EncryptionStatus(ctx context.Context) (EncryptionStatus, error)
-	// InitEncryption initializes encryption for the store with the given
-	// passphrase. The exact semantics depend on the implementation.
+	// GetValues retrieves specific values from a tree. The paths slice
+	// specifies exactly which values to read, enabling the plugin to
+	// fetch them directly without recursive traversal. Paths that do
+	// not exist are omitted from the result.
+	GetValues(ctx context.Context, id string, paths []string) (map[string]config.Value, error)
+	// PutValues writes specific values to a tree. Only the specified
+	// paths are created or updated; other existing paths are not
+	// affected. The opts parameter may be nil when no CAS is needed.
+	PutValues(ctx context.Context, id string, values map[string]config.Value, opts *PutOptions) error
+	// DeleteValues removes specific values from a tree.
+	DeleteValues(ctx context.Context, id string, paths []string) error
+
+	// --- Tree-level versioning (VersioningTree mode) ---
+
+	// ListTreeVersions returns version identifiers for the tree,
+	// ordered newest first. Returns an error if versioning mode is not
+	// VersioningTree.
+	ListTreeVersions(ctx context.Context, id string) ([]string, error)
+	// GetTreeVersion retrieves specific values from a specific tree
+	// version. Returns an error if versioning mode is not VersioningTree.
+	GetTreeVersion(ctx context.Context, id string, version string, paths []string) (map[string]config.Value, error)
+	// RollbackTree restores the tree to a previous version, creating a
+	// new version whose contents match the specified version. Returns an
+	// error if versioning mode is not VersioningTree.
+	RollbackTree(ctx context.Context, id string, version string) error
+	// DeleteTreeVersion permanently removes a single tree version.
+	// Returns an error if versioning mode is not VersioningTree.
+	DeleteTreeVersion(ctx context.Context, id string, version string) error
+
+	// --- Value-level versioning (VersioningValue mode) ---
+
+	// ListValueVersions returns version identifiers for a specific
+	// value, ordered newest first. Returns an error if versioning mode
+	// is not VersioningValue.
+	ListValueVersions(ctx context.Context, id string, path string) ([]string, error)
+	// GetValueVersion retrieves a specific version of a single value.
+	// Returns an error if versioning mode is not VersioningValue.
+	GetValueVersion(ctx context.Context, id string, path string, version string) (config.Value, bool, error)
+	// RollbackValue restores a value to a previous version, creating
+	// a new version with the old content. Returns an error if
+	// versioning mode is not VersioningValue.
+	RollbackValue(ctx context.Context, id string, path string, version string) error
+	// DeleteValueVersion permanently removes a single value version.
+	// Returns an error if versioning mode is not VersioningValue.
+	DeleteValueVersion(ctx context.Context, id string, path string, version string) error
+
+	// --- Encryption ---
+
+	// InitEncryption initializes encryption for the store with the
+	// given passphrase. The exact semantics depend on the implementation.
 	InitEncryption(ctx context.Context, passphrase []byte) error
 	// RotateEncryption re-encrypts all stored data with a new passphrase.
 	RotateEncryption(ctx context.Context, oldPassphrase, newPassphrase []byte) error
+
+	// --- Access control ---
+
+	// GrantAccess grants a user access to specific paths within a tree.
+	// Returns an error if the store does not support access control.
+	GrantAccess(ctx context.Context, id string, user string, permissions []Permission) error
+	// RevokeAccess removes a user's access to specific paths within a
+	// tree. Returns an error if the store does not support access control.
+	RevokeAccess(ctx context.Context, id string, user string, paths []string) error
+	// ListAccess returns the current access permissions for a tree,
+	// keyed by user. Returns an error if the store does not support
+	// access control.
+	ListAccess(ctx context.Context, id string) (map[string][]Permission, error)
 }
 
 // PluginMap is the map of plugins the host expects. Plugin binaries must

--- a/pkg/zhiplugin/store/proto/store.pb.go
+++ b/pkg/zhiplugin/store/proto/store.pb.go
@@ -25,119 +25,125 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type SaveRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// The identifier for this configuration tree.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// The full configuration tree to persist.
-	Tree          []*proto.TreeEntry `protobuf:"bytes,2,rep,name=tree,proto3" json:"tree,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
+type VersioningMode int32
 
-func (x *SaveRequest) Reset() {
-	*x = SaveRequest{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[0]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
+const (
+	VersioningMode_VERSIONING_NONE  VersioningMode = 0
+	VersioningMode_VERSIONING_TREE  VersioningMode = 1
+	VersioningMode_VERSIONING_VALUE VersioningMode = 2
+)
 
-func (x *SaveRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*SaveRequest) ProtoMessage() {}
-
-func (x *SaveRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[0]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
+// Enum value maps for VersioningMode.
+var (
+	VersioningMode_name = map[int32]string{
+		0: "VERSIONING_NONE",
+		1: "VERSIONING_TREE",
+		2: "VERSIONING_VALUE",
 	}
-	return mi.MessageOf(x)
+	VersioningMode_value = map[string]int32{
+		"VERSIONING_NONE":  0,
+		"VERSIONING_TREE":  1,
+		"VERSIONING_VALUE": 2,
+	}
+)
+
+func (x VersioningMode) Enum() *VersioningMode {
+	p := new(VersioningMode)
+	*p = x
+	return p
 }
 
-// Deprecated: Use SaveRequest.ProtoReflect.Descriptor instead.
-func (*SaveRequest) Descriptor() ([]byte, []int) {
+func (x VersioningMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (VersioningMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_zhiplugin_v1_store_proto_enumTypes[0].Descriptor()
+}
+
+func (VersioningMode) Type() protoreflect.EnumType {
+	return &file_zhiplugin_v1_store_proto_enumTypes[0]
+}
+
+func (x VersioningMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use VersioningMode.Descriptor instead.
+func (VersioningMode) EnumDescriptor() ([]byte, []int) {
 	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *SaveRequest) GetId() string {
-	if x != nil {
-		return x.Id
+type ActionType int32
+
+const (
+	ActionType_ACTION_READ   ActionType = 0
+	ActionType_ACTION_WRITE  ActionType = 1
+	ActionType_ACTION_DELETE ActionType = 2
+)
+
+// Enum value maps for ActionType.
+var (
+	ActionType_name = map[int32]string{
+		0: "ACTION_READ",
+		1: "ACTION_WRITE",
+		2: "ACTION_DELETE",
 	}
-	return ""
-}
-
-func (x *SaveRequest) GetTree() []*proto.TreeEntry {
-	if x != nil {
-		return x.Tree
+	ActionType_value = map[string]int32{
+		"ACTION_READ":   0,
+		"ACTION_WRITE":  1,
+		"ACTION_DELETE": 2,
 	}
-	return nil
+)
+
+func (x ActionType) Enum() *ActionType {
+	p := new(ActionType)
+	*p = x
+	return p
 }
 
-// SaveResponse is intentionally empty.
-type SaveResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+func (x ActionType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (x *SaveResponse) Reset() {
-	*x = SaveResponse{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[1]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
+func (ActionType) Descriptor() protoreflect.EnumDescriptor {
+	return file_zhiplugin_v1_store_proto_enumTypes[1].Descriptor()
 }
 
-func (x *SaveResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
+func (ActionType) Type() protoreflect.EnumType {
+	return &file_zhiplugin_v1_store_proto_enumTypes[1]
 }
 
-func (*SaveResponse) ProtoMessage() {}
-
-func (x *SaveResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[1]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
+func (x ActionType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use SaveResponse.ProtoReflect.Descriptor instead.
-func (*SaveResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use ActionType.Descriptor instead.
+func (ActionType) EnumDescriptor() ([]byte, []int) {
 	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{1}
 }
 
-type LoadRequest struct {
+type StoreCapabilitiesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *LoadRequest) Reset() {
-	*x = LoadRequest{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[2]
+func (x *StoreCapabilitiesRequest) Reset() {
+	*x = StoreCapabilitiesRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *LoadRequest) String() string {
+func (x *StoreCapabilitiesRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*LoadRequest) ProtoMessage() {}
+func (*StoreCapabilitiesRequest) ProtoMessage() {}
 
-func (x *LoadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[2]
+func (x *StoreCapabilitiesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -148,42 +154,37 @@ func (x *LoadRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use LoadRequest.ProtoReflect.Descriptor instead.
-func (*LoadRequest) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{2}
+// Deprecated: Use StoreCapabilitiesRequest.ProtoReflect.Descriptor instead.
+func (*StoreCapabilitiesRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *LoadRequest) GetId() string {
-	if x != nil {
-		return x.Id
-	}
-	return ""
-}
-
-type LoadResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	Found bool                   `protobuf:"varint,1,opt,name=found,proto3" json:"found,omitempty"`
-	// The configuration tree entries. Empty when found is false.
-	Tree          []*proto.TreeEntry `protobuf:"bytes,2,rep,name=tree,proto3" json:"tree,omitempty"`
+type StoreCapabilitiesResponse struct {
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Versioning VersioningMode         `protobuf:"varint,1,opt,name=versioning,proto3,enum=zhiplugin.v1.VersioningMode" json:"versioning,omitempty"`
+	// 0 = EncryptionNone, 1 = EncryptionSupported, 2 = EncryptionActive.
+	Encryption    int32 `protobuf:"varint,2,opt,name=encryption,proto3" json:"encryption,omitempty"`
+	Auth          bool  `protobuf:"varint,3,opt,name=auth,proto3" json:"auth,omitempty"`
+	AccessControl bool  `protobuf:"varint,4,opt,name=access_control,json=accessControl,proto3" json:"access_control,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *LoadResponse) Reset() {
-	*x = LoadResponse{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[3]
+func (x *StoreCapabilitiesResponse) Reset() {
+	*x = StoreCapabilitiesResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *LoadResponse) String() string {
+func (x *StoreCapabilitiesResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*LoadResponse) ProtoMessage() {}
+func (*StoreCapabilitiesResponse) ProtoMessage() {}
 
-func (x *LoadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[3]
+func (x *StoreCapabilitiesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -194,47 +195,64 @@ func (x *LoadResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use LoadResponse.ProtoReflect.Descriptor instead.
-func (*LoadResponse) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{3}
+// Deprecated: Use StoreCapabilitiesResponse.ProtoReflect.Descriptor instead.
+func (*StoreCapabilitiesResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *LoadResponse) GetFound() bool {
+func (x *StoreCapabilitiesResponse) GetVersioning() VersioningMode {
 	if x != nil {
-		return x.Found
+		return x.Versioning
+	}
+	return VersioningMode_VERSIONING_NONE
+}
+
+func (x *StoreCapabilitiesResponse) GetEncryption() int32 {
+	if x != nil {
+		return x.Encryption
+	}
+	return 0
+}
+
+func (x *StoreCapabilitiesResponse) GetAuth() bool {
+	if x != nil {
+		return x.Auth
 	}
 	return false
 }
 
-func (x *LoadResponse) GetTree() []*proto.TreeEntry {
+func (x *StoreCapabilitiesResponse) GetAccessControl() bool {
 	if x != nil {
-		return x.Tree
+		return x.AccessControl
 	}
-	return nil
+	return false
 }
 
-type DeleteRequest struct {
+type AuthFieldMsg struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Description   string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	Required      bool                   `protobuf:"varint,3,opt,name=required,proto3" json:"required,omitempty"`
+	Secret        bool                   `protobuf:"varint,4,opt,name=secret,proto3" json:"secret,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DeleteRequest) Reset() {
-	*x = DeleteRequest{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[4]
+func (x *AuthFieldMsg) Reset() {
+	*x = AuthFieldMsg{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DeleteRequest) String() string {
+func (x *AuthFieldMsg) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DeleteRequest) ProtoMessage() {}
+func (*AuthFieldMsg) ProtoMessage() {}
 
-func (x *DeleteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[4]
+func (x *AuthFieldMsg) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -245,39 +263,156 @@ func (x *DeleteRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DeleteRequest.ProtoReflect.Descriptor instead.
-func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{4}
+// Deprecated: Use AuthFieldMsg.ProtoReflect.Descriptor instead.
+func (*AuthFieldMsg) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *DeleteRequest) GetId() string {
+func (x *AuthFieldMsg) GetName() string {
 	if x != nil {
-		return x.Id
+		return x.Name
 	}
 	return ""
 }
 
-// DeleteResponse is intentionally empty.
-type DeleteResponse struct {
+func (x *AuthFieldMsg) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *AuthFieldMsg) GetRequired() bool {
+	if x != nil {
+		return x.Required
+	}
+	return false
+}
+
+func (x *AuthFieldMsg) GetSecret() bool {
+	if x != nil {
+		return x.Secret
+	}
+	return false
+}
+
+type AuthMethodMsg struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Type          string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	Description   string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	Fields        []*AuthFieldMsg        `protobuf:"bytes,3,rep,name=fields,proto3" json:"fields,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuthMethodMsg) Reset() {
+	*x = AuthMethodMsg{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuthMethodMsg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuthMethodMsg) ProtoMessage() {}
+
+func (x *AuthMethodMsg) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuthMethodMsg.ProtoReflect.Descriptor instead.
+func (*AuthMethodMsg) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *AuthMethodMsg) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *AuthMethodMsg) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *AuthMethodMsg) GetFields() []*AuthFieldMsg {
+	if x != nil {
+		return x.Fields
+	}
+	return nil
+}
+
+type AuthMethodsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DeleteResponse) Reset() {
-	*x = DeleteResponse{}
+func (x *AuthMethodsRequest) Reset() {
+	*x = AuthMethodsRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuthMethodsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuthMethodsRequest) ProtoMessage() {}
+
+func (x *AuthMethodsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuthMethodsRequest.ProtoReflect.Descriptor instead.
+func (*AuthMethodsRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{4}
+}
+
+type AuthMethodsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Methods       []*AuthMethodMsg       `protobuf:"bytes,1,rep,name=methods,proto3" json:"methods,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuthMethodsResponse) Reset() {
+	*x = AuthMethodsResponse{}
 	mi := &file_zhiplugin_v1_store_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DeleteResponse) String() string {
+func (x *AuthMethodsResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DeleteResponse) ProtoMessage() {}
+func (*AuthMethodsResponse) ProtoMessage() {}
 
-func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
+func (x *AuthMethodsResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_zhiplugin_v1_store_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -289,12 +424,130 @@ func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DeleteResponse.ProtoReflect.Descriptor instead.
-func (*DeleteResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use AuthMethodsResponse.ProtoReflect.Descriptor instead.
+func (*AuthMethodsResponse) Descriptor() ([]byte, []int) {
 	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{5}
 }
 
-// ListTreesRequest is intentionally empty.
+func (x *AuthMethodsResponse) GetMethods() []*AuthMethodMsg {
+	if x != nil {
+		return x.Methods
+	}
+	return nil
+}
+
+type LoginRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Method        string                 `protobuf:"bytes,1,opt,name=method,proto3" json:"method,omitempty"`
+	Credentials   map[string]string      `protobuf:"bytes,2,rep,name=credentials,proto3" json:"credentials,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LoginRequest) Reset() {
+	*x = LoginRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LoginRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LoginRequest) ProtoMessage() {}
+
+func (x *LoginRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LoginRequest.ProtoReflect.Descriptor instead.
+func (*LoginRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *LoginRequest) GetMethod() string {
+	if x != nil {
+		return x.Method
+	}
+	return ""
+}
+
+func (x *LoginRequest) GetCredentials() map[string]string {
+	if x != nil {
+		return x.Credentials
+	}
+	return nil
+}
+
+type LoginResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Token         string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
+	ExpiresAt     string                 `protobuf:"bytes,2,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	Metadata      map[string]string      `protobuf:"bytes,3,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LoginResponse) Reset() {
+	*x = LoginResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LoginResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LoginResponse) ProtoMessage() {}
+
+func (x *LoginResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LoginResponse.ProtoReflect.Descriptor instead.
+func (*LoginResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *LoginResponse) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+func (x *LoginResponse) GetExpiresAt() string {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return ""
+}
+
+func (x *LoginResponse) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ListTreesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -303,7 +556,7 @@ type ListTreesRequest struct {
 
 func (x *ListTreesRequest) Reset() {
 	*x = ListTreesRequest{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[6]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -315,7 +568,7 @@ func (x *ListTreesRequest) String() string {
 func (*ListTreesRequest) ProtoMessage() {}
 
 func (x *ListTreesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[6]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -328,7 +581,7 @@ func (x *ListTreesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTreesRequest.ProtoReflect.Descriptor instead.
 func (*ListTreesRequest) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{6}
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{8}
 }
 
 type ListTreesResponse struct {
@@ -340,7 +593,7 @@ type ListTreesResponse struct {
 
 func (x *ListTreesResponse) Reset() {
 	*x = ListTreesResponse{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[7]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -352,7 +605,7 @@ func (x *ListTreesResponse) String() string {
 func (*ListTreesResponse) ProtoMessage() {}
 
 func (x *ListTreesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[7]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -365,7 +618,7 @@ func (x *ListTreesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTreesResponse.ProtoReflect.Descriptor instead.
 func (*ListTreesResponse) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{7}
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ListTreesResponse) GetIds() []string {
@@ -375,108 +628,27 @@ func (x *ListTreesResponse) GetIds() []string {
 	return nil
 }
 
-// SupportsVersioningRequest is intentionally empty.
-type SupportsVersioningRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *SupportsVersioningRequest) Reset() {
-	*x = SupportsVersioningRequest{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[8]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *SupportsVersioningRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*SupportsVersioningRequest) ProtoMessage() {}
-
-func (x *SupportsVersioningRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[8]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use SupportsVersioningRequest.ProtoReflect.Descriptor instead.
-func (*SupportsVersioningRequest) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{8}
-}
-
-type SupportsVersioningResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Supported     bool                   `protobuf:"varint,1,opt,name=supported,proto3" json:"supported,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *SupportsVersioningResponse) Reset() {
-	*x = SupportsVersioningResponse{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[9]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *SupportsVersioningResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*SupportsVersioningResponse) ProtoMessage() {}
-
-func (x *SupportsVersioningResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[9]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use SupportsVersioningResponse.ProtoReflect.Descriptor instead.
-func (*SupportsVersioningResponse) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{9}
-}
-
-func (x *SupportsVersioningResponse) GetSupported() bool {
-	if x != nil {
-		return x.Supported
-	}
-	return false
-}
-
-type ListVersionsRequest struct {
+type DeleteTreeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ListVersionsRequest) Reset() {
-	*x = ListVersionsRequest{}
+func (x *DeleteTreeRequest) Reset() {
+	*x = DeleteTreeRequest{}
 	mi := &file_zhiplugin_v1_store_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ListVersionsRequest) String() string {
+func (x *DeleteTreeRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ListVersionsRequest) ProtoMessage() {}
+func (*DeleteTreeRequest) ProtoMessage() {}
 
-func (x *ListVersionsRequest) ProtoReflect() protoreflect.Message {
+func (x *DeleteTreeRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_zhiplugin_v1_store_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -488,40 +660,38 @@ func (x *ListVersionsRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ListVersionsRequest.ProtoReflect.Descriptor instead.
-func (*ListVersionsRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use DeleteTreeRequest.ProtoReflect.Descriptor instead.
+func (*DeleteTreeRequest) Descriptor() ([]byte, []int) {
 	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{10}
 }
 
-func (x *ListVersionsRequest) GetId() string {
+func (x *DeleteTreeRequest) GetId() string {
 	if x != nil {
 		return x.Id
 	}
 	return ""
 }
 
-type ListVersionsResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Version identifiers, ordered newest first.
-	Versions      []string `protobuf:"bytes,1,rep,name=versions,proto3" json:"versions,omitempty"`
+type DeleteTreeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ListVersionsResponse) Reset() {
-	*x = ListVersionsResponse{}
+func (x *DeleteTreeResponse) Reset() {
+	*x = DeleteTreeResponse{}
 	mi := &file_zhiplugin_v1_store_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ListVersionsResponse) String() string {
+func (x *DeleteTreeResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ListVersionsResponse) ProtoMessage() {}
+func (*DeleteTreeResponse) ProtoMessage() {}
 
-func (x *ListVersionsResponse) ProtoReflect() protoreflect.Message {
+func (x *DeleteTreeResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_zhiplugin_v1_store_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -533,19 +703,494 @@ func (x *ListVersionsResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ListVersionsResponse.ProtoReflect.Descriptor instead.
-func (*ListVersionsResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use DeleteTreeResponse.ProtoReflect.Descriptor instead.
+func (*DeleteTreeResponse) Descriptor() ([]byte, []int) {
 	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{11}
 }
 
-func (x *ListVersionsResponse) GetVersions() []string {
+type GetValuesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Paths         []string               `protobuf:"bytes,2,rep,name=paths,proto3" json:"paths,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetValuesRequest) Reset() {
+	*x = GetValuesRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetValuesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetValuesRequest) ProtoMessage() {}
+
+func (x *GetValuesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetValuesRequest.ProtoReflect.Descriptor instead.
+func (*GetValuesRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *GetValuesRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *GetValuesRequest) GetPaths() []string {
+	if x != nil {
+		return x.Paths
+	}
+	return nil
+}
+
+type GetValuesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Values keyed by path.
+	Values        []*proto.TreeEntry `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetValuesResponse) Reset() {
+	*x = GetValuesResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetValuesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetValuesResponse) ProtoMessage() {}
+
+func (x *GetValuesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetValuesResponse.ProtoReflect.Descriptor instead.
+func (*GetValuesResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *GetValuesResponse) GetValues() []*proto.TreeEntry {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+type PutValuesRequest struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Id     string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Values []*proto.TreeEntry     `protobuf:"bytes,2,rep,name=values,proto3" json:"values,omitempty"`
+	// Optional CAS fields.
+	CasVersion    string            `protobuf:"bytes,3,opt,name=cas_version,json=casVersion,proto3" json:"cas_version,omitempty"`
+	CasVersions   map[string]string `protobuf:"bytes,4,rep,name=cas_versions,json=casVersions,proto3" json:"cas_versions,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PutValuesRequest) Reset() {
+	*x = PutValuesRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PutValuesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PutValuesRequest) ProtoMessage() {}
+
+func (x *PutValuesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PutValuesRequest.ProtoReflect.Descriptor instead.
+func (*PutValuesRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *PutValuesRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *PutValuesRequest) GetValues() []*proto.TreeEntry {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+func (x *PutValuesRequest) GetCasVersion() string {
+	if x != nil {
+		return x.CasVersion
+	}
+	return ""
+}
+
+func (x *PutValuesRequest) GetCasVersions() map[string]string {
+	if x != nil {
+		return x.CasVersions
+	}
+	return nil
+}
+
+type PutValuesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PutValuesResponse) Reset() {
+	*x = PutValuesResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PutValuesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PutValuesResponse) ProtoMessage() {}
+
+func (x *PutValuesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PutValuesResponse.ProtoReflect.Descriptor instead.
+func (*PutValuesResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{15}
+}
+
+type DeleteValuesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Paths         []string               `protobuf:"bytes,2,rep,name=paths,proto3" json:"paths,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteValuesRequest) Reset() {
+	*x = DeleteValuesRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteValuesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteValuesRequest) ProtoMessage() {}
+
+func (x *DeleteValuesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteValuesRequest.ProtoReflect.Descriptor instead.
+func (*DeleteValuesRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *DeleteValuesRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *DeleteValuesRequest) GetPaths() []string {
+	if x != nil {
+		return x.Paths
+	}
+	return nil
+}
+
+type DeleteValuesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteValuesResponse) Reset() {
+	*x = DeleteValuesResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteValuesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteValuesResponse) ProtoMessage() {}
+
+func (x *DeleteValuesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteValuesResponse.ProtoReflect.Descriptor instead.
+func (*DeleteValuesResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{17}
+}
+
+type ListTreeVersionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTreeVersionsRequest) Reset() {
+	*x = ListTreeVersionsRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTreeVersionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTreeVersionsRequest) ProtoMessage() {}
+
+func (x *ListTreeVersionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTreeVersionsRequest.ProtoReflect.Descriptor instead.
+func (*ListTreeVersionsRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ListTreeVersionsRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type ListTreeVersionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Versions      []string               `protobuf:"bytes,1,rep,name=versions,proto3" json:"versions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTreeVersionsResponse) Reset() {
+	*x = ListTreeVersionsResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTreeVersionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTreeVersionsResponse) ProtoMessage() {}
+
+func (x *ListTreeVersionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTreeVersionsResponse.ProtoReflect.Descriptor instead.
+func (*ListTreeVersionsResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *ListTreeVersionsResponse) GetVersions() []string {
 	if x != nil {
 		return x.Versions
 	}
 	return nil
 }
 
-type LoadVersionRequest struct {
+type GetTreeVersionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Version       string                 `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
+	Paths         []string               `protobuf:"bytes,3,rep,name=paths,proto3" json:"paths,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetTreeVersionRequest) Reset() {
+	*x = GetTreeVersionRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetTreeVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetTreeVersionRequest) ProtoMessage() {}
+
+func (x *GetTreeVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetTreeVersionRequest.ProtoReflect.Descriptor instead.
+func (*GetTreeVersionRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *GetTreeVersionRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *GetTreeVersionRequest) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *GetTreeVersionRequest) GetPaths() []string {
+	if x != nil {
+		return x.Paths
+	}
+	return nil
+}
+
+type GetTreeVersionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Values        []*proto.TreeEntry     `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetTreeVersionResponse) Reset() {
+	*x = GetTreeVersionResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetTreeVersionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetTreeVersionResponse) ProtoMessage() {}
+
+func (x *GetTreeVersionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetTreeVersionResponse.ProtoReflect.Descriptor instead.
+func (*GetTreeVersionResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *GetTreeVersionResponse) GetValues() []*proto.TreeEntry {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+type RollbackTreeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	Version       string                 `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
@@ -553,21 +1198,21 @@ type LoadVersionRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *LoadVersionRequest) Reset() {
-	*x = LoadVersionRequest{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[12]
+func (x *RollbackTreeRequest) Reset() {
+	*x = RollbackTreeRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *LoadVersionRequest) String() string {
+func (x *RollbackTreeRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*LoadVersionRequest) ProtoMessage() {}
+func (*RollbackTreeRequest) ProtoMessage() {}
 
-func (x *LoadVersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[12]
+func (x *RollbackTreeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -578,49 +1223,46 @@ func (x *LoadVersionRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use LoadVersionRequest.ProtoReflect.Descriptor instead.
-func (*LoadVersionRequest) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{12}
+// Deprecated: Use RollbackTreeRequest.ProtoReflect.Descriptor instead.
+func (*RollbackTreeRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{22}
 }
 
-func (x *LoadVersionRequest) GetId() string {
+func (x *RollbackTreeRequest) GetId() string {
 	if x != nil {
 		return x.Id
 	}
 	return ""
 }
 
-func (x *LoadVersionRequest) GetVersion() string {
+func (x *RollbackTreeRequest) GetVersion() string {
 	if x != nil {
 		return x.Version
 	}
 	return ""
 }
 
-type LoadVersionResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	Found bool                   `protobuf:"varint,1,opt,name=found,proto3" json:"found,omitempty"`
-	// The configuration tree entries. Empty when found is false.
-	Tree          []*proto.TreeEntry `protobuf:"bytes,2,rep,name=tree,proto3" json:"tree,omitempty"`
+type RollbackTreeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *LoadVersionResponse) Reset() {
-	*x = LoadVersionResponse{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[13]
+func (x *RollbackTreeResponse) Reset() {
+	*x = RollbackTreeResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *LoadVersionResponse) String() string {
+func (x *RollbackTreeResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*LoadVersionResponse) ProtoMessage() {}
+func (*RollbackTreeResponse) ProtoMessage() {}
 
-func (x *LoadVersionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[13]
+func (x *RollbackTreeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -631,48 +1273,339 @@ func (x *LoadVersionResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use LoadVersionResponse.ProtoReflect.Descriptor instead.
-func (*LoadVersionResponse) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{13}
+// Deprecated: Use RollbackTreeResponse.ProtoReflect.Descriptor instead.
+func (*RollbackTreeResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{23}
 }
 
-func (x *LoadVersionResponse) GetFound() bool {
+type DeleteTreeVersionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Version       string                 `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteTreeVersionRequest) Reset() {
+	*x = DeleteTreeVersionRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteTreeVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteTreeVersionRequest) ProtoMessage() {}
+
+func (x *DeleteTreeVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteTreeVersionRequest.ProtoReflect.Descriptor instead.
+func (*DeleteTreeVersionRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *DeleteTreeVersionRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *DeleteTreeVersionRequest) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+type DeleteTreeVersionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteTreeVersionResponse) Reset() {
+	*x = DeleteTreeVersionResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteTreeVersionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteTreeVersionResponse) ProtoMessage() {}
+
+func (x *DeleteTreeVersionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteTreeVersionResponse.ProtoReflect.Descriptor instead.
+func (*DeleteTreeVersionResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{25}
+}
+
+type ListValueVersionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Path          string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListValueVersionsRequest) Reset() {
+	*x = ListValueVersionsRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListValueVersionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListValueVersionsRequest) ProtoMessage() {}
+
+func (x *ListValueVersionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListValueVersionsRequest.ProtoReflect.Descriptor instead.
+func (*ListValueVersionsRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *ListValueVersionsRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ListValueVersionsRequest) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+type ListValueVersionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Versions      []string               `protobuf:"bytes,1,rep,name=versions,proto3" json:"versions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListValueVersionsResponse) Reset() {
+	*x = ListValueVersionsResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListValueVersionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListValueVersionsResponse) ProtoMessage() {}
+
+func (x *ListValueVersionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListValueVersionsResponse.ProtoReflect.Descriptor instead.
+func (*ListValueVersionsResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *ListValueVersionsResponse) GetVersions() []string {
+	if x != nil {
+		return x.Versions
+	}
+	return nil
+}
+
+type GetValueVersionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Path          string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	Version       string                 `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetValueVersionRequest) Reset() {
+	*x = GetValueVersionRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetValueVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetValueVersionRequest) ProtoMessage() {}
+
+func (x *GetValueVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetValueVersionRequest.ProtoReflect.Descriptor instead.
+func (*GetValueVersionRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *GetValueVersionRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *GetValueVersionRequest) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *GetValueVersionRequest) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+type GetValueVersionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Found         bool                   `protobuf:"varint,1,opt,name=found,proto3" json:"found,omitempty"`
+	ValueJson     []byte                 `protobuf:"bytes,2,opt,name=value_json,json=valueJson,proto3" json:"value_json,omitempty"`
+	MetadataJson  []byte                 `protobuf:"bytes,3,opt,name=metadata_json,json=metadataJson,proto3" json:"metadata_json,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetValueVersionResponse) Reset() {
+	*x = GetValueVersionResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetValueVersionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetValueVersionResponse) ProtoMessage() {}
+
+func (x *GetValueVersionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetValueVersionResponse.ProtoReflect.Descriptor instead.
+func (*GetValueVersionResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *GetValueVersionResponse) GetFound() bool {
 	if x != nil {
 		return x.Found
 	}
 	return false
 }
 
-func (x *LoadVersionResponse) GetTree() []*proto.TreeEntry {
+func (x *GetValueVersionResponse) GetValueJson() []byte {
 	if x != nil {
-		return x.Tree
+		return x.ValueJson
 	}
 	return nil
 }
 
-type DeleteVersionRequest struct {
+func (x *GetValueVersionResponse) GetMetadataJson() []byte {
+	if x != nil {
+		return x.MetadataJson
+	}
+	return nil
+}
+
+type RollbackValueRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Version       string                 `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
+	Path          string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	Version       string                 `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DeleteVersionRequest) Reset() {
-	*x = DeleteVersionRequest{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[14]
+func (x *RollbackValueRequest) Reset() {
+	*x = RollbackValueRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DeleteVersionRequest) String() string {
+func (x *RollbackValueRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DeleteVersionRequest) ProtoMessage() {}
+func (*RollbackValueRequest) ProtoMessage() {}
 
-func (x *DeleteVersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[14]
+func (x *RollbackValueRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -683,47 +1616,53 @@ func (x *DeleteVersionRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DeleteVersionRequest.ProtoReflect.Descriptor instead.
-func (*DeleteVersionRequest) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{14}
+// Deprecated: Use RollbackValueRequest.ProtoReflect.Descriptor instead.
+func (*RollbackValueRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{30}
 }
 
-func (x *DeleteVersionRequest) GetId() string {
+func (x *RollbackValueRequest) GetId() string {
 	if x != nil {
 		return x.Id
 	}
 	return ""
 }
 
-func (x *DeleteVersionRequest) GetVersion() string {
+func (x *RollbackValueRequest) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *RollbackValueRequest) GetVersion() string {
 	if x != nil {
 		return x.Version
 	}
 	return ""
 }
 
-// DeleteVersionResponse is intentionally empty.
-type DeleteVersionResponse struct {
+type RollbackValueResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DeleteVersionResponse) Reset() {
-	*x = DeleteVersionResponse{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[15]
+func (x *RollbackValueResponse) Reset() {
+	*x = RollbackValueResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DeleteVersionResponse) String() string {
+func (x *RollbackValueResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DeleteVersionResponse) ProtoMessage() {}
+func (*RollbackValueResponse) ProtoMessage() {}
 
-func (x *DeleteVersionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[15]
+func (x *RollbackValueResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -734,33 +1673,92 @@ func (x *DeleteVersionResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DeleteVersionResponse.ProtoReflect.Descriptor instead.
-func (*DeleteVersionResponse) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{15}
+// Deprecated: Use RollbackValueResponse.ProtoReflect.Descriptor instead.
+func (*RollbackValueResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{31}
 }
 
-// EncryptionStatusRequest is intentionally empty.
-type EncryptionStatusRequest struct {
+type DeleteValueVersionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Path          string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	Version       string                 `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteValueVersionRequest) Reset() {
+	*x = DeleteValueVersionRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteValueVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteValueVersionRequest) ProtoMessage() {}
+
+func (x *DeleteValueVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteValueVersionRequest.ProtoReflect.Descriptor instead.
+func (*DeleteValueVersionRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *DeleteValueVersionRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *DeleteValueVersionRequest) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *DeleteValueVersionRequest) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+type DeleteValueVersionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *EncryptionStatusRequest) Reset() {
-	*x = EncryptionStatusRequest{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[16]
+func (x *DeleteValueVersionResponse) Reset() {
+	*x = DeleteValueVersionResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *EncryptionStatusRequest) String() string {
+func (x *DeleteValueVersionResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*EncryptionStatusRequest) ProtoMessage() {}
+func (*DeleteValueVersionResponse) ProtoMessage() {}
 
-func (x *EncryptionStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[16]
+func (x *DeleteValueVersionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -771,67 +1769,21 @@ func (x *EncryptionStatusRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use EncryptionStatusRequest.ProtoReflect.Descriptor instead.
-func (*EncryptionStatusRequest) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{16}
-}
-
-type EncryptionStatusResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// 0 = EncryptionNone, 1 = EncryptionSupported, 2 = EncryptionActive.
-	Status        int32 `protobuf:"varint,1,opt,name=status,proto3" json:"status,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *EncryptionStatusResponse) Reset() {
-	*x = EncryptionStatusResponse{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[17]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *EncryptionStatusResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*EncryptionStatusResponse) ProtoMessage() {}
-
-func (x *EncryptionStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[17]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use EncryptionStatusResponse.ProtoReflect.Descriptor instead.
-func (*EncryptionStatusResponse) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{17}
-}
-
-func (x *EncryptionStatusResponse) GetStatus() int32 {
-	if x != nil {
-		return x.Status
-	}
-	return 0
+// Deprecated: Use DeleteValueVersionResponse.ProtoReflect.Descriptor instead.
+func (*DeleteValueVersionResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{33}
 }
 
 type InitEncryptionRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// The passphrase or key material to initialize encryption with.
-	Passphrase    []byte `protobuf:"bytes,1,opt,name=passphrase,proto3" json:"passphrase,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Passphrase    []byte                 `protobuf:"bytes,1,opt,name=passphrase,proto3" json:"passphrase,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *InitEncryptionRequest) Reset() {
 	*x = InitEncryptionRequest{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[18]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -843,7 +1795,7 @@ func (x *InitEncryptionRequest) String() string {
 func (*InitEncryptionRequest) ProtoMessage() {}
 
 func (x *InitEncryptionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[18]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -856,7 +1808,7 @@ func (x *InitEncryptionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InitEncryptionRequest.ProtoReflect.Descriptor instead.
 func (*InitEncryptionRequest) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{18}
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *InitEncryptionRequest) GetPassphrase() []byte {
@@ -866,7 +1818,6 @@ func (x *InitEncryptionRequest) GetPassphrase() []byte {
 	return nil
 }
 
-// InitEncryptionResponse is intentionally empty.
 type InitEncryptionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -875,7 +1826,7 @@ type InitEncryptionResponse struct {
 
 func (x *InitEncryptionResponse) Reset() {
 	*x = InitEncryptionResponse{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[19]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -887,7 +1838,7 @@ func (x *InitEncryptionResponse) String() string {
 func (*InitEncryptionResponse) ProtoMessage() {}
 
 func (x *InitEncryptionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[19]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -900,22 +1851,20 @@ func (x *InitEncryptionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InitEncryptionResponse.ProtoReflect.Descriptor instead.
 func (*InitEncryptionResponse) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{19}
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{35}
 }
 
 type RotateEncryptionRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// The current passphrase.
-	OldPassphrase []byte `protobuf:"bytes,1,opt,name=old_passphrase,json=oldPassphrase,proto3" json:"old_passphrase,omitempty"`
-	// The new passphrase to rotate to.
-	NewPassphrase []byte `protobuf:"bytes,2,opt,name=new_passphrase,json=newPassphrase,proto3" json:"new_passphrase,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OldPassphrase []byte                 `protobuf:"bytes,1,opt,name=old_passphrase,json=oldPassphrase,proto3" json:"old_passphrase,omitempty"`
+	NewPassphrase []byte                 `protobuf:"bytes,2,opt,name=new_passphrase,json=newPassphrase,proto3" json:"new_passphrase,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RotateEncryptionRequest) Reset() {
 	*x = RotateEncryptionRequest{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[20]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -927,7 +1876,7 @@ func (x *RotateEncryptionRequest) String() string {
 func (*RotateEncryptionRequest) ProtoMessage() {}
 
 func (x *RotateEncryptionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[20]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -940,7 +1889,7 @@ func (x *RotateEncryptionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotateEncryptionRequest.ProtoReflect.Descriptor instead.
 func (*RotateEncryptionRequest) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{20}
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *RotateEncryptionRequest) GetOldPassphrase() []byte {
@@ -957,7 +1906,6 @@ func (x *RotateEncryptionRequest) GetNewPassphrase() []byte {
 	return nil
 }
 
-// RotateEncryptionResponse is intentionally empty.
 type RotateEncryptionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -966,7 +1914,7 @@ type RotateEncryptionResponse struct {
 
 func (x *RotateEncryptionResponse) Reset() {
 	*x = RotateEncryptionResponse{}
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[21]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -978,7 +1926,7 @@ func (x *RotateEncryptionResponse) String() string {
 func (*RotateEncryptionResponse) ProtoMessage() {}
 
 func (x *RotateEncryptionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_zhiplugin_v1_store_proto_msgTypes[21]
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -991,49 +1939,494 @@ func (x *RotateEncryptionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotateEncryptionResponse.ProtoReflect.Descriptor instead.
 func (*RotateEncryptionResponse) Descriptor() ([]byte, []int) {
-	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{21}
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{37}
+}
+
+type PermissionMsg struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Actions       []ActionType           `protobuf:"varint,2,rep,packed,name=actions,proto3,enum=zhiplugin.v1.ActionType" json:"actions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PermissionMsg) Reset() {
+	*x = PermissionMsg{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PermissionMsg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PermissionMsg) ProtoMessage() {}
+
+func (x *PermissionMsg) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PermissionMsg.ProtoReflect.Descriptor instead.
+func (*PermissionMsg) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *PermissionMsg) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *PermissionMsg) GetActions() []ActionType {
+	if x != nil {
+		return x.Actions
+	}
+	return nil
+}
+
+type GrantAccessRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	User          string                 `protobuf:"bytes,2,opt,name=user,proto3" json:"user,omitempty"`
+	Permissions   []*PermissionMsg       `protobuf:"bytes,3,rep,name=permissions,proto3" json:"permissions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GrantAccessRequest) Reset() {
+	*x = GrantAccessRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GrantAccessRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GrantAccessRequest) ProtoMessage() {}
+
+func (x *GrantAccessRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GrantAccessRequest.ProtoReflect.Descriptor instead.
+func (*GrantAccessRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *GrantAccessRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *GrantAccessRequest) GetUser() string {
+	if x != nil {
+		return x.User
+	}
+	return ""
+}
+
+func (x *GrantAccessRequest) GetPermissions() []*PermissionMsg {
+	if x != nil {
+		return x.Permissions
+	}
+	return nil
+}
+
+type GrantAccessResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GrantAccessResponse) Reset() {
+	*x = GrantAccessResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GrantAccessResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GrantAccessResponse) ProtoMessage() {}
+
+func (x *GrantAccessResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GrantAccessResponse.ProtoReflect.Descriptor instead.
+func (*GrantAccessResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{40}
+}
+
+type RevokeAccessRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	User          string                 `protobuf:"bytes,2,opt,name=user,proto3" json:"user,omitempty"`
+	Paths         []string               `protobuf:"bytes,3,rep,name=paths,proto3" json:"paths,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RevokeAccessRequest) Reset() {
+	*x = RevokeAccessRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevokeAccessRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevokeAccessRequest) ProtoMessage() {}
+
+func (x *RevokeAccessRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevokeAccessRequest.ProtoReflect.Descriptor instead.
+func (*RevokeAccessRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *RevokeAccessRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *RevokeAccessRequest) GetUser() string {
+	if x != nil {
+		return x.User
+	}
+	return ""
+}
+
+func (x *RevokeAccessRequest) GetPaths() []string {
+	if x != nil {
+		return x.Paths
+	}
+	return nil
+}
+
+type RevokeAccessResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RevokeAccessResponse) Reset() {
+	*x = RevokeAccessResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevokeAccessResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevokeAccessResponse) ProtoMessage() {}
+
+func (x *RevokeAccessResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevokeAccessResponse.ProtoReflect.Descriptor instead.
+func (*RevokeAccessResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{42}
+}
+
+type ListAccessRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAccessRequest) Reset() {
+	*x = ListAccessRequest{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAccessRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAccessRequest) ProtoMessage() {}
+
+func (x *ListAccessRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAccessRequest.ProtoReflect.Descriptor instead.
+func (*ListAccessRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *ListAccessRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type UserPermissions struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Permissions   []*PermissionMsg       `protobuf:"bytes,1,rep,name=permissions,proto3" json:"permissions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserPermissions) Reset() {
+	*x = UserPermissions{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserPermissions) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserPermissions) ProtoMessage() {}
+
+func (x *UserPermissions) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserPermissions.ProtoReflect.Descriptor instead.
+func (*UserPermissions) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *UserPermissions) GetPermissions() []*PermissionMsg {
+	if x != nil {
+		return x.Permissions
+	}
+	return nil
+}
+
+type ListAccessResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Access permissions keyed by user.
+	Access        map[string]*UserPermissions `protobuf:"bytes,1,rep,name=access,proto3" json:"access,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAccessResponse) Reset() {
+	*x = ListAccessResponse{}
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAccessResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAccessResponse) ProtoMessage() {}
+
+func (x *ListAccessResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_store_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAccessResponse.ProtoReflect.Descriptor instead.
+func (*ListAccessResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_store_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *ListAccessResponse) GetAccess() map[string]*UserPermissions {
+	if x != nil {
+		return x.Access
+	}
+	return nil
 }
 
 var File_zhiplugin_v1_store_proto protoreflect.FileDescriptor
 
 const file_zhiplugin_v1_store_proto_rawDesc = "" +
 	"\n" +
-	"\x18zhiplugin/v1/store.proto\x12\fzhiplugin.v1\x1a\x19zhiplugin/v1/config.proto\"J\n" +
-	"\vSaveRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x12+\n" +
-	"\x04tree\x18\x02 \x03(\v2\x17.zhiplugin.v1.TreeEntryR\x04tree\"\x0e\n" +
-	"\fSaveResponse\"\x1d\n" +
-	"\vLoadRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\"Q\n" +
-	"\fLoadResponse\x12\x14\n" +
-	"\x05found\x18\x01 \x01(\bR\x05found\x12+\n" +
-	"\x04tree\x18\x02 \x03(\v2\x17.zhiplugin.v1.TreeEntryR\x04tree\"\x1f\n" +
-	"\rDeleteRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\"\x10\n" +
-	"\x0eDeleteResponse\"\x12\n" +
+	"\x18zhiplugin/v1/store.proto\x12\fzhiplugin.v1\x1a\x19zhiplugin/v1/config.proto\"\x1a\n" +
+	"\x18StoreCapabilitiesRequest\"\xb4\x01\n" +
+	"\x19StoreCapabilitiesResponse\x12<\n" +
+	"\n" +
+	"versioning\x18\x01 \x01(\x0e2\x1c.zhiplugin.v1.VersioningModeR\n" +
+	"versioning\x12\x1e\n" +
+	"\n" +
+	"encryption\x18\x02 \x01(\x05R\n" +
+	"encryption\x12\x12\n" +
+	"\x04auth\x18\x03 \x01(\bR\x04auth\x12%\n" +
+	"\x0eaccess_control\x18\x04 \x01(\bR\raccessControl\"x\n" +
+	"\fAuthFieldMsg\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x1a\n" +
+	"\brequired\x18\x03 \x01(\bR\brequired\x12\x16\n" +
+	"\x06secret\x18\x04 \x01(\bR\x06secret\"y\n" +
+	"\rAuthMethodMsg\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12 \n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x122\n" +
+	"\x06fields\x18\x03 \x03(\v2\x1a.zhiplugin.v1.AuthFieldMsgR\x06fields\"\x14\n" +
+	"\x12AuthMethodsRequest\"L\n" +
+	"\x13AuthMethodsResponse\x125\n" +
+	"\amethods\x18\x01 \x03(\v2\x1b.zhiplugin.v1.AuthMethodMsgR\amethods\"\xb5\x01\n" +
+	"\fLoginRequest\x12\x16\n" +
+	"\x06method\x18\x01 \x01(\tR\x06method\x12M\n" +
+	"\vcredentials\x18\x02 \x03(\v2+.zhiplugin.v1.LoginRequest.CredentialsEntryR\vcredentials\x1a>\n" +
+	"\x10CredentialsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xc8\x01\n" +
+	"\rLoginResponse\x12\x14\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\x12\x1d\n" +
+	"\n" +
+	"expires_at\x18\x02 \x01(\tR\texpiresAt\x12E\n" +
+	"\bmetadata\x18\x03 \x03(\v2).zhiplugin.v1.LoginResponse.MetadataEntryR\bmetadata\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x12\n" +
 	"\x10ListTreesRequest\"%\n" +
 	"\x11ListTreesResponse\x12\x10\n" +
-	"\x03ids\x18\x01 \x03(\tR\x03ids\"\x1b\n" +
-	"\x19SupportsVersioningRequest\":\n" +
-	"\x1aSupportsVersioningResponse\x12\x1c\n" +
-	"\tsupported\x18\x01 \x01(\bR\tsupported\"%\n" +
-	"\x13ListVersionsRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\"2\n" +
-	"\x14ListVersionsResponse\x12\x1a\n" +
-	"\bversions\x18\x01 \x03(\tR\bversions\">\n" +
-	"\x12LoadVersionRequest\x12\x0e\n" +
+	"\x03ids\x18\x01 \x03(\tR\x03ids\"#\n" +
+	"\x11DeleteTreeRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\x14\n" +
+	"\x12DeleteTreeResponse\"8\n" +
+	"\x10GetValuesRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
+	"\x05paths\x18\x02 \x03(\tR\x05paths\"D\n" +
+	"\x11GetValuesResponse\x12/\n" +
+	"\x06values\x18\x01 \x03(\v2\x17.zhiplugin.v1.TreeEntryR\x06values\"\x88\x02\n" +
+	"\x10PutValuesRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12/\n" +
+	"\x06values\x18\x02 \x03(\v2\x17.zhiplugin.v1.TreeEntryR\x06values\x12\x1f\n" +
+	"\vcas_version\x18\x03 \x01(\tR\n" +
+	"casVersion\x12R\n" +
+	"\fcas_versions\x18\x04 \x03(\v2/.zhiplugin.v1.PutValuesRequest.CasVersionsEntryR\vcasVersions\x1a>\n" +
+	"\x10CasVersionsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x13\n" +
+	"\x11PutValuesResponse\";\n" +
+	"\x13DeleteValuesRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
+	"\x05paths\x18\x02 \x03(\tR\x05paths\"\x16\n" +
+	"\x14DeleteValuesResponse\")\n" +
+	"\x17ListTreeVersionsRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"6\n" +
+	"\x18ListTreeVersionsResponse\x12\x1a\n" +
+	"\bversions\x18\x01 \x03(\tR\bversions\"W\n" +
+	"\x15GetTreeVersionRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
-	"\aversion\x18\x02 \x01(\tR\aversion\"X\n" +
-	"\x13LoadVersionResponse\x12\x14\n" +
-	"\x05found\x18\x01 \x01(\bR\x05found\x12+\n" +
-	"\x04tree\x18\x02 \x03(\v2\x17.zhiplugin.v1.TreeEntryR\x04tree\"@\n" +
-	"\x14DeleteVersionRequest\x12\x0e\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\x12\x14\n" +
+	"\x05paths\x18\x03 \x03(\tR\x05paths\"I\n" +
+	"\x16GetTreeVersionResponse\x12/\n" +
+	"\x06values\x18\x01 \x03(\v2\x17.zhiplugin.v1.TreeEntryR\x06values\"?\n" +
+	"\x13RollbackTreeRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
-	"\aversion\x18\x02 \x01(\tR\aversion\"\x17\n" +
-	"\x15DeleteVersionResponse\"\x19\n" +
-	"\x17EncryptionStatusRequest\"2\n" +
-	"\x18EncryptionStatusResponse\x12\x16\n" +
-	"\x06status\x18\x01 \x01(\x05R\x06status\"7\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\"\x16\n" +
+	"\x14RollbackTreeResponse\"D\n" +
+	"\x18DeleteTreeVersionRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\"\x1b\n" +
+	"\x19DeleteTreeVersionResponse\">\n" +
+	"\x18ListValueVersionsRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04path\x18\x02 \x01(\tR\x04path\"7\n" +
+	"\x19ListValueVersionsResponse\x12\x1a\n" +
+	"\bversions\x18\x01 \x03(\tR\bversions\"V\n" +
+	"\x16GetValueVersionRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04path\x18\x02 \x01(\tR\x04path\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\tR\aversion\"s\n" +
+	"\x17GetValueVersionResponse\x12\x14\n" +
+	"\x05found\x18\x01 \x01(\bR\x05found\x12\x1d\n" +
+	"\n" +
+	"value_json\x18\x02 \x01(\fR\tvalueJson\x12#\n" +
+	"\rmetadata_json\x18\x03 \x01(\fR\fmetadataJson\"T\n" +
+	"\x14RollbackValueRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04path\x18\x02 \x01(\tR\x04path\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\tR\aversion\"\x17\n" +
+	"\x15RollbackValueResponse\"Y\n" +
+	"\x19DeleteValueVersionRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04path\x18\x02 \x01(\tR\x04path\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\tR\aversion\"\x1c\n" +
+	"\x1aDeleteValueVersionResponse\"7\n" +
 	"\x15InitEncryptionRequest\x12\x1e\n" +
 	"\n" +
 	"passphrase\x18\x01 \x01(\fR\n" +
@@ -1042,19 +2435,62 @@ const file_zhiplugin_v1_store_proto_rawDesc = "" +
 	"\x17RotateEncryptionRequest\x12%\n" +
 	"\x0eold_passphrase\x18\x01 \x01(\fR\roldPassphrase\x12%\n" +
 	"\x0enew_passphrase\x18\x02 \x01(\fR\rnewPassphrase\"\x1a\n" +
-	"\x18RotateEncryptionResponse2\xb0\a\n" +
-	"\fStoreService\x12=\n" +
-	"\x04Save\x12\x19.zhiplugin.v1.SaveRequest\x1a\x1a.zhiplugin.v1.SaveResponse\x12=\n" +
-	"\x04Load\x12\x19.zhiplugin.v1.LoadRequest\x1a\x1a.zhiplugin.v1.LoadResponse\x12C\n" +
-	"\x06Delete\x12\x1b.zhiplugin.v1.DeleteRequest\x1a\x1c.zhiplugin.v1.DeleteResponse\x12L\n" +
-	"\tListTrees\x12\x1e.zhiplugin.v1.ListTreesRequest\x1a\x1f.zhiplugin.v1.ListTreesResponse\x12g\n" +
-	"\x12SupportsVersioning\x12'.zhiplugin.v1.SupportsVersioningRequest\x1a(.zhiplugin.v1.SupportsVersioningResponse\x12U\n" +
-	"\fListVersions\x12!.zhiplugin.v1.ListVersionsRequest\x1a\".zhiplugin.v1.ListVersionsResponse\x12R\n" +
-	"\vLoadVersion\x12 .zhiplugin.v1.LoadVersionRequest\x1a!.zhiplugin.v1.LoadVersionResponse\x12X\n" +
-	"\rDeleteVersion\x12\".zhiplugin.v1.DeleteVersionRequest\x1a#.zhiplugin.v1.DeleteVersionResponse\x12a\n" +
-	"\x10EncryptionStatus\x12%.zhiplugin.v1.EncryptionStatusRequest\x1a&.zhiplugin.v1.EncryptionStatusResponse\x12[\n" +
+	"\x18RotateEncryptionResponse\"W\n" +
+	"\rPermissionMsg\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x122\n" +
+	"\aactions\x18\x02 \x03(\x0e2\x18.zhiplugin.v1.ActionTypeR\aactions\"w\n" +
+	"\x12GrantAccessRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04user\x18\x02 \x01(\tR\x04user\x12=\n" +
+	"\vpermissions\x18\x03 \x03(\v2\x1b.zhiplugin.v1.PermissionMsgR\vpermissions\"\x15\n" +
+	"\x13GrantAccessResponse\"O\n" +
+	"\x13RevokeAccessRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04user\x18\x02 \x01(\tR\x04user\x12\x14\n" +
+	"\x05paths\x18\x03 \x03(\tR\x05paths\"\x16\n" +
+	"\x14RevokeAccessResponse\"#\n" +
+	"\x11ListAccessRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"P\n" +
+	"\x0fUserPermissions\x12=\n" +
+	"\vpermissions\x18\x01 \x03(\v2\x1b.zhiplugin.v1.PermissionMsgR\vpermissions\"\xb4\x01\n" +
+	"\x12ListAccessResponse\x12D\n" +
+	"\x06access\x18\x01 \x03(\v2,.zhiplugin.v1.ListAccessResponse.AccessEntryR\x06access\x1aX\n" +
+	"\vAccessEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x123\n" +
+	"\x05value\x18\x02 \x01(\v2\x1d.zhiplugin.v1.UserPermissionsR\x05value:\x028\x01*P\n" +
+	"\x0eVersioningMode\x12\x13\n" +
+	"\x0fVERSIONING_NONE\x10\x00\x12\x13\n" +
+	"\x0fVERSIONING_TREE\x10\x01\x12\x14\n" +
+	"\x10VERSIONING_VALUE\x10\x02*B\n" +
+	"\n" +
+	"ActionType\x12\x0f\n" +
+	"\vACTION_READ\x10\x00\x12\x10\n" +
+	"\fACTION_WRITE\x10\x01\x12\x11\n" +
+	"\rACTION_DELETE\x10\x022\xd9\x0e\n" +
+	"\fStoreService\x12_\n" +
+	"\fCapabilities\x12&.zhiplugin.v1.StoreCapabilitiesRequest\x1a'.zhiplugin.v1.StoreCapabilitiesResponse\x12R\n" +
+	"\vAuthMethods\x12 .zhiplugin.v1.AuthMethodsRequest\x1a!.zhiplugin.v1.AuthMethodsResponse\x12@\n" +
+	"\x05Login\x12\x1a.zhiplugin.v1.LoginRequest\x1a\x1b.zhiplugin.v1.LoginResponse\x12L\n" +
+	"\tListTrees\x12\x1e.zhiplugin.v1.ListTreesRequest\x1a\x1f.zhiplugin.v1.ListTreesResponse\x12O\n" +
+	"\n" +
+	"DeleteTree\x12\x1f.zhiplugin.v1.DeleteTreeRequest\x1a .zhiplugin.v1.DeleteTreeResponse\x12L\n" +
+	"\tGetValues\x12\x1e.zhiplugin.v1.GetValuesRequest\x1a\x1f.zhiplugin.v1.GetValuesResponse\x12L\n" +
+	"\tPutValues\x12\x1e.zhiplugin.v1.PutValuesRequest\x1a\x1f.zhiplugin.v1.PutValuesResponse\x12U\n" +
+	"\fDeleteValues\x12!.zhiplugin.v1.DeleteValuesRequest\x1a\".zhiplugin.v1.DeleteValuesResponse\x12a\n" +
+	"\x10ListTreeVersions\x12%.zhiplugin.v1.ListTreeVersionsRequest\x1a&.zhiplugin.v1.ListTreeVersionsResponse\x12[\n" +
+	"\x0eGetTreeVersion\x12#.zhiplugin.v1.GetTreeVersionRequest\x1a$.zhiplugin.v1.GetTreeVersionResponse\x12U\n" +
+	"\fRollbackTree\x12!.zhiplugin.v1.RollbackTreeRequest\x1a\".zhiplugin.v1.RollbackTreeResponse\x12d\n" +
+	"\x11DeleteTreeVersion\x12&.zhiplugin.v1.DeleteTreeVersionRequest\x1a'.zhiplugin.v1.DeleteTreeVersionResponse\x12d\n" +
+	"\x11ListValueVersions\x12&.zhiplugin.v1.ListValueVersionsRequest\x1a'.zhiplugin.v1.ListValueVersionsResponse\x12^\n" +
+	"\x0fGetValueVersion\x12$.zhiplugin.v1.GetValueVersionRequest\x1a%.zhiplugin.v1.GetValueVersionResponse\x12X\n" +
+	"\rRollbackValue\x12\".zhiplugin.v1.RollbackValueRequest\x1a#.zhiplugin.v1.RollbackValueResponse\x12g\n" +
+	"\x12DeleteValueVersion\x12'.zhiplugin.v1.DeleteValueVersionRequest\x1a(.zhiplugin.v1.DeleteValueVersionResponse\x12[\n" +
 	"\x0eInitEncryption\x12#.zhiplugin.v1.InitEncryptionRequest\x1a$.zhiplugin.v1.InitEncryptionResponse\x12a\n" +
-	"\x10RotateEncryption\x12%.zhiplugin.v1.RotateEncryptionRequest\x1a&.zhiplugin.v1.RotateEncryptionResponseB3Z1github.com/MrWong99/zhi/pkg/zhiplugin/store/protob\x06proto3"
+	"\x10RotateEncryption\x12%.zhiplugin.v1.RotateEncryptionRequest\x1a&.zhiplugin.v1.RotateEncryptionResponse\x12R\n" +
+	"\vGrantAccess\x12 .zhiplugin.v1.GrantAccessRequest\x1a!.zhiplugin.v1.GrantAccessResponse\x12U\n" +
+	"\fRevokeAccess\x12!.zhiplugin.v1.RevokeAccessRequest\x1a\".zhiplugin.v1.RevokeAccessResponse\x12O\n" +
+	"\n" +
+	"ListAccess\x12\x1f.zhiplugin.v1.ListAccessRequest\x1a .zhiplugin.v1.ListAccessResponseB3Z1github.com/MrWong99/zhi/pkg/zhiplugin/store/protob\x06proto3"
 
 var (
 	file_zhiplugin_v1_store_proto_rawDescOnce sync.Once
@@ -1068,63 +2504,125 @@ func file_zhiplugin_v1_store_proto_rawDescGZIP() []byte {
 	return file_zhiplugin_v1_store_proto_rawDescData
 }
 
-var file_zhiplugin_v1_store_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_zhiplugin_v1_store_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_zhiplugin_v1_store_proto_msgTypes = make([]protoimpl.MessageInfo, 50)
 var file_zhiplugin_v1_store_proto_goTypes = []any{
-	(*SaveRequest)(nil),                // 0: zhiplugin.v1.SaveRequest
-	(*SaveResponse)(nil),               // 1: zhiplugin.v1.SaveResponse
-	(*LoadRequest)(nil),                // 2: zhiplugin.v1.LoadRequest
-	(*LoadResponse)(nil),               // 3: zhiplugin.v1.LoadResponse
-	(*DeleteRequest)(nil),              // 4: zhiplugin.v1.DeleteRequest
-	(*DeleteResponse)(nil),             // 5: zhiplugin.v1.DeleteResponse
-	(*ListTreesRequest)(nil),           // 6: zhiplugin.v1.ListTreesRequest
-	(*ListTreesResponse)(nil),          // 7: zhiplugin.v1.ListTreesResponse
-	(*SupportsVersioningRequest)(nil),  // 8: zhiplugin.v1.SupportsVersioningRequest
-	(*SupportsVersioningResponse)(nil), // 9: zhiplugin.v1.SupportsVersioningResponse
-	(*ListVersionsRequest)(nil),        // 10: zhiplugin.v1.ListVersionsRequest
-	(*ListVersionsResponse)(nil),       // 11: zhiplugin.v1.ListVersionsResponse
-	(*LoadVersionRequest)(nil),         // 12: zhiplugin.v1.LoadVersionRequest
-	(*LoadVersionResponse)(nil),        // 13: zhiplugin.v1.LoadVersionResponse
-	(*DeleteVersionRequest)(nil),       // 14: zhiplugin.v1.DeleteVersionRequest
-	(*DeleteVersionResponse)(nil),      // 15: zhiplugin.v1.DeleteVersionResponse
-	(*EncryptionStatusRequest)(nil),    // 16: zhiplugin.v1.EncryptionStatusRequest
-	(*EncryptionStatusResponse)(nil),   // 17: zhiplugin.v1.EncryptionStatusResponse
-	(*InitEncryptionRequest)(nil),      // 18: zhiplugin.v1.InitEncryptionRequest
-	(*InitEncryptionResponse)(nil),     // 19: zhiplugin.v1.InitEncryptionResponse
-	(*RotateEncryptionRequest)(nil),    // 20: zhiplugin.v1.RotateEncryptionRequest
-	(*RotateEncryptionResponse)(nil),   // 21: zhiplugin.v1.RotateEncryptionResponse
-	(*proto.TreeEntry)(nil),            // 22: zhiplugin.v1.TreeEntry
+	(VersioningMode)(0),                // 0: zhiplugin.v1.VersioningMode
+	(ActionType)(0),                    // 1: zhiplugin.v1.ActionType
+	(*StoreCapabilitiesRequest)(nil),   // 2: zhiplugin.v1.StoreCapabilitiesRequest
+	(*StoreCapabilitiesResponse)(nil),  // 3: zhiplugin.v1.StoreCapabilitiesResponse
+	(*AuthFieldMsg)(nil),               // 4: zhiplugin.v1.AuthFieldMsg
+	(*AuthMethodMsg)(nil),              // 5: zhiplugin.v1.AuthMethodMsg
+	(*AuthMethodsRequest)(nil),         // 6: zhiplugin.v1.AuthMethodsRequest
+	(*AuthMethodsResponse)(nil),        // 7: zhiplugin.v1.AuthMethodsResponse
+	(*LoginRequest)(nil),               // 8: zhiplugin.v1.LoginRequest
+	(*LoginResponse)(nil),              // 9: zhiplugin.v1.LoginResponse
+	(*ListTreesRequest)(nil),           // 10: zhiplugin.v1.ListTreesRequest
+	(*ListTreesResponse)(nil),          // 11: zhiplugin.v1.ListTreesResponse
+	(*DeleteTreeRequest)(nil),          // 12: zhiplugin.v1.DeleteTreeRequest
+	(*DeleteTreeResponse)(nil),         // 13: zhiplugin.v1.DeleteTreeResponse
+	(*GetValuesRequest)(nil),           // 14: zhiplugin.v1.GetValuesRequest
+	(*GetValuesResponse)(nil),          // 15: zhiplugin.v1.GetValuesResponse
+	(*PutValuesRequest)(nil),           // 16: zhiplugin.v1.PutValuesRequest
+	(*PutValuesResponse)(nil),          // 17: zhiplugin.v1.PutValuesResponse
+	(*DeleteValuesRequest)(nil),        // 18: zhiplugin.v1.DeleteValuesRequest
+	(*DeleteValuesResponse)(nil),       // 19: zhiplugin.v1.DeleteValuesResponse
+	(*ListTreeVersionsRequest)(nil),    // 20: zhiplugin.v1.ListTreeVersionsRequest
+	(*ListTreeVersionsResponse)(nil),   // 21: zhiplugin.v1.ListTreeVersionsResponse
+	(*GetTreeVersionRequest)(nil),      // 22: zhiplugin.v1.GetTreeVersionRequest
+	(*GetTreeVersionResponse)(nil),     // 23: zhiplugin.v1.GetTreeVersionResponse
+	(*RollbackTreeRequest)(nil),        // 24: zhiplugin.v1.RollbackTreeRequest
+	(*RollbackTreeResponse)(nil),       // 25: zhiplugin.v1.RollbackTreeResponse
+	(*DeleteTreeVersionRequest)(nil),   // 26: zhiplugin.v1.DeleteTreeVersionRequest
+	(*DeleteTreeVersionResponse)(nil),  // 27: zhiplugin.v1.DeleteTreeVersionResponse
+	(*ListValueVersionsRequest)(nil),   // 28: zhiplugin.v1.ListValueVersionsRequest
+	(*ListValueVersionsResponse)(nil),  // 29: zhiplugin.v1.ListValueVersionsResponse
+	(*GetValueVersionRequest)(nil),     // 30: zhiplugin.v1.GetValueVersionRequest
+	(*GetValueVersionResponse)(nil),    // 31: zhiplugin.v1.GetValueVersionResponse
+	(*RollbackValueRequest)(nil),       // 32: zhiplugin.v1.RollbackValueRequest
+	(*RollbackValueResponse)(nil),      // 33: zhiplugin.v1.RollbackValueResponse
+	(*DeleteValueVersionRequest)(nil),  // 34: zhiplugin.v1.DeleteValueVersionRequest
+	(*DeleteValueVersionResponse)(nil), // 35: zhiplugin.v1.DeleteValueVersionResponse
+	(*InitEncryptionRequest)(nil),      // 36: zhiplugin.v1.InitEncryptionRequest
+	(*InitEncryptionResponse)(nil),     // 37: zhiplugin.v1.InitEncryptionResponse
+	(*RotateEncryptionRequest)(nil),    // 38: zhiplugin.v1.RotateEncryptionRequest
+	(*RotateEncryptionResponse)(nil),   // 39: zhiplugin.v1.RotateEncryptionResponse
+	(*PermissionMsg)(nil),              // 40: zhiplugin.v1.PermissionMsg
+	(*GrantAccessRequest)(nil),         // 41: zhiplugin.v1.GrantAccessRequest
+	(*GrantAccessResponse)(nil),        // 42: zhiplugin.v1.GrantAccessResponse
+	(*RevokeAccessRequest)(nil),        // 43: zhiplugin.v1.RevokeAccessRequest
+	(*RevokeAccessResponse)(nil),       // 44: zhiplugin.v1.RevokeAccessResponse
+	(*ListAccessRequest)(nil),          // 45: zhiplugin.v1.ListAccessRequest
+	(*UserPermissions)(nil),            // 46: zhiplugin.v1.UserPermissions
+	(*ListAccessResponse)(nil),         // 47: zhiplugin.v1.ListAccessResponse
+	nil,                                // 48: zhiplugin.v1.LoginRequest.CredentialsEntry
+	nil,                                // 49: zhiplugin.v1.LoginResponse.MetadataEntry
+	nil,                                // 50: zhiplugin.v1.PutValuesRequest.CasVersionsEntry
+	nil,                                // 51: zhiplugin.v1.ListAccessResponse.AccessEntry
+	(*proto.TreeEntry)(nil),            // 52: zhiplugin.v1.TreeEntry
 }
 var file_zhiplugin_v1_store_proto_depIdxs = []int32{
-	22, // 0: zhiplugin.v1.SaveRequest.tree:type_name -> zhiplugin.v1.TreeEntry
-	22, // 1: zhiplugin.v1.LoadResponse.tree:type_name -> zhiplugin.v1.TreeEntry
-	22, // 2: zhiplugin.v1.LoadVersionResponse.tree:type_name -> zhiplugin.v1.TreeEntry
-	0,  // 3: zhiplugin.v1.StoreService.Save:input_type -> zhiplugin.v1.SaveRequest
-	2,  // 4: zhiplugin.v1.StoreService.Load:input_type -> zhiplugin.v1.LoadRequest
-	4,  // 5: zhiplugin.v1.StoreService.Delete:input_type -> zhiplugin.v1.DeleteRequest
-	6,  // 6: zhiplugin.v1.StoreService.ListTrees:input_type -> zhiplugin.v1.ListTreesRequest
-	8,  // 7: zhiplugin.v1.StoreService.SupportsVersioning:input_type -> zhiplugin.v1.SupportsVersioningRequest
-	10, // 8: zhiplugin.v1.StoreService.ListVersions:input_type -> zhiplugin.v1.ListVersionsRequest
-	12, // 9: zhiplugin.v1.StoreService.LoadVersion:input_type -> zhiplugin.v1.LoadVersionRequest
-	14, // 10: zhiplugin.v1.StoreService.DeleteVersion:input_type -> zhiplugin.v1.DeleteVersionRequest
-	16, // 11: zhiplugin.v1.StoreService.EncryptionStatus:input_type -> zhiplugin.v1.EncryptionStatusRequest
-	18, // 12: zhiplugin.v1.StoreService.InitEncryption:input_type -> zhiplugin.v1.InitEncryptionRequest
-	20, // 13: zhiplugin.v1.StoreService.RotateEncryption:input_type -> zhiplugin.v1.RotateEncryptionRequest
-	1,  // 14: zhiplugin.v1.StoreService.Save:output_type -> zhiplugin.v1.SaveResponse
-	3,  // 15: zhiplugin.v1.StoreService.Load:output_type -> zhiplugin.v1.LoadResponse
-	5,  // 16: zhiplugin.v1.StoreService.Delete:output_type -> zhiplugin.v1.DeleteResponse
-	7,  // 17: zhiplugin.v1.StoreService.ListTrees:output_type -> zhiplugin.v1.ListTreesResponse
-	9,  // 18: zhiplugin.v1.StoreService.SupportsVersioning:output_type -> zhiplugin.v1.SupportsVersioningResponse
-	11, // 19: zhiplugin.v1.StoreService.ListVersions:output_type -> zhiplugin.v1.ListVersionsResponse
-	13, // 20: zhiplugin.v1.StoreService.LoadVersion:output_type -> zhiplugin.v1.LoadVersionResponse
-	15, // 21: zhiplugin.v1.StoreService.DeleteVersion:output_type -> zhiplugin.v1.DeleteVersionResponse
-	17, // 22: zhiplugin.v1.StoreService.EncryptionStatus:output_type -> zhiplugin.v1.EncryptionStatusResponse
-	19, // 23: zhiplugin.v1.StoreService.InitEncryption:output_type -> zhiplugin.v1.InitEncryptionResponse
-	21, // 24: zhiplugin.v1.StoreService.RotateEncryption:output_type -> zhiplugin.v1.RotateEncryptionResponse
-	14, // [14:25] is the sub-list for method output_type
-	3,  // [3:14] is the sub-list for method input_type
-	3,  // [3:3] is the sub-list for extension type_name
-	3,  // [3:3] is the sub-list for extension extendee
-	0,  // [0:3] is the sub-list for field type_name
+	0,  // 0: zhiplugin.v1.StoreCapabilitiesResponse.versioning:type_name -> zhiplugin.v1.VersioningMode
+	4,  // 1: zhiplugin.v1.AuthMethodMsg.fields:type_name -> zhiplugin.v1.AuthFieldMsg
+	5,  // 2: zhiplugin.v1.AuthMethodsResponse.methods:type_name -> zhiplugin.v1.AuthMethodMsg
+	48, // 3: zhiplugin.v1.LoginRequest.credentials:type_name -> zhiplugin.v1.LoginRequest.CredentialsEntry
+	49, // 4: zhiplugin.v1.LoginResponse.metadata:type_name -> zhiplugin.v1.LoginResponse.MetadataEntry
+	52, // 5: zhiplugin.v1.GetValuesResponse.values:type_name -> zhiplugin.v1.TreeEntry
+	52, // 6: zhiplugin.v1.PutValuesRequest.values:type_name -> zhiplugin.v1.TreeEntry
+	50, // 7: zhiplugin.v1.PutValuesRequest.cas_versions:type_name -> zhiplugin.v1.PutValuesRequest.CasVersionsEntry
+	52, // 8: zhiplugin.v1.GetTreeVersionResponse.values:type_name -> zhiplugin.v1.TreeEntry
+	1,  // 9: zhiplugin.v1.PermissionMsg.actions:type_name -> zhiplugin.v1.ActionType
+	40, // 10: zhiplugin.v1.GrantAccessRequest.permissions:type_name -> zhiplugin.v1.PermissionMsg
+	40, // 11: zhiplugin.v1.UserPermissions.permissions:type_name -> zhiplugin.v1.PermissionMsg
+	51, // 12: zhiplugin.v1.ListAccessResponse.access:type_name -> zhiplugin.v1.ListAccessResponse.AccessEntry
+	46, // 13: zhiplugin.v1.ListAccessResponse.AccessEntry.value:type_name -> zhiplugin.v1.UserPermissions
+	2,  // 14: zhiplugin.v1.StoreService.Capabilities:input_type -> zhiplugin.v1.StoreCapabilitiesRequest
+	6,  // 15: zhiplugin.v1.StoreService.AuthMethods:input_type -> zhiplugin.v1.AuthMethodsRequest
+	8,  // 16: zhiplugin.v1.StoreService.Login:input_type -> zhiplugin.v1.LoginRequest
+	10, // 17: zhiplugin.v1.StoreService.ListTrees:input_type -> zhiplugin.v1.ListTreesRequest
+	12, // 18: zhiplugin.v1.StoreService.DeleteTree:input_type -> zhiplugin.v1.DeleteTreeRequest
+	14, // 19: zhiplugin.v1.StoreService.GetValues:input_type -> zhiplugin.v1.GetValuesRequest
+	16, // 20: zhiplugin.v1.StoreService.PutValues:input_type -> zhiplugin.v1.PutValuesRequest
+	18, // 21: zhiplugin.v1.StoreService.DeleteValues:input_type -> zhiplugin.v1.DeleteValuesRequest
+	20, // 22: zhiplugin.v1.StoreService.ListTreeVersions:input_type -> zhiplugin.v1.ListTreeVersionsRequest
+	22, // 23: zhiplugin.v1.StoreService.GetTreeVersion:input_type -> zhiplugin.v1.GetTreeVersionRequest
+	24, // 24: zhiplugin.v1.StoreService.RollbackTree:input_type -> zhiplugin.v1.RollbackTreeRequest
+	26, // 25: zhiplugin.v1.StoreService.DeleteTreeVersion:input_type -> zhiplugin.v1.DeleteTreeVersionRequest
+	28, // 26: zhiplugin.v1.StoreService.ListValueVersions:input_type -> zhiplugin.v1.ListValueVersionsRequest
+	30, // 27: zhiplugin.v1.StoreService.GetValueVersion:input_type -> zhiplugin.v1.GetValueVersionRequest
+	32, // 28: zhiplugin.v1.StoreService.RollbackValue:input_type -> zhiplugin.v1.RollbackValueRequest
+	34, // 29: zhiplugin.v1.StoreService.DeleteValueVersion:input_type -> zhiplugin.v1.DeleteValueVersionRequest
+	36, // 30: zhiplugin.v1.StoreService.InitEncryption:input_type -> zhiplugin.v1.InitEncryptionRequest
+	38, // 31: zhiplugin.v1.StoreService.RotateEncryption:input_type -> zhiplugin.v1.RotateEncryptionRequest
+	41, // 32: zhiplugin.v1.StoreService.GrantAccess:input_type -> zhiplugin.v1.GrantAccessRequest
+	43, // 33: zhiplugin.v1.StoreService.RevokeAccess:input_type -> zhiplugin.v1.RevokeAccessRequest
+	45, // 34: zhiplugin.v1.StoreService.ListAccess:input_type -> zhiplugin.v1.ListAccessRequest
+	3,  // 35: zhiplugin.v1.StoreService.Capabilities:output_type -> zhiplugin.v1.StoreCapabilitiesResponse
+	7,  // 36: zhiplugin.v1.StoreService.AuthMethods:output_type -> zhiplugin.v1.AuthMethodsResponse
+	9,  // 37: zhiplugin.v1.StoreService.Login:output_type -> zhiplugin.v1.LoginResponse
+	11, // 38: zhiplugin.v1.StoreService.ListTrees:output_type -> zhiplugin.v1.ListTreesResponse
+	13, // 39: zhiplugin.v1.StoreService.DeleteTree:output_type -> zhiplugin.v1.DeleteTreeResponse
+	15, // 40: zhiplugin.v1.StoreService.GetValues:output_type -> zhiplugin.v1.GetValuesResponse
+	17, // 41: zhiplugin.v1.StoreService.PutValues:output_type -> zhiplugin.v1.PutValuesResponse
+	19, // 42: zhiplugin.v1.StoreService.DeleteValues:output_type -> zhiplugin.v1.DeleteValuesResponse
+	21, // 43: zhiplugin.v1.StoreService.ListTreeVersions:output_type -> zhiplugin.v1.ListTreeVersionsResponse
+	23, // 44: zhiplugin.v1.StoreService.GetTreeVersion:output_type -> zhiplugin.v1.GetTreeVersionResponse
+	25, // 45: zhiplugin.v1.StoreService.RollbackTree:output_type -> zhiplugin.v1.RollbackTreeResponse
+	27, // 46: zhiplugin.v1.StoreService.DeleteTreeVersion:output_type -> zhiplugin.v1.DeleteTreeVersionResponse
+	29, // 47: zhiplugin.v1.StoreService.ListValueVersions:output_type -> zhiplugin.v1.ListValueVersionsResponse
+	31, // 48: zhiplugin.v1.StoreService.GetValueVersion:output_type -> zhiplugin.v1.GetValueVersionResponse
+	33, // 49: zhiplugin.v1.StoreService.RollbackValue:output_type -> zhiplugin.v1.RollbackValueResponse
+	35, // 50: zhiplugin.v1.StoreService.DeleteValueVersion:output_type -> zhiplugin.v1.DeleteValueVersionResponse
+	37, // 51: zhiplugin.v1.StoreService.InitEncryption:output_type -> zhiplugin.v1.InitEncryptionResponse
+	39, // 52: zhiplugin.v1.StoreService.RotateEncryption:output_type -> zhiplugin.v1.RotateEncryptionResponse
+	42, // 53: zhiplugin.v1.StoreService.GrantAccess:output_type -> zhiplugin.v1.GrantAccessResponse
+	44, // 54: zhiplugin.v1.StoreService.RevokeAccess:output_type -> zhiplugin.v1.RevokeAccessResponse
+	47, // 55: zhiplugin.v1.StoreService.ListAccess:output_type -> zhiplugin.v1.ListAccessResponse
+	35, // [35:56] is the sub-list for method output_type
+	14, // [14:35] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_zhiplugin_v1_store_proto_init() }
@@ -1137,13 +2635,14 @@ func file_zhiplugin_v1_store_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_zhiplugin_v1_store_proto_rawDesc), len(file_zhiplugin_v1_store_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   22,
+			NumEnums:      2,
+			NumMessages:   50,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_zhiplugin_v1_store_proto_goTypes,
 		DependencyIndexes: file_zhiplugin_v1_store_proto_depIdxs,
+		EnumInfos:         file_zhiplugin_v1_store_proto_enumTypes,
 		MessageInfos:      file_zhiplugin_v1_store_proto_msgTypes,
 	}.Build()
 	File_zhiplugin_v1_store_proto = out.File

--- a/pkg/zhiplugin/store/proto/store_grpc.pb.go
+++ b/pkg/zhiplugin/store/proto/store_grpc.pb.go
@@ -22,17 +22,27 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	StoreService_Save_FullMethodName               = "/zhiplugin.v1.StoreService/Save"
-	StoreService_Load_FullMethodName               = "/zhiplugin.v1.StoreService/Load"
-	StoreService_Delete_FullMethodName             = "/zhiplugin.v1.StoreService/Delete"
+	StoreService_Capabilities_FullMethodName       = "/zhiplugin.v1.StoreService/Capabilities"
+	StoreService_AuthMethods_FullMethodName        = "/zhiplugin.v1.StoreService/AuthMethods"
+	StoreService_Login_FullMethodName              = "/zhiplugin.v1.StoreService/Login"
 	StoreService_ListTrees_FullMethodName          = "/zhiplugin.v1.StoreService/ListTrees"
-	StoreService_SupportsVersioning_FullMethodName = "/zhiplugin.v1.StoreService/SupportsVersioning"
-	StoreService_ListVersions_FullMethodName       = "/zhiplugin.v1.StoreService/ListVersions"
-	StoreService_LoadVersion_FullMethodName        = "/zhiplugin.v1.StoreService/LoadVersion"
-	StoreService_DeleteVersion_FullMethodName      = "/zhiplugin.v1.StoreService/DeleteVersion"
-	StoreService_EncryptionStatus_FullMethodName   = "/zhiplugin.v1.StoreService/EncryptionStatus"
+	StoreService_DeleteTree_FullMethodName         = "/zhiplugin.v1.StoreService/DeleteTree"
+	StoreService_GetValues_FullMethodName          = "/zhiplugin.v1.StoreService/GetValues"
+	StoreService_PutValues_FullMethodName          = "/zhiplugin.v1.StoreService/PutValues"
+	StoreService_DeleteValues_FullMethodName       = "/zhiplugin.v1.StoreService/DeleteValues"
+	StoreService_ListTreeVersions_FullMethodName   = "/zhiplugin.v1.StoreService/ListTreeVersions"
+	StoreService_GetTreeVersion_FullMethodName     = "/zhiplugin.v1.StoreService/GetTreeVersion"
+	StoreService_RollbackTree_FullMethodName       = "/zhiplugin.v1.StoreService/RollbackTree"
+	StoreService_DeleteTreeVersion_FullMethodName  = "/zhiplugin.v1.StoreService/DeleteTreeVersion"
+	StoreService_ListValueVersions_FullMethodName  = "/zhiplugin.v1.StoreService/ListValueVersions"
+	StoreService_GetValueVersion_FullMethodName    = "/zhiplugin.v1.StoreService/GetValueVersion"
+	StoreService_RollbackValue_FullMethodName      = "/zhiplugin.v1.StoreService/RollbackValue"
+	StoreService_DeleteValueVersion_FullMethodName = "/zhiplugin.v1.StoreService/DeleteValueVersion"
 	StoreService_InitEncryption_FullMethodName     = "/zhiplugin.v1.StoreService/InitEncryption"
 	StoreService_RotateEncryption_FullMethodName   = "/zhiplugin.v1.StoreService/RotateEncryption"
+	StoreService_GrantAccess_FullMethodName        = "/zhiplugin.v1.StoreService/GrantAccess"
+	StoreService_RevokeAccess_FullMethodName       = "/zhiplugin.v1.StoreService/RevokeAccess"
+	StoreService_ListAccess_FullMethodName         = "/zhiplugin.v1.StoreService/ListAccess"
 )
 
 // StoreServiceClient is the client API for StoreService service.
@@ -40,39 +50,51 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
 // StoreService is the gRPC interface every zhi store plugin must implement.
-// Store plugins persist, retrieve, and delete configuration trees.
+// Store plugins persist, retrieve, and delete configuration values within
+// named trees with granular, value-level operations.
 type StoreServiceClient interface {
-	// Save persists a configuration tree under the given ID.
-	// If versioning is supported, this creates a new version.
-	Save(ctx context.Context, in *SaveRequest, opts ...grpc.CallOption) (*SaveResponse, error)
-	// Load retrieves the latest version of the configuration tree with the
-	// given ID.
-	Load(ctx context.Context, in *LoadRequest, opts ...grpc.CallOption) (*LoadResponse, error)
-	// Delete removes the configuration tree and all its versions.
-	Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*DeleteResponse, error)
-	// ListTrees returns all stored tree IDs.
+	// Capabilities reports the store's supported features.
+	Capabilities(ctx context.Context, in *StoreCapabilitiesRequest, opts ...grpc.CallOption) (*StoreCapabilitiesResponse, error)
+	// AuthMethods returns the authentication methods supported by this store.
+	AuthMethods(ctx context.Context, in *AuthMethodsRequest, opts ...grpc.CallOption) (*AuthMethodsResponse, error)
+	// Login authenticates with the store using the given method and credentials.
+	Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error)
+	// ListTrees returns all tree IDs the current identity has access to.
 	ListTrees(ctx context.Context, in *ListTreesRequest, opts ...grpc.CallOption) (*ListTreesResponse, error)
-	// SupportsVersioning reports whether this store keeps older versions of
-	// trees.
-	SupportsVersioning(ctx context.Context, in *SupportsVersioningRequest, opts ...grpc.CallOption) (*SupportsVersioningResponse, error)
-	// ListVersions returns version identifiers for a given tree ID, ordered
-	// newest first. Returns an error if versioning is not supported.
-	ListVersions(ctx context.Context, in *ListVersionsRequest, opts ...grpc.CallOption) (*ListVersionsResponse, error)
-	// LoadVersion retrieves a specific version of the configuration tree.
-	// Returns an error if versioning is not supported.
-	LoadVersion(ctx context.Context, in *LoadVersionRequest, opts ...grpc.CallOption) (*LoadVersionResponse, error)
-	// DeleteVersion permanently removes a single version of a configuration
-	// tree. Returns an error if versioning is not supported.
-	DeleteVersion(ctx context.Context, in *DeleteVersionRequest, opts ...grpc.CallOption) (*DeleteVersionResponse, error)
-	// EncryptionStatus reports the current encryption state of the store.
-	EncryptionStatus(ctx context.Context, in *EncryptionStatusRequest, opts ...grpc.CallOption) (*EncryptionStatusResponse, error)
-	// InitEncryption initializes encryption for the store with the given
-	// passphrase. Returns an error if encryption is not supported or is
-	// already active.
+	// DeleteTree removes an entire tree and all its versions/values.
+	DeleteTree(ctx context.Context, in *DeleteTreeRequest, opts ...grpc.CallOption) (*DeleteTreeResponse, error)
+	// GetValues retrieves specific values from a tree by their paths.
+	GetValues(ctx context.Context, in *GetValuesRequest, opts ...grpc.CallOption) (*GetValuesResponse, error)
+	// PutValues writes specific values to a tree.
+	PutValues(ctx context.Context, in *PutValuesRequest, opts ...grpc.CallOption) (*PutValuesResponse, error)
+	// DeleteValues removes specific values from a tree.
+	DeleteValues(ctx context.Context, in *DeleteValuesRequest, opts ...grpc.CallOption) (*DeleteValuesResponse, error)
+	// ListTreeVersions returns version identifiers for a tree (VersioningTree).
+	ListTreeVersions(ctx context.Context, in *ListTreeVersionsRequest, opts ...grpc.CallOption) (*ListTreeVersionsResponse, error)
+	// GetTreeVersion retrieves specific values from a specific tree version.
+	GetTreeVersion(ctx context.Context, in *GetTreeVersionRequest, opts ...grpc.CallOption) (*GetTreeVersionResponse, error)
+	// RollbackTree restores a tree to a previous version.
+	RollbackTree(ctx context.Context, in *RollbackTreeRequest, opts ...grpc.CallOption) (*RollbackTreeResponse, error)
+	// DeleteTreeVersion permanently removes a single tree version.
+	DeleteTreeVersion(ctx context.Context, in *DeleteTreeVersionRequest, opts ...grpc.CallOption) (*DeleteTreeVersionResponse, error)
+	// ListValueVersions returns version identifiers for a specific value (VersioningValue).
+	ListValueVersions(ctx context.Context, in *ListValueVersionsRequest, opts ...grpc.CallOption) (*ListValueVersionsResponse, error)
+	// GetValueVersion retrieves a specific version of a single value.
+	GetValueVersion(ctx context.Context, in *GetValueVersionRequest, opts ...grpc.CallOption) (*GetValueVersionResponse, error)
+	// RollbackValue restores a value to a previous version.
+	RollbackValue(ctx context.Context, in *RollbackValueRequest, opts ...grpc.CallOption) (*RollbackValueResponse, error)
+	// DeleteValueVersion permanently removes a single value version.
+	DeleteValueVersion(ctx context.Context, in *DeleteValueVersionRequest, opts ...grpc.CallOption) (*DeleteValueVersionResponse, error)
+	// InitEncryption initializes encryption for the store.
 	InitEncryption(ctx context.Context, in *InitEncryptionRequest, opts ...grpc.CallOption) (*InitEncryptionResponse, error)
-	// RotateEncryption re-encrypts all stored data with a new passphrase.
-	// Returns an error if encryption is not supported or not active.
+	// RotateEncryption re-encrypts stored data with a new passphrase.
 	RotateEncryption(ctx context.Context, in *RotateEncryptionRequest, opts ...grpc.CallOption) (*RotateEncryptionResponse, error)
+	// GrantAccess grants a user access to specific paths within a tree.
+	GrantAccess(ctx context.Context, in *GrantAccessRequest, opts ...grpc.CallOption) (*GrantAccessResponse, error)
+	// RevokeAccess removes a user's access to specific paths within a tree.
+	RevokeAccess(ctx context.Context, in *RevokeAccessRequest, opts ...grpc.CallOption) (*RevokeAccessResponse, error)
+	// ListAccess returns the current access permissions for a tree.
+	ListAccess(ctx context.Context, in *ListAccessRequest, opts ...grpc.CallOption) (*ListAccessResponse, error)
 }
 
 type storeServiceClient struct {
@@ -83,30 +105,30 @@ func NewStoreServiceClient(cc grpc.ClientConnInterface) StoreServiceClient {
 	return &storeServiceClient{cc}
 }
 
-func (c *storeServiceClient) Save(ctx context.Context, in *SaveRequest, opts ...grpc.CallOption) (*SaveResponse, error) {
+func (c *storeServiceClient) Capabilities(ctx context.Context, in *StoreCapabilitiesRequest, opts ...grpc.CallOption) (*StoreCapabilitiesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(SaveResponse)
-	err := c.cc.Invoke(ctx, StoreService_Save_FullMethodName, in, out, cOpts...)
+	out := new(StoreCapabilitiesResponse)
+	err := c.cc.Invoke(ctx, StoreService_Capabilities_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *storeServiceClient) Load(ctx context.Context, in *LoadRequest, opts ...grpc.CallOption) (*LoadResponse, error) {
+func (c *storeServiceClient) AuthMethods(ctx context.Context, in *AuthMethodsRequest, opts ...grpc.CallOption) (*AuthMethodsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(LoadResponse)
-	err := c.cc.Invoke(ctx, StoreService_Load_FullMethodName, in, out, cOpts...)
+	out := new(AuthMethodsResponse)
+	err := c.cc.Invoke(ctx, StoreService_AuthMethods_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *storeServiceClient) Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*DeleteResponse, error) {
+func (c *storeServiceClient) Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(DeleteResponse)
-	err := c.cc.Invoke(ctx, StoreService_Delete_FullMethodName, in, out, cOpts...)
+	out := new(LoginResponse)
+	err := c.cc.Invoke(ctx, StoreService_Login_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -123,50 +145,120 @@ func (c *storeServiceClient) ListTrees(ctx context.Context, in *ListTreesRequest
 	return out, nil
 }
 
-func (c *storeServiceClient) SupportsVersioning(ctx context.Context, in *SupportsVersioningRequest, opts ...grpc.CallOption) (*SupportsVersioningResponse, error) {
+func (c *storeServiceClient) DeleteTree(ctx context.Context, in *DeleteTreeRequest, opts ...grpc.CallOption) (*DeleteTreeResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(SupportsVersioningResponse)
-	err := c.cc.Invoke(ctx, StoreService_SupportsVersioning_FullMethodName, in, out, cOpts...)
+	out := new(DeleteTreeResponse)
+	err := c.cc.Invoke(ctx, StoreService_DeleteTree_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *storeServiceClient) ListVersions(ctx context.Context, in *ListVersionsRequest, opts ...grpc.CallOption) (*ListVersionsResponse, error) {
+func (c *storeServiceClient) GetValues(ctx context.Context, in *GetValuesRequest, opts ...grpc.CallOption) (*GetValuesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(ListVersionsResponse)
-	err := c.cc.Invoke(ctx, StoreService_ListVersions_FullMethodName, in, out, cOpts...)
+	out := new(GetValuesResponse)
+	err := c.cc.Invoke(ctx, StoreService_GetValues_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *storeServiceClient) LoadVersion(ctx context.Context, in *LoadVersionRequest, opts ...grpc.CallOption) (*LoadVersionResponse, error) {
+func (c *storeServiceClient) PutValues(ctx context.Context, in *PutValuesRequest, opts ...grpc.CallOption) (*PutValuesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(LoadVersionResponse)
-	err := c.cc.Invoke(ctx, StoreService_LoadVersion_FullMethodName, in, out, cOpts...)
+	out := new(PutValuesResponse)
+	err := c.cc.Invoke(ctx, StoreService_PutValues_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *storeServiceClient) DeleteVersion(ctx context.Context, in *DeleteVersionRequest, opts ...grpc.CallOption) (*DeleteVersionResponse, error) {
+func (c *storeServiceClient) DeleteValues(ctx context.Context, in *DeleteValuesRequest, opts ...grpc.CallOption) (*DeleteValuesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(DeleteVersionResponse)
-	err := c.cc.Invoke(ctx, StoreService_DeleteVersion_FullMethodName, in, out, cOpts...)
+	out := new(DeleteValuesResponse)
+	err := c.cc.Invoke(ctx, StoreService_DeleteValues_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *storeServiceClient) EncryptionStatus(ctx context.Context, in *EncryptionStatusRequest, opts ...grpc.CallOption) (*EncryptionStatusResponse, error) {
+func (c *storeServiceClient) ListTreeVersions(ctx context.Context, in *ListTreeVersionsRequest, opts ...grpc.CallOption) (*ListTreeVersionsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(EncryptionStatusResponse)
-	err := c.cc.Invoke(ctx, StoreService_EncryptionStatus_FullMethodName, in, out, cOpts...)
+	out := new(ListTreeVersionsResponse)
+	err := c.cc.Invoke(ctx, StoreService_ListTreeVersions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *storeServiceClient) GetTreeVersion(ctx context.Context, in *GetTreeVersionRequest, opts ...grpc.CallOption) (*GetTreeVersionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetTreeVersionResponse)
+	err := c.cc.Invoke(ctx, StoreService_GetTreeVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *storeServiceClient) RollbackTree(ctx context.Context, in *RollbackTreeRequest, opts ...grpc.CallOption) (*RollbackTreeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RollbackTreeResponse)
+	err := c.cc.Invoke(ctx, StoreService_RollbackTree_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *storeServiceClient) DeleteTreeVersion(ctx context.Context, in *DeleteTreeVersionRequest, opts ...grpc.CallOption) (*DeleteTreeVersionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteTreeVersionResponse)
+	err := c.cc.Invoke(ctx, StoreService_DeleteTreeVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *storeServiceClient) ListValueVersions(ctx context.Context, in *ListValueVersionsRequest, opts ...grpc.CallOption) (*ListValueVersionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListValueVersionsResponse)
+	err := c.cc.Invoke(ctx, StoreService_ListValueVersions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *storeServiceClient) GetValueVersion(ctx context.Context, in *GetValueVersionRequest, opts ...grpc.CallOption) (*GetValueVersionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetValueVersionResponse)
+	err := c.cc.Invoke(ctx, StoreService_GetValueVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *storeServiceClient) RollbackValue(ctx context.Context, in *RollbackValueRequest, opts ...grpc.CallOption) (*RollbackValueResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RollbackValueResponse)
+	err := c.cc.Invoke(ctx, StoreService_RollbackValue_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *storeServiceClient) DeleteValueVersion(ctx context.Context, in *DeleteValueVersionRequest, opts ...grpc.CallOption) (*DeleteValueVersionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteValueVersionResponse)
+	err := c.cc.Invoke(ctx, StoreService_DeleteValueVersion_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -193,44 +285,86 @@ func (c *storeServiceClient) RotateEncryption(ctx context.Context, in *RotateEnc
 	return out, nil
 }
 
+func (c *storeServiceClient) GrantAccess(ctx context.Context, in *GrantAccessRequest, opts ...grpc.CallOption) (*GrantAccessResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GrantAccessResponse)
+	err := c.cc.Invoke(ctx, StoreService_GrantAccess_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *storeServiceClient) RevokeAccess(ctx context.Context, in *RevokeAccessRequest, opts ...grpc.CallOption) (*RevokeAccessResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RevokeAccessResponse)
+	err := c.cc.Invoke(ctx, StoreService_RevokeAccess_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *storeServiceClient) ListAccess(ctx context.Context, in *ListAccessRequest, opts ...grpc.CallOption) (*ListAccessResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListAccessResponse)
+	err := c.cc.Invoke(ctx, StoreService_ListAccess_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // StoreServiceServer is the server API for StoreService service.
 // All implementations must embed UnimplementedStoreServiceServer
 // for forward compatibility.
 //
 // StoreService is the gRPC interface every zhi store plugin must implement.
-// Store plugins persist, retrieve, and delete configuration trees.
+// Store plugins persist, retrieve, and delete configuration values within
+// named trees with granular, value-level operations.
 type StoreServiceServer interface {
-	// Save persists a configuration tree under the given ID.
-	// If versioning is supported, this creates a new version.
-	Save(context.Context, *SaveRequest) (*SaveResponse, error)
-	// Load retrieves the latest version of the configuration tree with the
-	// given ID.
-	Load(context.Context, *LoadRequest) (*LoadResponse, error)
-	// Delete removes the configuration tree and all its versions.
-	Delete(context.Context, *DeleteRequest) (*DeleteResponse, error)
-	// ListTrees returns all stored tree IDs.
+	// Capabilities reports the store's supported features.
+	Capabilities(context.Context, *StoreCapabilitiesRequest) (*StoreCapabilitiesResponse, error)
+	// AuthMethods returns the authentication methods supported by this store.
+	AuthMethods(context.Context, *AuthMethodsRequest) (*AuthMethodsResponse, error)
+	// Login authenticates with the store using the given method and credentials.
+	Login(context.Context, *LoginRequest) (*LoginResponse, error)
+	// ListTrees returns all tree IDs the current identity has access to.
 	ListTrees(context.Context, *ListTreesRequest) (*ListTreesResponse, error)
-	// SupportsVersioning reports whether this store keeps older versions of
-	// trees.
-	SupportsVersioning(context.Context, *SupportsVersioningRequest) (*SupportsVersioningResponse, error)
-	// ListVersions returns version identifiers for a given tree ID, ordered
-	// newest first. Returns an error if versioning is not supported.
-	ListVersions(context.Context, *ListVersionsRequest) (*ListVersionsResponse, error)
-	// LoadVersion retrieves a specific version of the configuration tree.
-	// Returns an error if versioning is not supported.
-	LoadVersion(context.Context, *LoadVersionRequest) (*LoadVersionResponse, error)
-	// DeleteVersion permanently removes a single version of a configuration
-	// tree. Returns an error if versioning is not supported.
-	DeleteVersion(context.Context, *DeleteVersionRequest) (*DeleteVersionResponse, error)
-	// EncryptionStatus reports the current encryption state of the store.
-	EncryptionStatus(context.Context, *EncryptionStatusRequest) (*EncryptionStatusResponse, error)
-	// InitEncryption initializes encryption for the store with the given
-	// passphrase. Returns an error if encryption is not supported or is
-	// already active.
+	// DeleteTree removes an entire tree and all its versions/values.
+	DeleteTree(context.Context, *DeleteTreeRequest) (*DeleteTreeResponse, error)
+	// GetValues retrieves specific values from a tree by their paths.
+	GetValues(context.Context, *GetValuesRequest) (*GetValuesResponse, error)
+	// PutValues writes specific values to a tree.
+	PutValues(context.Context, *PutValuesRequest) (*PutValuesResponse, error)
+	// DeleteValues removes specific values from a tree.
+	DeleteValues(context.Context, *DeleteValuesRequest) (*DeleteValuesResponse, error)
+	// ListTreeVersions returns version identifiers for a tree (VersioningTree).
+	ListTreeVersions(context.Context, *ListTreeVersionsRequest) (*ListTreeVersionsResponse, error)
+	// GetTreeVersion retrieves specific values from a specific tree version.
+	GetTreeVersion(context.Context, *GetTreeVersionRequest) (*GetTreeVersionResponse, error)
+	// RollbackTree restores a tree to a previous version.
+	RollbackTree(context.Context, *RollbackTreeRequest) (*RollbackTreeResponse, error)
+	// DeleteTreeVersion permanently removes a single tree version.
+	DeleteTreeVersion(context.Context, *DeleteTreeVersionRequest) (*DeleteTreeVersionResponse, error)
+	// ListValueVersions returns version identifiers for a specific value (VersioningValue).
+	ListValueVersions(context.Context, *ListValueVersionsRequest) (*ListValueVersionsResponse, error)
+	// GetValueVersion retrieves a specific version of a single value.
+	GetValueVersion(context.Context, *GetValueVersionRequest) (*GetValueVersionResponse, error)
+	// RollbackValue restores a value to a previous version.
+	RollbackValue(context.Context, *RollbackValueRequest) (*RollbackValueResponse, error)
+	// DeleteValueVersion permanently removes a single value version.
+	DeleteValueVersion(context.Context, *DeleteValueVersionRequest) (*DeleteValueVersionResponse, error)
+	// InitEncryption initializes encryption for the store.
 	InitEncryption(context.Context, *InitEncryptionRequest) (*InitEncryptionResponse, error)
-	// RotateEncryption re-encrypts all stored data with a new passphrase.
-	// Returns an error if encryption is not supported or not active.
+	// RotateEncryption re-encrypts stored data with a new passphrase.
 	RotateEncryption(context.Context, *RotateEncryptionRequest) (*RotateEncryptionResponse, error)
+	// GrantAccess grants a user access to specific paths within a tree.
+	GrantAccess(context.Context, *GrantAccessRequest) (*GrantAccessResponse, error)
+	// RevokeAccess removes a user's access to specific paths within a tree.
+	RevokeAccess(context.Context, *RevokeAccessRequest) (*RevokeAccessResponse, error)
+	// ListAccess returns the current access permissions for a tree.
+	ListAccess(context.Context, *ListAccessRequest) (*ListAccessResponse, error)
 	mustEmbedUnimplementedStoreServiceServer()
 }
 
@@ -241,38 +375,68 @@ type StoreServiceServer interface {
 // pointer dereference when methods are called.
 type UnimplementedStoreServiceServer struct{}
 
-func (UnimplementedStoreServiceServer) Save(context.Context, *SaveRequest) (*SaveResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method Save not implemented")
+func (UnimplementedStoreServiceServer) Capabilities(context.Context, *StoreCapabilitiesRequest) (*StoreCapabilitiesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Capabilities not implemented")
 }
-func (UnimplementedStoreServiceServer) Load(context.Context, *LoadRequest) (*LoadResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method Load not implemented")
+func (UnimplementedStoreServiceServer) AuthMethods(context.Context, *AuthMethodsRequest) (*AuthMethodsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method AuthMethods not implemented")
 }
-func (UnimplementedStoreServiceServer) Delete(context.Context, *DeleteRequest) (*DeleteResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method Delete not implemented")
+func (UnimplementedStoreServiceServer) Login(context.Context, *LoginRequest) (*LoginResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Login not implemented")
 }
 func (UnimplementedStoreServiceServer) ListTrees(context.Context, *ListTreesRequest) (*ListTreesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListTrees not implemented")
 }
-func (UnimplementedStoreServiceServer) SupportsVersioning(context.Context, *SupportsVersioningRequest) (*SupportsVersioningResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method SupportsVersioning not implemented")
+func (UnimplementedStoreServiceServer) DeleteTree(context.Context, *DeleteTreeRequest) (*DeleteTreeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteTree not implemented")
 }
-func (UnimplementedStoreServiceServer) ListVersions(context.Context, *ListVersionsRequest) (*ListVersionsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method ListVersions not implemented")
+func (UnimplementedStoreServiceServer) GetValues(context.Context, *GetValuesRequest) (*GetValuesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetValues not implemented")
 }
-func (UnimplementedStoreServiceServer) LoadVersion(context.Context, *LoadVersionRequest) (*LoadVersionResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method LoadVersion not implemented")
+func (UnimplementedStoreServiceServer) PutValues(context.Context, *PutValuesRequest) (*PutValuesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PutValues not implemented")
 }
-func (UnimplementedStoreServiceServer) DeleteVersion(context.Context, *DeleteVersionRequest) (*DeleteVersionResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method DeleteVersion not implemented")
+func (UnimplementedStoreServiceServer) DeleteValues(context.Context, *DeleteValuesRequest) (*DeleteValuesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteValues not implemented")
 }
-func (UnimplementedStoreServiceServer) EncryptionStatus(context.Context, *EncryptionStatusRequest) (*EncryptionStatusResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method EncryptionStatus not implemented")
+func (UnimplementedStoreServiceServer) ListTreeVersions(context.Context, *ListTreeVersionsRequest) (*ListTreeVersionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListTreeVersions not implemented")
+}
+func (UnimplementedStoreServiceServer) GetTreeVersion(context.Context, *GetTreeVersionRequest) (*GetTreeVersionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetTreeVersion not implemented")
+}
+func (UnimplementedStoreServiceServer) RollbackTree(context.Context, *RollbackTreeRequest) (*RollbackTreeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RollbackTree not implemented")
+}
+func (UnimplementedStoreServiceServer) DeleteTreeVersion(context.Context, *DeleteTreeVersionRequest) (*DeleteTreeVersionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteTreeVersion not implemented")
+}
+func (UnimplementedStoreServiceServer) ListValueVersions(context.Context, *ListValueVersionsRequest) (*ListValueVersionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListValueVersions not implemented")
+}
+func (UnimplementedStoreServiceServer) GetValueVersion(context.Context, *GetValueVersionRequest) (*GetValueVersionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetValueVersion not implemented")
+}
+func (UnimplementedStoreServiceServer) RollbackValue(context.Context, *RollbackValueRequest) (*RollbackValueResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RollbackValue not implemented")
+}
+func (UnimplementedStoreServiceServer) DeleteValueVersion(context.Context, *DeleteValueVersionRequest) (*DeleteValueVersionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteValueVersion not implemented")
 }
 func (UnimplementedStoreServiceServer) InitEncryption(context.Context, *InitEncryptionRequest) (*InitEncryptionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method InitEncryption not implemented")
 }
 func (UnimplementedStoreServiceServer) RotateEncryption(context.Context, *RotateEncryptionRequest) (*RotateEncryptionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RotateEncryption not implemented")
+}
+func (UnimplementedStoreServiceServer) GrantAccess(context.Context, *GrantAccessRequest) (*GrantAccessResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GrantAccess not implemented")
+}
+func (UnimplementedStoreServiceServer) RevokeAccess(context.Context, *RevokeAccessRequest) (*RevokeAccessResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RevokeAccess not implemented")
+}
+func (UnimplementedStoreServiceServer) ListAccess(context.Context, *ListAccessRequest) (*ListAccessResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListAccess not implemented")
 }
 func (UnimplementedStoreServiceServer) mustEmbedUnimplementedStoreServiceServer() {}
 func (UnimplementedStoreServiceServer) testEmbeddedByValue()                      {}
@@ -295,56 +459,56 @@ func RegisterStoreServiceServer(s grpc.ServiceRegistrar, srv StoreServiceServer)
 	s.RegisterService(&StoreService_ServiceDesc, srv)
 }
 
-func _StoreService_Save_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(SaveRequest)
+func _StoreService_Capabilities_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StoreCapabilitiesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StoreServiceServer).Save(ctx, in)
+		return srv.(StoreServiceServer).Capabilities(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: StoreService_Save_FullMethodName,
+		FullMethod: StoreService_Capabilities_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StoreServiceServer).Save(ctx, req.(*SaveRequest))
+		return srv.(StoreServiceServer).Capabilities(ctx, req.(*StoreCapabilitiesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StoreService_Load_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(LoadRequest)
+func _StoreService_AuthMethods_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AuthMethodsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StoreServiceServer).Load(ctx, in)
+		return srv.(StoreServiceServer).AuthMethods(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: StoreService_Load_FullMethodName,
+		FullMethod: StoreService_AuthMethods_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StoreServiceServer).Load(ctx, req.(*LoadRequest))
+		return srv.(StoreServiceServer).AuthMethods(ctx, req.(*AuthMethodsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StoreService_Delete_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(DeleteRequest)
+func _StoreService_Login_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LoginRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StoreServiceServer).Delete(ctx, in)
+		return srv.(StoreServiceServer).Login(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: StoreService_Delete_FullMethodName,
+		FullMethod: StoreService_Login_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StoreServiceServer).Delete(ctx, req.(*DeleteRequest))
+		return srv.(StoreServiceServer).Login(ctx, req.(*LoginRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -367,92 +531,218 @@ func _StoreService_ListTrees_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StoreService_SupportsVersioning_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(SupportsVersioningRequest)
+func _StoreService_DeleteTree_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteTreeRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StoreServiceServer).SupportsVersioning(ctx, in)
+		return srv.(StoreServiceServer).DeleteTree(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: StoreService_SupportsVersioning_FullMethodName,
+		FullMethod: StoreService_DeleteTree_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StoreServiceServer).SupportsVersioning(ctx, req.(*SupportsVersioningRequest))
+		return srv.(StoreServiceServer).DeleteTree(ctx, req.(*DeleteTreeRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StoreService_ListVersions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ListVersionsRequest)
+func _StoreService_GetValues_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetValuesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StoreServiceServer).ListVersions(ctx, in)
+		return srv.(StoreServiceServer).GetValues(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: StoreService_ListVersions_FullMethodName,
+		FullMethod: StoreService_GetValues_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StoreServiceServer).ListVersions(ctx, req.(*ListVersionsRequest))
+		return srv.(StoreServiceServer).GetValues(ctx, req.(*GetValuesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StoreService_LoadVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(LoadVersionRequest)
+func _StoreService_PutValues_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PutValuesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StoreServiceServer).LoadVersion(ctx, in)
+		return srv.(StoreServiceServer).PutValues(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: StoreService_LoadVersion_FullMethodName,
+		FullMethod: StoreService_PutValues_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StoreServiceServer).LoadVersion(ctx, req.(*LoadVersionRequest))
+		return srv.(StoreServiceServer).PutValues(ctx, req.(*PutValuesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StoreService_DeleteVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(DeleteVersionRequest)
+func _StoreService_DeleteValues_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteValuesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StoreServiceServer).DeleteVersion(ctx, in)
+		return srv.(StoreServiceServer).DeleteValues(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: StoreService_DeleteVersion_FullMethodName,
+		FullMethod: StoreService_DeleteValues_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StoreServiceServer).DeleteVersion(ctx, req.(*DeleteVersionRequest))
+		return srv.(StoreServiceServer).DeleteValues(ctx, req.(*DeleteValuesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _StoreService_EncryptionStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(EncryptionStatusRequest)
+func _StoreService_ListTreeVersions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListTreeVersionsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(StoreServiceServer).EncryptionStatus(ctx, in)
+		return srv.(StoreServiceServer).ListTreeVersions(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: StoreService_EncryptionStatus_FullMethodName,
+		FullMethod: StoreService_ListTreeVersions_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(StoreServiceServer).EncryptionStatus(ctx, req.(*EncryptionStatusRequest))
+		return srv.(StoreServiceServer).ListTreeVersions(ctx, req.(*ListTreeVersionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _StoreService_GetTreeVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetTreeVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StoreServiceServer).GetTreeVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: StoreService_GetTreeVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StoreServiceServer).GetTreeVersion(ctx, req.(*GetTreeVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _StoreService_RollbackTree_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RollbackTreeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StoreServiceServer).RollbackTree(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: StoreService_RollbackTree_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StoreServiceServer).RollbackTree(ctx, req.(*RollbackTreeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _StoreService_DeleteTreeVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteTreeVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StoreServiceServer).DeleteTreeVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: StoreService_DeleteTreeVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StoreServiceServer).DeleteTreeVersion(ctx, req.(*DeleteTreeVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _StoreService_ListValueVersions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListValueVersionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StoreServiceServer).ListValueVersions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: StoreService_ListValueVersions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StoreServiceServer).ListValueVersions(ctx, req.(*ListValueVersionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _StoreService_GetValueVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetValueVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StoreServiceServer).GetValueVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: StoreService_GetValueVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StoreServiceServer).GetValueVersion(ctx, req.(*GetValueVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _StoreService_RollbackValue_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RollbackValueRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StoreServiceServer).RollbackValue(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: StoreService_RollbackValue_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StoreServiceServer).RollbackValue(ctx, req.(*RollbackValueRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _StoreService_DeleteValueVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteValueVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StoreServiceServer).DeleteValueVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: StoreService_DeleteValueVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StoreServiceServer).DeleteValueVersion(ctx, req.(*DeleteValueVersionRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -493,6 +783,60 @@ func _StoreService_RotateEncryption_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _StoreService_GrantAccess_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GrantAccessRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StoreServiceServer).GrantAccess(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: StoreService_GrantAccess_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StoreServiceServer).GrantAccess(ctx, req.(*GrantAccessRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _StoreService_RevokeAccess_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RevokeAccessRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StoreServiceServer).RevokeAccess(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: StoreService_RevokeAccess_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StoreServiceServer).RevokeAccess(ctx, req.(*RevokeAccessRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _StoreService_ListAccess_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListAccessRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(StoreServiceServer).ListAccess(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: StoreService_ListAccess_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(StoreServiceServer).ListAccess(ctx, req.(*ListAccessRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // StoreService_ServiceDesc is the grpc.ServiceDesc for StoreService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -501,40 +845,68 @@ var StoreService_ServiceDesc = grpc.ServiceDesc{
 	HandlerType: (*StoreServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "Save",
-			Handler:    _StoreService_Save_Handler,
+			MethodName: "Capabilities",
+			Handler:    _StoreService_Capabilities_Handler,
 		},
 		{
-			MethodName: "Load",
-			Handler:    _StoreService_Load_Handler,
+			MethodName: "AuthMethods",
+			Handler:    _StoreService_AuthMethods_Handler,
 		},
 		{
-			MethodName: "Delete",
-			Handler:    _StoreService_Delete_Handler,
+			MethodName: "Login",
+			Handler:    _StoreService_Login_Handler,
 		},
 		{
 			MethodName: "ListTrees",
 			Handler:    _StoreService_ListTrees_Handler,
 		},
 		{
-			MethodName: "SupportsVersioning",
-			Handler:    _StoreService_SupportsVersioning_Handler,
+			MethodName: "DeleteTree",
+			Handler:    _StoreService_DeleteTree_Handler,
 		},
 		{
-			MethodName: "ListVersions",
-			Handler:    _StoreService_ListVersions_Handler,
+			MethodName: "GetValues",
+			Handler:    _StoreService_GetValues_Handler,
 		},
 		{
-			MethodName: "LoadVersion",
-			Handler:    _StoreService_LoadVersion_Handler,
+			MethodName: "PutValues",
+			Handler:    _StoreService_PutValues_Handler,
 		},
 		{
-			MethodName: "DeleteVersion",
-			Handler:    _StoreService_DeleteVersion_Handler,
+			MethodName: "DeleteValues",
+			Handler:    _StoreService_DeleteValues_Handler,
 		},
 		{
-			MethodName: "EncryptionStatus",
-			Handler:    _StoreService_EncryptionStatus_Handler,
+			MethodName: "ListTreeVersions",
+			Handler:    _StoreService_ListTreeVersions_Handler,
+		},
+		{
+			MethodName: "GetTreeVersion",
+			Handler:    _StoreService_GetTreeVersion_Handler,
+		},
+		{
+			MethodName: "RollbackTree",
+			Handler:    _StoreService_RollbackTree_Handler,
+		},
+		{
+			MethodName: "DeleteTreeVersion",
+			Handler:    _StoreService_DeleteTreeVersion_Handler,
+		},
+		{
+			MethodName: "ListValueVersions",
+			Handler:    _StoreService_ListValueVersions_Handler,
+		},
+		{
+			MethodName: "GetValueVersion",
+			Handler:    _StoreService_GetValueVersion_Handler,
+		},
+		{
+			MethodName: "RollbackValue",
+			Handler:    _StoreService_RollbackValue_Handler,
+		},
+		{
+			MethodName: "DeleteValueVersion",
+			Handler:    _StoreService_DeleteValueVersion_Handler,
 		},
 		{
 			MethodName: "InitEncryption",
@@ -543,6 +915,18 @@ var StoreService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RotateEncryption",
 			Handler:    _StoreService_RotateEncryption_Handler,
+		},
+		{
+			MethodName: "GrantAccess",
+			Handler:    _StoreService_GrantAccess_Handler,
+		},
+		{
+			MethodName: "RevokeAccess",
+			Handler:    _StoreService_RevokeAccess_Handler,
+		},
+		{
+			MethodName: "ListAccess",
+			Handler:    _StoreService_ListAccess_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/zhiplugin/store/store.go
+++ b/pkg/zhiplugin/store/store.go
@@ -1,8 +1,10 @@
 // Package store defines the store plugin API for zhi.
 //
-// Store plugins persist, retrieve, and delete configuration trees. They may
-// optionally support versioning (keeping older versions of trees) and
-// encryption at rest.
+// Store plugins persist, retrieve, and delete configuration values within
+// named trees. The API is designed with security-first principles:
+// operations are granular down to individual values, authentication and
+// access control hooks are built in, and versioning supports both
+// tree-level and value-level flavors.
 package store
 
 // EncryptionStatus reports the encryption state of a store plugin.
@@ -30,4 +32,126 @@ func (s EncryptionStatus) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+// VersioningMode describes how a store plugin versions data.
+type VersioningMode int
+
+const (
+	// VersioningNone means the store does not support versioning.
+	VersioningNone VersioningMode = iota
+	// VersioningTree means the entire tree is versioned atomically.
+	// A save creates a new version of the whole tree, and rollbacks
+	// restore the entire tree.
+	VersioningTree
+	// VersioningValue means individual values are versioned independently.
+	// Each value has its own version history and can be rolled back
+	// individually.
+	VersioningValue
+)
+
+func (m VersioningMode) String() string {
+	switch m {
+	case VersioningNone:
+		return "none"
+	case VersioningTree:
+		return "tree"
+	case VersioningValue:
+		return "value"
+	default:
+		return "unknown"
+	}
+}
+
+// Capabilities reports what features a store plugin supports.
+type Capabilities struct {
+	// Versioning describes the versioning strategy.
+	Versioning VersioningMode
+	// Encryption reports the current encryption state.
+	Encryption EncryptionStatus
+	// Auth is true if the store requires or supports authentication.
+	Auth bool
+	// AccessControl is true if the store supports per-value access
+	// control and sharing.
+	AccessControl bool
+}
+
+// AuthMethod describes an authentication method supported by the store.
+type AuthMethod struct {
+	// Type is the method identifier, e.g. "userpass", "token", "oidc".
+	Type string
+	// Description is a human-readable description of the method.
+	Description string
+	// Fields describes the credential fields needed for this method.
+	Fields []AuthField
+}
+
+// AuthField describes a single credential field for an auth method.
+type AuthField struct {
+	// Name is the field identifier, e.g. "username", "password", "token".
+	Name string
+	// Description is a human-readable label for the field.
+	Description string
+	// Required is true if this field must be provided.
+	Required bool
+	// Secret is true if this field should be masked in UIs (e.g. passwords).
+	Secret bool
+}
+
+// Credential represents an opaque authentication credential returned
+// after a successful login.
+type Credential struct {
+	// Token is an opaque session or access token.
+	Token string
+	// ExpiresAt is an optional RFC3339 timestamp indicating expiry.
+	ExpiresAt string
+	// Metadata carries optional key-value information about the session.
+	Metadata map[string]string
+}
+
+// PutOptions controls optional behaviour of PutValues.
+type PutOptions struct {
+	// CASVersion is the expected current tree version for tree-level CAS.
+	// If non-empty and the current version differs, the write fails with
+	// an error. Only meaningful when versioning mode is VersioningTree.
+	CASVersion string
+	// CASVersions maps individual paths to their expected current
+	// versions. If a path's current version differs, the write for that
+	// path fails. Only meaningful when versioning mode is VersioningValue.
+	CASVersions map[string]string
+}
+
+// Action describes a type of access to a stored value.
+type Action int
+
+const (
+	// ActionRead allows reading a value.
+	ActionRead Action = iota
+	// ActionWrite allows creating or updating a value.
+	ActionWrite
+	// ActionDelete allows removing a value.
+	ActionDelete
+)
+
+func (a Action) String() string {
+	switch a {
+	case ActionRead:
+		return "read"
+	case ActionWrite:
+		return "write"
+	case ActionDelete:
+		return "delete"
+	default:
+		return "unknown"
+	}
+}
+
+// Permission describes access to a specific path or path prefix within
+// a tree.
+type Permission struct {
+	// Path is an exact path (e.g. "database/host") or a path prefix
+	// ending in "/" (e.g. "database/") that this permission covers.
+	Path string
+	// Actions lists the allowed operations.
+	Actions []Action
 }

--- a/pkg/zhiplugin/store/store_test.go
+++ b/pkg/zhiplugin/store/store_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"sync"
 	"testing"
 
@@ -13,128 +12,147 @@ import (
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
 )
 
-// --- testPlugin: in-memory store with versioning, no encryption -----------
-
+// testPlugin is a full in-memory implementation of Plugin for testing
+// the gRPC round-trip. It supports no versioning, auth, or encryption.
 type testPlugin struct {
 	mu    sync.RWMutex
-	trees map[string][]*config.Tree // id -> versions (newest last)
+	trees map[string]map[string]config.Value // tree id -> path -> value
 }
 
 func newTestPlugin() *testPlugin {
-	return &testPlugin{trees: make(map[string][]*config.Tree)}
+	return &testPlugin{trees: make(map[string]map[string]config.Value)}
 }
 
-func (p *testPlugin) Save(_ context.Context, id string, tree config.TreeReader) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	cp := config.NewTree()
-	for _, path := range tree.List() {
-		v, ok := tree.Get(path)
-		if !ok {
-			continue
-		}
-		_ = cp.Set(path, &v)
-	}
-	p.trees[id] = append(p.trees[id], cp)
-	return nil
+func (t *testPlugin) Capabilities(context.Context) (*Capabilities, error) {
+	return &Capabilities{
+		Versioning:    VersioningNone,
+		Encryption:    EncryptionNone,
+		Auth:          false,
+		AccessControl: false,
+	}, nil
 }
 
-func (p *testPlugin) Load(_ context.Context, id string) (*config.Tree, bool, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	versions, ok := p.trees[id]
-	if !ok || len(versions) == 0 {
-		return nil, false, nil
-	}
-	return versions[len(versions)-1], true, nil
+func (t *testPlugin) AuthMethods(context.Context) ([]AuthMethod, error) {
+	return nil, nil
 }
 
-func (p *testPlugin) Delete(_ context.Context, id string) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	delete(p.trees, id)
-	return nil
+func (t *testPlugin) Login(context.Context, string, map[string]string) (*Credential, error) {
+	return nil, errors.New("authentication not supported")
 }
 
-func (p *testPlugin) ListTrees(_ context.Context) ([]string, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	ids := make([]string, 0, len(p.trees))
-	for id := range p.trees {
+func (t *testPlugin) ListTrees(_ context.Context) ([]string, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	ids := make([]string, 0, len(t.trees))
+	for id := range t.trees {
 		ids = append(ids, id)
 	}
 	return ids, nil
 }
 
-func (p *testPlugin) SupportsVersioning(_ context.Context) (bool, error) {
-	return true, nil
+func (t *testPlugin) DeleteTree(_ context.Context, id string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.trees, id)
+	return nil
 }
 
-func (p *testPlugin) ListVersions(_ context.Context, id string) ([]string, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	versions, ok := p.trees[id]
+func (t *testPlugin) GetValues(_ context.Context, id string, paths []string) (map[string]config.Value, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	tree, ok := t.trees[id]
 	if !ok {
-		return nil, nil
+		return map[string]config.Value{}, nil
 	}
-	// Newest first: versions slice stores oldest first, so iterate in reverse.
-	result := make([]string, len(versions))
-	for i := range versions {
-		result[len(versions)-1-i] = fmt.Sprintf("v%d", i+1)
+	result := make(map[string]config.Value, len(paths))
+	for _, p := range paths {
+		if v, found := tree[p]; found {
+			result[p] = v
+		}
 	}
 	return result, nil
 }
 
-func (p *testPlugin) LoadVersion(_ context.Context, id string, version string) (*config.Tree, bool, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	versions, ok := p.trees[id]
+func (t *testPlugin) PutValues(_ context.Context, id string, values map[string]config.Value, _ *PutOptions) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	tree, ok := t.trees[id]
 	if !ok {
-		return nil, false, nil
+		tree = make(map[string]config.Value)
+		t.trees[id] = tree
 	}
-	for i := range versions {
-		label := fmt.Sprintf("v%d", i+1)
-		if label == version {
-			return versions[i], true, nil
-		}
+	for path, v := range values {
+		tree[path] = v
 	}
-	return nil, false, nil
+	return nil
 }
 
-func (p *testPlugin) DeleteVersion(_ context.Context, id string, version string) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	versions, ok := p.trees[id]
+func (t *testPlugin) DeleteValues(_ context.Context, id string, paths []string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	tree, ok := t.trees[id]
 	if !ok {
-		return errors.New("tree not found")
+		return nil
 	}
-	for i := range versions {
-		label := fmt.Sprintf("v%d", i+1)
-		if label == version {
-			p.trees[id] = slices.Delete(versions, i, i+1)
-			if len(p.trees[id]) == 0 {
-				delete(p.trees, id)
-			}
-			return nil
-		}
+	for _, p := range paths {
+		delete(tree, p)
 	}
-	return errors.New("version not found")
+	return nil
 }
 
-func (p *testPlugin) EncryptionStatus(_ context.Context) (EncryptionStatus, error) {
-	return EncryptionNone, nil
+func (t *testPlugin) ListTreeVersions(context.Context, string) ([]string, error) {
+	return nil, errors.New("versioning not supported")
 }
 
-func (p *testPlugin) InitEncryption(_ context.Context, _ []byte) error {
+func (t *testPlugin) GetTreeVersion(context.Context, string, string, []string) (map[string]config.Value, error) {
+	return nil, errors.New("versioning not supported")
+}
+
+func (t *testPlugin) RollbackTree(context.Context, string, string) error {
+	return errors.New("versioning not supported")
+}
+
+func (t *testPlugin) DeleteTreeVersion(context.Context, string, string) error {
+	return errors.New("versioning not supported")
+}
+
+func (t *testPlugin) ListValueVersions(context.Context, string, string) ([]string, error) {
+	return nil, errors.New("versioning not supported")
+}
+
+func (t *testPlugin) GetValueVersion(context.Context, string, string, string) (config.Value, bool, error) {
+	return config.Value{}, false, errors.New("versioning not supported")
+}
+
+func (t *testPlugin) RollbackValue(context.Context, string, string, string) error {
+	return errors.New("versioning not supported")
+}
+
+func (t *testPlugin) DeleteValueVersion(context.Context, string, string, string) error {
+	return errors.New("versioning not supported")
+}
+
+func (t *testPlugin) InitEncryption(context.Context, []byte) error {
 	return errors.New("encryption not supported")
 }
 
-func (p *testPlugin) RotateEncryption(_ context.Context, _, _ []byte) error {
+func (t *testPlugin) RotateEncryption(context.Context, []byte, []byte) error {
 	return errors.New("encryption not supported")
 }
 
-// --- dispense helper ------------------------------------------------------
+func (t *testPlugin) GrantAccess(context.Context, string, string, []Permission) error {
+	return errors.New("access control not supported")
+}
 
+func (t *testPlugin) RevokeAccess(context.Context, string, string, []string) error {
+	return errors.New("access control not supported")
+}
+
+func (t *testPlugin) ListAccess(context.Context, string) (map[string][]Permission, error) {
+	return nil, errors.New("access control not supported")
+}
+
+// dispense starts an in-process gRPC plugin and returns a connected client.
 func dispense(t *testing.T, impl Plugin) Plugin {
 	t.Helper()
 	client, _ := goplugin.TestPluginGRPCConn(t, false, map[string]goplugin.Plugin{
@@ -147,75 +165,128 @@ func dispense(t *testing.T, impl Plugin) Plugin {
 	return raw.(Plugin)
 }
 
-// --- tests ----------------------------------------------------------------
-
-func TestEncryptionStatusString(t *testing.T) {
-	tests := []struct {
-		s    EncryptionStatus
-		want string
-	}{
-		{EncryptionNone, "none"},
-		{EncryptionSupported, "supported"},
-		{EncryptionActive, "active"},
-		{EncryptionStatus(99), "unknown"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			if got := tt.s.String(); got != tt.want {
-				t.Errorf("EncryptionStatus(%d).String() = %q, want %q", tt.s, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestSaveAndLoad(t *testing.T) {
+func TestCapabilities(t *testing.T) {
 	p := dispense(t, newTestPlugin())
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("db/host", &config.Value{Val: "localhost", Metadata: map[string]any{"desc": "host"}})
-	_ = tree.Set("db/port", &config.Value{Val: float64(5432)})
-
-	if err := p.Save(ctx, "production", tree); err != nil {
-		t.Fatalf("Save: %v", err)
-	}
-
-	loaded, found, err := p.Load(ctx, "production")
+	caps, err := p.Capabilities(ctx)
 	if err != nil {
-		t.Fatalf("Load: %v", err)
+		t.Fatalf("Capabilities: %v", err)
 	}
-	if !found {
-		t.Fatal("Load: not found")
+	if caps.Versioning != VersioningNone {
+		t.Errorf("Versioning = %v, want VersioningNone", caps.Versioning)
 	}
-
-	v, ok := loaded.Get("db/host")
-	if !ok {
-		t.Fatal("db/host missing from loaded tree")
+	if caps.Encryption != EncryptionNone {
+		t.Errorf("Encryption = %v, want EncryptionNone", caps.Encryption)
 	}
-	if v.Val != "localhost" {
-		t.Errorf("db/host = %v, want %q", v.Val, "localhost")
+	if caps.Auth {
+		t.Error("Auth should be false")
 	}
-	if v.Metadata["desc"] != "host" {
-		t.Errorf("metadata[desc] = %v, want %q", v.Metadata["desc"], "host")
-	}
-
-	v, ok = loaded.Get("db/port")
-	if !ok {
-		t.Fatal("db/port missing from loaded tree")
-	}
-	if v.Val != float64(5432) {
-		t.Errorf("db/port = %v, want 5432", v.Val)
+	if caps.AccessControl {
+		t.Error("AccessControl should be false")
 	}
 }
 
-func TestLoadMissing(t *testing.T) {
+func TestPutAndGetValues(t *testing.T) {
 	p := dispense(t, newTestPlugin())
-	_, found, err := p.Load(context.Background(), "nonexistent")
-	if err != nil {
-		t.Fatalf("Load: %v", err)
+	ctx := context.Background()
+
+	values := map[string]config.Value{
+		"db/host": {Val: "localhost"},
+		"db/port": {Val: float64(5432)},
 	}
-	if found {
-		t.Error("Load returned found=true for missing tree")
+	if err := p.PutValues(ctx, "prod", values, nil); err != nil {
+		t.Fatalf("PutValues: %v", err)
+	}
+
+	got, err := p.GetValues(ctx, "prod", []string{"db/host", "db/port"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d values, want 2", len(got))
+	}
+	if got["db/host"].Val != "localhost" {
+		t.Errorf("db/host = %v, want %q", got["db/host"].Val, "localhost")
+	}
+}
+
+func TestGetValuesMissing(t *testing.T) {
+	p := dispense(t, newTestPlugin())
+	ctx := context.Background()
+
+	got, err := p.GetValues(ctx, "nope", []string{"a/b"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d values, want 0 for missing tree", len(got))
+	}
+}
+
+func TestPartialGet(t *testing.T) {
+	p := dispense(t, newTestPlugin())
+	ctx := context.Background()
+
+	values := map[string]config.Value{
+		"a/x": {Val: "one"},
+		"a/y": {Val: "two"},
+		"b/z": {Val: "three"},
+	}
+	_ = p.PutValues(ctx, "test", values, nil)
+
+	// Only request two of the three paths.
+	got, err := p.GetValues(ctx, "test", []string{"a/x", "b/z"})
+	if err != nil {
+		t.Fatalf("GetValues: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d values, want 2", len(got))
+	}
+	if got["a/x"].Val != "one" {
+		t.Errorf("a/x = %v, want %q", got["a/x"].Val, "one")
+	}
+	if got["b/z"].Val != "three" {
+		t.Errorf("b/z = %v, want %q", got["b/z"].Val, "three")
+	}
+}
+
+func TestPutOverwrite(t *testing.T) {
+	p := dispense(t, newTestPlugin())
+	ctx := context.Background()
+
+	_ = p.PutValues(ctx, "app", map[string]config.Value{
+		"app/name": {Val: "old"},
+	}, nil)
+	_ = p.PutValues(ctx, "app", map[string]config.Value{
+		"app/name": {Val: "new"},
+	}, nil)
+
+	got, _ := p.GetValues(ctx, "app", []string{"app/name"})
+	if got["app/name"].Val != "new" {
+		t.Errorf("Val = %v, want %q", got["app/name"].Val, "new")
+	}
+}
+
+func TestDeleteValues(t *testing.T) {
+	p := dispense(t, newTestPlugin())
+	ctx := context.Background()
+
+	_ = p.PutValues(ctx, "test", map[string]config.Value{
+		"a/x": {Val: "one"},
+		"a/y": {Val: "two"},
+	}, nil)
+
+	if err := p.DeleteValues(ctx, "test", []string{"a/x"}); err != nil {
+		t.Fatalf("DeleteValues: %v", err)
+	}
+
+	got, _ := p.GetValues(ctx, "test", []string{"a/x", "a/y"})
+	if _, found := got["a/x"]; found {
+		t.Error("a/x should have been deleted")
+	}
+	if got["a/y"].Val != "two" {
+		t.Errorf("a/y = %v, want %q", got["a/y"].Val, "two")
 	}
 }
 
@@ -223,17 +294,17 @@ func TestDeleteTree(t *testing.T) {
 	p := dispense(t, newTestPlugin())
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("a/b", &config.Value{Val: "x"})
-	_ = p.Save(ctx, "temp", tree)
+	_ = p.PutValues(ctx, "temp", map[string]config.Value{
+		"a/b": {Val: "x"},
+	}, nil)
 
-	if err := p.Delete(ctx, "temp"); err != nil {
-		t.Fatalf("Delete: %v", err)
+	if err := p.DeleteTree(ctx, "temp"); err != nil {
+		t.Fatalf("DeleteTree: %v", err)
 	}
 
-	_, found, _ := p.Load(ctx, "temp")
-	if found {
-		t.Error("tree still found after Delete")
+	got, _ := p.GetValues(ctx, "temp", []string{"a/b"})
+	if len(got) != 0 {
+		t.Error("tree still has values after DeleteTree")
 	}
 }
 
@@ -241,189 +312,15 @@ func TestListTrees(t *testing.T) {
 	p := dispense(t, newTestPlugin())
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("a/b", &config.Value{Val: "x"})
-
-	_ = p.Save(ctx, "alpha", tree)
-	_ = p.Save(ctx, "beta", tree)
+	_ = p.PutValues(ctx, "one", map[string]config.Value{"a/b": {Val: "x"}}, nil)
+	_ = p.PutValues(ctx, "two", map[string]config.Value{"a/b": {Val: "y"}}, nil)
 
 	ids, err := p.ListTrees(ctx)
 	if err != nil {
 		t.Fatalf("ListTrees: %v", err)
 	}
-	slices.Sort(ids)
-	want := []string{"alpha", "beta"}
-	if !slices.Equal(ids, want) {
-		t.Errorf("ListTrees() = %v, want %v", ids, want)
-	}
-}
-
-func TestSupportsVersioning(t *testing.T) {
-	p := dispense(t, newTestPlugin())
-	supported, err := p.SupportsVersioning(context.Background())
-	if err != nil {
-		t.Fatalf("SupportsVersioning: %v", err)
-	}
-	if !supported {
-		t.Error("SupportsVersioning() = false, want true")
-	}
-}
-
-func TestVersioning(t *testing.T) {
-	p := dispense(t, newTestPlugin())
-	ctx := context.Background()
-
-	// Save two versions.
-	tree1 := config.NewTree()
-	_ = tree1.Set("app/version", &config.Value{Val: "1.0"})
-	_ = p.Save(ctx, "myapp", tree1)
-
-	tree2 := config.NewTree()
-	_ = tree2.Set("app/version", &config.Value{Val: "2.0"})
-	_ = p.Save(ctx, "myapp", tree2)
-
-	// Latest should be v2.
-	latest, found, err := p.Load(ctx, "myapp")
-	if err != nil || !found {
-		t.Fatalf("Load latest: err=%v, found=%v", err, found)
-	}
-	v, _ := latest.Get("app/version")
-	if v.Val != "2.0" {
-		t.Errorf("latest version = %v, want %q", v.Val, "2.0")
-	}
-
-	// List versions.
-	versions, err := p.ListVersions(ctx, "myapp")
-	if err != nil {
-		t.Fatalf("ListVersions: %v", err)
-	}
-	if len(versions) != 2 {
-		t.Fatalf("got %d versions, want 2", len(versions))
-	}
-	// Newest first.
-	if versions[0] != "v2" || versions[1] != "v1" {
-		t.Errorf("versions = %v, want [v2, v1]", versions)
-	}
-
-	// Load older version.
-	old, found, err := p.LoadVersion(ctx, "myapp", "v1")
-	if err != nil || !found {
-		t.Fatalf("LoadVersion v1: err=%v, found=%v", err, found)
-	}
-	v, _ = old.Get("app/version")
-	if v.Val != "1.0" {
-		t.Errorf("v1 version = %v, want %q", v.Val, "1.0")
-	}
-}
-
-func TestLoadVersionMissing(t *testing.T) {
-	p := dispense(t, newTestPlugin())
-	_, found, err := p.LoadVersion(context.Background(), "nope", "v1")
-	if err != nil {
-		t.Fatalf("LoadVersion: %v", err)
-	}
-	if found {
-		t.Error("LoadVersion returned found=true for missing tree")
-	}
-}
-
-func TestDeleteVersion(t *testing.T) {
-	p := dispense(t, newTestPlugin())
-	ctx := context.Background()
-
-	// Save three versions.
-	for i := 1; i <= 3; i++ {
-		tree := config.NewTree()
-		_ = tree.Set("app/version", &config.Value{Val: fmt.Sprintf("%d.0", i)})
-		_ = p.Save(ctx, "myapp", tree)
-	}
-
-	// Delete the middle version.
-	if err := p.DeleteVersion(ctx, "myapp", "v2"); err != nil {
-		t.Fatalf("DeleteVersion: %v", err)
-	}
-
-	versions, err := p.ListVersions(ctx, "myapp")
-	if err != nil {
-		t.Fatalf("ListVersions: %v", err)
-	}
-	if len(versions) != 2 {
-		t.Fatalf("got %d versions after delete, want 2", len(versions))
-	}
-
-	// Latest should still be the last saved version.
-	latest, found, _ := p.Load(ctx, "myapp")
-	if !found {
-		t.Fatal("tree not found after DeleteVersion")
-	}
-	v, _ := latest.Get("app/version")
-	if v.Val != "3.0" {
-		t.Errorf("latest = %v, want %q", v.Val, "3.0")
-	}
-}
-
-func TestDeleteVersionNonexistent(t *testing.T) {
-	p := dispense(t, newTestPlugin())
-	err := p.DeleteVersion(context.Background(), "nope", "v1")
-	if err == nil {
-		t.Error("DeleteVersion should return error for missing tree")
-	}
-}
-
-func TestEncryptionStatusOverGRPC(t *testing.T) {
-	p := dispense(t, newTestPlugin())
-	status, err := p.EncryptionStatus(context.Background())
-	if err != nil {
-		t.Fatalf("EncryptionStatus: %v", err)
-	}
-	if status != EncryptionNone {
-		t.Errorf("EncryptionStatus() = %v, want EncryptionNone", status)
-	}
-}
-
-func TestInitEncryptionUnsupported(t *testing.T) {
-	p := dispense(t, newTestPlugin())
-	err := p.InitEncryption(context.Background(), []byte("secret"))
-	if err == nil {
-		t.Error("InitEncryption should return error for unsupported store")
-	}
-}
-
-func TestRotateEncryptionUnsupported(t *testing.T) {
-	p := dispense(t, newTestPlugin())
-	err := p.RotateEncryption(context.Background(), []byte("old"), []byte("new"))
-	if err == nil {
-		t.Error("RotateEncryption should return error for unsupported store")
-	}
-}
-
-func TestValidatorsNotStored(t *testing.T) {
-	p := dispense(t, newTestPlugin())
-	ctx := context.Background()
-
-	tree := config.NewTree()
-	_ = tree.Set("key", &config.Value{
-		Val: "value",
-		Validators: []config.ValidateFunc{
-			func(any, config.TreeReader) []config.ValidationResult {
-				return []config.ValidationResult{{Severity: config.Blocking, Message: "fail"}}
-			},
-		},
-	})
-
-	_ = p.Save(ctx, "test", tree)
-
-	loaded, found, _ := p.Load(ctx, "test")
-	if !found {
-		t.Fatal("not found")
-	}
-
-	v, ok := loaded.Get("key")
-	if !ok {
-		t.Fatal("key missing")
-	}
-	if len(v.Validators) != 0 {
-		t.Errorf("got %d validators, want 0 (validators must not be stored)", len(v.Validators))
+	if len(ids) != 2 {
+		t.Fatalf("got %d ids, want 2", len(ids))
 	}
 }
 
@@ -431,27 +328,288 @@ func TestMetadataPreserved(t *testing.T) {
 	p := dispense(t, newTestPlugin())
 	ctx := context.Background()
 
-	tree := config.NewTree()
-	_ = tree.Set("db/host", &config.Value{
-		Val:      "localhost",
-		Metadata: map[string]any{"description": "Database host", "required": true},
-	})
+	_ = p.PutValues(ctx, "meta", map[string]config.Value{
+		"key": {Val: "value", Metadata: map[string]any{"description": "test key"}},
+	}, nil)
 
-	_ = p.Save(ctx, "test", tree)
+	got, _ := p.GetValues(ctx, "meta", []string{"key"})
+	if got["key"].Metadata["description"] != "test key" {
+		t.Errorf("description = %v, want %q", got["key"].Metadata["description"], "test key")
+	}
+}
 
-	loaded, found, _ := p.Load(ctx, "test")
-	if !found {
-		t.Fatal("not found")
+func TestValidatorsNotStored(t *testing.T) {
+	p := dispense(t, newTestPlugin())
+	ctx := context.Background()
+
+	_ = p.PutValues(ctx, "val", map[string]config.Value{
+		"key": {
+			Val:        "test",
+			Validators: []config.ValidateFunc{func(any, config.TreeReader) []config.ValidationResult { return nil }},
+		},
+	}, nil)
+
+	got, _ := p.GetValues(ctx, "val", []string{"key"})
+	if len(got["key"].Validators) != 0 {
+		t.Error("Validators should not be stored (they cannot cross gRPC)")
+	}
+}
+
+func TestVersioningNotSupported(t *testing.T) {
+	p := dispense(t, newTestPlugin())
+	ctx := context.Background()
+
+	_, err := p.ListTreeVersions(ctx, "any")
+	if err == nil {
+		t.Error("ListTreeVersions should return error")
 	}
 
-	v, ok := loaded.Get("db/host")
+	_, err = p.GetTreeVersion(ctx, "any", "v1", nil)
+	if err == nil {
+		t.Error("GetTreeVersion should return error")
+	}
+
+	if err := p.RollbackTree(ctx, "any", "v1"); err == nil {
+		t.Error("RollbackTree should return error")
+	}
+
+	if err := p.DeleteTreeVersion(ctx, "any", "v1"); err == nil {
+		t.Error("DeleteTreeVersion should return error")
+	}
+
+	_, err = p.ListValueVersions(ctx, "any", "path")
+	if err == nil {
+		t.Error("ListValueVersions should return error")
+	}
+
+	_, _, err = p.GetValueVersion(ctx, "any", "path", "v1")
+	if err == nil {
+		t.Error("GetValueVersion should return error")
+	}
+
+	if err := p.RollbackValue(ctx, "any", "path", "v1"); err == nil {
+		t.Error("RollbackValue should return error")
+	}
+
+	if err := p.DeleteValueVersion(ctx, "any", "path", "v1"); err == nil {
+		t.Error("DeleteValueVersion should return error")
+	}
+}
+
+func TestEncryptionNotSupported(t *testing.T) {
+	p := dispense(t, newTestPlugin())
+	ctx := context.Background()
+
+	caps, _ := p.Capabilities(ctx)
+	if caps.Encryption != EncryptionNone {
+		t.Errorf("Encryption = %v, want EncryptionNone", caps.Encryption)
+	}
+
+	if err := p.InitEncryption(ctx, []byte("pass")); err == nil {
+		t.Error("InitEncryption should return error")
+	}
+
+	if err := p.RotateEncryption(ctx, []byte("old"), []byte("new")); err == nil {
+		t.Error("RotateEncryption should return error")
+	}
+}
+
+func TestAccessControlNotSupported(t *testing.T) {
+	p := dispense(t, newTestPlugin())
+	ctx := context.Background()
+
+	if err := p.GrantAccess(ctx, "id", "user", []Permission{{Path: "a/b", Actions: []Action{ActionRead}}}); err == nil {
+		t.Error("GrantAccess should return error")
+	}
+
+	if err := p.RevokeAccess(ctx, "id", "user", []string{"a/b"}); err == nil {
+		t.Error("RevokeAccess should return error")
+	}
+
+	_, err := p.ListAccess(ctx, "id")
+	if err == nil {
+		t.Error("ListAccess should return error")
+	}
+}
+
+func TestAuthNotSupported(t *testing.T) {
+	p := dispense(t, newTestPlugin())
+	ctx := context.Background()
+
+	methods, err := p.AuthMethods(ctx)
+	if err != nil {
+		t.Fatalf("AuthMethods: %v", err)
+	}
+	if len(methods) != 0 {
+		t.Errorf("got %d auth methods, want 0", len(methods))
+	}
+
+	_, err = p.Login(ctx, "userpass", map[string]string{"user": "admin"})
+	if err == nil {
+		t.Error("Login should return error")
+	}
+}
+
+// --- Versioned tree test plugin ---
+
+type versionedTreePlugin struct {
+	testPlugin
+	versions map[string][]map[string]config.Value // tree id -> list of snapshots
+}
+
+func newVersionedTreePlugin() *versionedTreePlugin {
+	return &versionedTreePlugin{
+		testPlugin: *newTestPlugin(),
+		versions:   make(map[string][]map[string]config.Value),
+	}
+}
+
+func (v *versionedTreePlugin) Capabilities(context.Context) (*Capabilities, error) {
+	return &Capabilities{
+		Versioning: VersioningTree,
+		Encryption: EncryptionNone,
+	}, nil
+}
+
+func (v *versionedTreePlugin) PutValues(_ context.Context, id string, values map[string]config.Value, _ *PutOptions) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	tree, ok := v.trees[id]
 	if !ok {
-		t.Fatal("db/host missing")
+		tree = make(map[string]config.Value)
+		v.trees[id] = tree
 	}
-	if v.Metadata["description"] != "Database host" {
-		t.Errorf("description = %v, want %q", v.Metadata["description"], "Database host")
+	// Snapshot current state before writing.
+	snap := make(map[string]config.Value, len(tree))
+	for k, val := range tree {
+		snap[k] = val
 	}
-	if v.Metadata["required"] != true {
-		t.Errorf("required = %v, want true", v.Metadata["required"])
+	v.versions[id] = append(v.versions[id], snap)
+
+	for path, val := range values {
+		tree[path] = val
+	}
+	return nil
+}
+
+func (v *versionedTreePlugin) ListTreeVersions(_ context.Context, id string) ([]string, error) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	snaps := v.versions[id]
+	versions := make([]string, len(snaps))
+	for i := range snaps {
+		// Newest first.
+		versions[i] = fmt.Sprintf("v%d", len(snaps)-i)
+	}
+	return versions, nil
+}
+
+func (v *versionedTreePlugin) GetTreeVersion(_ context.Context, id string, version string, paths []string) (map[string]config.Value, error) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	snaps := v.versions[id]
+	idx, err := v.versionIndex(id, version)
+	if err != nil {
+		return nil, err
+	}
+	snap := snaps[idx]
+	result := make(map[string]config.Value)
+	for _, p := range paths {
+		if val, ok := snap[p]; ok {
+			result[p] = val
+		}
+	}
+	return result, nil
+}
+
+func (v *versionedTreePlugin) RollbackTree(_ context.Context, id string, version string) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	idx, err := v.versionIndex(id, version)
+	if err != nil {
+		return err
+	}
+	snap := v.versions[id][idx]
+	tree := make(map[string]config.Value, len(snap))
+	for k, val := range snap {
+		tree[k] = val
+	}
+	v.trees[id] = tree
+	return nil
+}
+
+func (v *versionedTreePlugin) DeleteTreeVersion(_ context.Context, id string, version string) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	idx, err := v.versionIndex(id, version)
+	if err != nil {
+		return err
+	}
+	snaps := v.versions[id]
+	v.versions[id] = append(snaps[:idx], snaps[idx+1:]...)
+	return nil
+}
+
+func (v *versionedTreePlugin) versionIndex(id string, version string) (int, error) {
+	snaps := v.versions[id]
+	for i := range snaps {
+		label := fmt.Sprintf("v%d", i+1)
+		if label == version {
+			return i, nil
+		}
+	}
+	return 0, fmt.Errorf("version %q not found for tree %q", version, id)
+}
+
+func TestTreeVersioning(t *testing.T) {
+	impl := newVersionedTreePlugin()
+	p := dispense(t, impl)
+	ctx := context.Background()
+
+	caps, _ := p.Capabilities(ctx)
+	if caps.Versioning != VersioningTree {
+		t.Fatalf("Versioning = %v, want VersioningTree", caps.Versioning)
+	}
+
+	// Write first version.
+	_ = p.PutValues(ctx, "app", map[string]config.Value{
+		"app/name": {Val: "v1"},
+	}, nil)
+	// Write second version.
+	_ = p.PutValues(ctx, "app", map[string]config.Value{
+		"app/name": {Val: "v2"},
+	}, nil)
+
+	versions, err := p.ListTreeVersions(ctx, "app")
+	if err != nil {
+		t.Fatalf("ListTreeVersions: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("got %d versions, want 2", len(versions))
+	}
+
+	// Get first version's data.
+	v1, err := p.GetTreeVersion(ctx, "app", "v1", []string{"app/name"})
+	if err != nil {
+		t.Fatalf("GetTreeVersion v1: %v", err)
+	}
+	// v1 is the snapshot taken before the first PutValues (empty tree).
+	if len(v1) != 0 {
+		t.Errorf("v1 should be empty (snapshot before first write), got %v", v1)
+	}
+
+	// Rollback to v1.
+	if err := p.RollbackTree(ctx, "app", "v1"); err != nil {
+		t.Fatalf("RollbackTree: %v", err)
+	}
+	got, _ := p.GetValues(ctx, "app", []string{"app/name"})
+	if _, found := got["app/name"]; found {
+		t.Error("after rollback to v1, app/name should not exist")
+	}
+
+	// Delete a version.
+	if err := p.DeleteTreeVersion(ctx, "app", "v2"); err != nil {
+		t.Fatalf("DeleteTreeVersion: %v", err)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

This PR completes the store plugin API restructure, moving from coarse-grained tree-level operations (`Save`/`Load`/`Delete`) to fine-grained value-level operations (`GetValues`/`PutValues`/`DeleteValues`). It also introduces comprehensive support for authentication, access control, versioning at both tree and value levels, and encryption management.

**Key changes:**
- Replace `Save(tree)` / `Load()` / `Delete()` with `GetValues(paths)` / `PutValues(values)` / `DeleteValues(paths)`
- Add `Capabilities()` RPC to report supported features (versioning mode, encryption, auth, access control)
- Add authentication flow: `AuthMethods()` and `Login(method, credentials)`
- Add tree-level versioning: `ListTreeVersions()`, `GetTreeVersion()`, `RollbackTree()`, `DeleteTreeVersion()`
- Add value-level versioning: `ListValueVersions()`, `GetValueVersion()`, `RollbackValue()`, `DeleteValueVersion()`
- Add access control: `GrantAccess()`, `RevokeAccess()`, `ListAccess()`
- Wire Check-and-Set (CAS) support via `PutOptions.CASVersions`
- Update proto definitions and regenerate gRPC code
- Update example plugins (JSON and memory stores) to implement new API
- Update all tests to use new API patterns

## Why is this change needed?

The original tree-level API was too coarse-grained for real-world use cases:
- **Lost updates**: Concurrent writes to the same tree would silently overwrite each other
- **Inefficiency**: Saving/loading entire trees when only a few values changed
- **Limited versioning**: No way to version individual values independently
- **No auth/access control**: Plugins couldn't implement fine-grained permissions
- **No CAS support**: No mechanism to prevent accidental overwrites

The new API enables:
- **Granular operations**: Work with individual values, not entire trees
- **Optimistic concurrency**: CAS support prevents lost updates
- **Flexible versioning**: Support both tree-level and value-level versioning
- **Authentication**: Plugins can implement auth methods (token, OIDC, AppRole, etc.)
- **Access control**: Fine-grained permissions per path and user
- **Better scalability**: Backends like Vault can optimize per-path operations

## How was this tested?

- [x] `make check` passes (all existing tests updated and passing)
- [x] New/updated tests cover the change:
  - Updated all example plugin tests to use new API (`TestPutAndGetValues`, `TestDeleteValues`, `TestCapabilities`, etc.)
  - Added tests for value filtering, tree deletion, and access control stubs
  - Verified versioning/encryption/auth error handling
- [x] Manual verification:
  - Both example plugins (JSON and memory) fully implement new API
  - Proto definitions compile and generate valid gRPC code
  - All test cases pass with new value-level operations

## Type of Change

- [x] Breaking change (store plugin API restructure)
- [x] New feature (authentication, access control, value-level versioning, CAS)
- [x] Refactor / code cleanup

## Checklist

- [x] My code follows the project's code style (`gofmt`, `go vet`)
- [x] I have added/updated tests for my changes
- [x] I have updated documentation (TODOS.md with implementation roadmap)
- [x] If I changed `.proto` files, I ran `make proto` and committed the generated code
- [x] My commits are focused and have clear messages

## Additional Notes

**TODOS.md** has been significantly expanded to track remaining work:
- Vault plugin implementation details (auth, KV v2 operations, CAS, versioning, encryption, access control)
- Engine & UI integration (version browsing, rollback, auth flow, CAS conflict resolution)
- Documentation updates needed
- Structured error types for common failures
- Integration tests against real Vault

The core API is now stable and all tests pass. The next phase is

https://claude.ai/code/session_01UuepEdTuCDxGtT7Vtc334E