### PR TITLE
Fix apply view output handling with persistent channel reads

### DIFF
--- a/internal/ui/tui/apply_view.go
+++ b/internal/ui/tui/apply_view.go
@@ -38,6 +38,8 @@ type ApplyView struct {
 	cancelFn context.CancelFunc
 	width    int
 	height   int
+	outputCh <-chan core.ApplyOutput // persisted for chained reads
+	resultCh <-chan ApplyDoneMsg     // carries the apply result
 }
 
 // NewApplyView creates a new apply view.
@@ -76,19 +78,26 @@ func (v *ApplyView) StartApply(ctx context.Context, controller *ui.UIController)
 	v.cancelFn = cancel
 
 	outputCh := make(chan core.ApplyOutput, 100)
+	resultCh := make(chan ApplyDoneMsg, 1)
+
+	v.outputCh = outputCh
+	v.resultCh = resultCh
 
 	// Start the apply goroutine.
 	go func() {
-		_, _ = controller.Apply(applyCtx, "", outputCh)
+		result, err := controller.Apply(applyCtx, "", outputCh)
+		resultCh <- ApplyDoneMsg{Result: result, Err: err}
 	}()
 
 	return tea.Batch(
 		v.spinner.Tick,
-		v.readOutput(outputCh),
+		v.readOutput(),
 	)
 }
 
-func (v *ApplyView) readOutput(ch <-chan core.ApplyOutput) tea.Cmd {
+func (v *ApplyView) readOutput() tea.Cmd {
+	ch := v.outputCh
+	rch := v.resultCh
 	return func() tea.Msg {
 		var batch []core.ApplyOutput
 		timer := time.NewTimer(50 * time.Millisecond)
@@ -102,7 +111,7 @@ func (v *ApplyView) readOutput(ch <-chan core.ApplyOutput) tea.Cmd {
 					if len(batch) > 0 {
 						return ApplyOutputMsg{Lines: batch}
 					}
-					return ApplyDoneMsg{}
+					return <-rch
 				}
 				batch = append(batch, line)
 				// If we've accumulated enough, send the batch.
@@ -136,7 +145,7 @@ func (v ApplyView) UpdateApply(msg tea.Msg) (ApplyView, tea.Cmd) {
 			v.cursor = len(v.lines) - 1
 			v.ensureVisible()
 		}
-		return v, nil
+		return v, v.readOutput()
 
 	case ApplyDoneMsg:
 		v.running = false


### PR DESCRIPTION
## What does this PR do?

This PR fixes the apply view's output handling by persisting channel references and ensuring continuous reading of apply results. The changes modify how `ApplyView` manages the output and result channels from the apply operation, allowing for proper chained reads and result delivery.

Key changes:
- Add `outputCh` and `resultCh` fields to `ApplyView` struct for persistent channel access
- Store channel references during `StartApply()` instead of passing them as parameters
- Modify `readOutput()` to access channels from the view state rather than parameters
- Return the actual apply result from the result channel instead of an empty `ApplyDoneMsg`
- Ensure `readOutput()` is called again after processing output messages to maintain the read loop

## Why is this change needed?

The previous implementation had a critical flaw: the `readOutput()` command was only called once during `StartApply()`, and it would return an empty `ApplyDoneMsg` when the output channel closed. This meant:

1. The result from `controller.Apply()` was being discarded
2. The read loop would terminate prematurely without properly delivering the final result
3. Subsequent output messages wouldn't trigger another read cycle

By persisting the channels in the view struct and continuously calling `readOutput()` after each output batch, we ensure:
- All output is properly consumed
- The actual apply result (with any errors) is delivered to the UI
- The read loop continues until completion

## How was this tested?

- [ ] `make check` passes
- [ ] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [ ] My code follows the project's code style (`gofmt`, `go vet`)
- [ ] I have added/updated tests for my changes
- [ ] I have updated documentation if needed
- [ ] If I changed `.proto` files, I ran `make proto` and committed the generated code
- [ ] My commits are focused and have clear messages

## Additional Notes

This fix ensures that apply operation results are properly propagated through the TUI, preventing loss of error information and ensuring the apply view correctly reflects the final state of the operation.

https://claude.ai/code/session_01UjZgjMkJbj7W55AbCFhzRD