### PR TITLE
feat(tui): implement UI labels in TUI provider with new builtin labels

### DIFF
--- a/internal/ui/tui/app.go
+++ b/internal/ui/tui/app.go
@@ -277,6 +277,23 @@ func (a *App) updateTreeView(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (a *App) updateEditorView(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// When confirming, delegate all input to the editor.
+	if a.editorView.IsConfirming() {
+		var cmd tea.Cmd
+		a.editorView, cmd = a.editorView.UpdateEditor(msg)
+		// If confirmation was declined (dirty reset to false), go back.
+		if !a.editorView.IsConfirming() && !a.editorView.dirty {
+			a.statusMsg = "Change cancelled"
+			a.activeView = viewTree
+			return a, nil
+		}
+		// If confirmation accepted, commit the value.
+		if !a.editorView.IsConfirming() && a.editorView.dirty {
+			return a.commitEditorValue()
+		}
+		return a, cmd
+	}
+
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		switch keyMsg.String() {
 		case "esc":
@@ -285,16 +302,17 @@ func (a *App) updateEditorView(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		case "enter":
 			if a.editorView.dirty {
-				val := a.editorView.CommitValue()
-				err := a.controller.SetValue(a.ctx, a.editorView.path, val)
-				if err != nil {
-					a.statusMsg = "Set failed: " + err.Error()
-				} else {
-					a.statusMsg = fmt.Sprintf("Updated %s", a.editorView.path)
-					a.refreshTreeView()
+				// Block save if pattern validation fails.
+				if a.editorView.HasPatternError() {
+					a.statusMsg = "Fix pattern errors before saving"
+					return a, nil
 				}
-				a.activeView = viewTree
-				return a, nil
+				// Check if confirmation is required.
+				if a.editorView.NeedsConfirmation() {
+					a.editorView.StartConfirmation()
+					return a, nil
+				}
+				return a.commitEditorValue()
 			}
 			a.activeView = viewTree
 			return a, nil
@@ -304,6 +322,19 @@ func (a *App) updateEditorView(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	a.editorView, cmd = a.editorView.UpdateEditor(msg)
 	return a, cmd
+}
+
+func (a *App) commitEditorValue() (tea.Model, tea.Cmd) {
+	val := a.editorView.CommitValue()
+	err := a.controller.SetValue(a.ctx, a.editorView.path, val)
+	if err != nil {
+		a.statusMsg = "Set failed: " + err.Error()
+	} else {
+		a.statusMsg = fmt.Sprintf("Updated %s", a.editorView.path)
+		a.refreshTreeView()
+	}
+	a.activeView = viewTree
+	return a, nil
 }
 
 func (a *App) updateComponentView(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/internal/ui/tui/app_test.go
+++ b/internal/ui/tui/app_test.go
@@ -28,6 +28,123 @@ func newMockConfig() *mockConfig {
 	return &mockConfig{tree: t}
 }
 
+// newMockConfigWithLabels creates a mock config with various UI labels set for testing.
+func newMockConfigWithLabels() *mockConfig {
+	t := config.NewTree()
+	_ = t.Set("database/type", &config.Value{
+		Val: "postgres",
+		Metadata: map[string]any{
+			"ui.enum":        []string{"postgres", "mysql", "sqlite"},
+			"ui.order":       1,
+			"ui.section":     "Connection",
+			"ui.displayName": "Database Engine",
+		},
+	})
+	_ = t.Set("database/host", &config.Value{
+		Val: "localhost",
+		Metadata: map[string]any{
+			"core.description": "Database hostname",
+			"ui.order":         2,
+			"ui.section":       "Connection",
+			"ui.placeholder":   "Enter hostname...",
+			"config.required":  true,
+		},
+	})
+	_ = t.Set("database/port", &config.Value{
+		Val: 5432,
+		Metadata: map[string]any{
+			"ui.order":   3,
+			"ui.section": "Connection",
+			"ui.pattern": `^\d+$`,
+		},
+	})
+	_ = t.Set("database/password", &config.Value{
+		Val: "s3cret",
+		Metadata: map[string]any{
+			"ui.password": true,
+			"ui.confirm":  true,
+			"ui.order":    4,
+			"ui.section":  "Connection",
+		},
+	})
+	_ = t.Set("database/internal-key", &config.Value{
+		Val:      "should-not-appear",
+		Metadata: map[string]any{"ui.hidden": true},
+	})
+	_ = t.Set("database/pg-options", &config.Value{
+		Val: "sslmode=require",
+		Metadata: map[string]any{
+			"ui.showIf":  "database/type=postgres",
+			"ui.order":   5,
+			"ui.section": "Connection",
+		},
+	})
+	_ = t.Set("database/mysql-charset", &config.Value{
+		Val: "utf8mb4",
+		Metadata: map[string]any{
+			"ui.showIf":  "database/type=mysql",
+			"ui.order":   5,
+			"ui.section": "Connection",
+		},
+	})
+	_ = t.Set("app/name", &config.Value{
+		Val: "myapp",
+		Metadata: map[string]any{
+			"ui.readonly":    true,
+			"ui.group":       "Application",
+			"ui.displayName": "Application Name",
+		},
+	})
+	_ = t.Set("app/version", &config.Value{
+		Val: "1.0.0",
+		Metadata: map[string]any{
+			"core.deprecated": "Use app/release-version instead",
+			"ui.group":        "Application",
+		},
+	})
+	_ = t.Set("redis/url", &config.Value{Val: "redis://localhost:6379"})
+	return &mockConfig{tree: t}
+}
+
+// setupTestControllerWithLabels creates a test controller with label-rich config values.
+func setupTestControllerWithLabels(t *testing.T) *ui.UIController {
+	t.Helper()
+
+	reg := core.NewRegistry()
+	mc := newMockConfigWithLabels()
+	ms := newMockStore()
+
+	if err := reg.RegisterConfig("mock", func(string, map[string]any) (config.Plugin, error) {
+		return mc, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.RegisterStore("mock", func(string, map[string]any) (store.Plugin, error) {
+		return ms, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := &core.WorkspaceConfig{
+		Version: "1",
+		Config:  core.ProviderRef{Provider: "mock"},
+		Store:   core.ProviderRef{Provider: "mock"},
+		Components: []core.ComponentDef{
+			{Name: "database", Paths: []string{"database/"}, Mandatory: true, Description: "PostgreSQL database"},
+			{Name: "app", Paths: []string{"app/"}, Dependencies: []string{"database"}, Description: "Application config"},
+			{Name: "redis", Paths: []string{"redis/"}, Dependencies: []string{"database"}, Description: "Redis cache"},
+		},
+		Dir: t.TempDir(),
+	}
+
+	eng, err := core.NewEngine(reg, ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ui.NewUIController(eng)
+}
+
 func (m *mockConfig) List(_ context.Context) ([]string, error) {
 	return m.tree.List(), nil
 }

--- a/internal/ui/tui/styles.go
+++ b/internal/ui/tui/styles.go
@@ -97,4 +97,41 @@ var (
 	// SpinnerStyle is used for the activity spinner.
 	SpinnerStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("205"))
+
+	// PasswordStyle is used for masked password values.
+	PasswordStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("8"))
+
+	// ReadonlyBadgeStyle is used for the [readonly] badge.
+	ReadonlyBadgeStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("8")).
+				Italic(true)
+
+	// RequiredBadgeStyle is used for the [required] badge.
+	RequiredBadgeStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("9"))
+
+	// DeprecatedStyle is used for deprecated value paths.
+	DeprecatedStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("8")).
+			Strikethrough(true)
+
+	// SectionHeaderStyle is used for section headings in the tree view.
+	SectionHeaderStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("14")).
+				Bold(true).
+				Underline(true)
+
+	// GroupBadgeStyle is used for the group badge in the tree view.
+	GroupBadgeStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("6"))
+
+	// ConfirmStyle is used for the [confirm] badge.
+	ConfirmStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("11"))
+
+	// EnumBadgeStyle is used for the enum indicator badge.
+	EnumBadgeStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("6")).
+			Italic(true)
 )

--- a/internal/ui/tui/tree_view.go
+++ b/internal/ui/tui/tree_view.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/MrWong99/zhi/internal/ui"
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/labels"
 )
 
 // TreeView displays the configuration tree as a navigable list.
 type TreeView struct {
 	controller      *ui.UIController
-	paths           []string
-	filteredPaths   []string
+	paths           []string // all paths after label-aware sorting
+	filteredPaths   []string // visible paths after filtering (text filter + label visibility)
 	cursor          int
 	offset          int
 	filter          string
@@ -30,7 +31,33 @@ type TreeView struct {
 // NewTreeView creates a new tree view.
 func NewTreeView(controller *ui.UIController, tree *config.Tree) TreeView {
 	paths := tree.List()
-	sort.Strings(paths)
+
+	// Sort paths using label-aware ordering: first by ui.order, then
+	// by ui.group, then alphabetically within each group.
+	sort.Slice(paths, func(i, j int) bool {
+		vi, _ := tree.Get(paths[i])
+		vj, _ := tree.Get(paths[j])
+
+		orderI := labels.GetOrder(vi.Metadata)
+		orderJ := labels.GetOrder(vj.Metadata)
+		if orderI != orderJ {
+			return orderI < orderJ
+		}
+
+		groupI := labels.GetGroup(vi.Metadata)
+		groupJ := labels.GetGroup(vj.Metadata)
+		if groupI != groupJ {
+			return groupI < groupJ
+		}
+
+		sectionI := labels.GetSection(vi.Metadata)
+		sectionJ := labels.GetSection(vj.Metadata)
+		if sectionI != sectionJ {
+			return sectionI < sectionJ
+		}
+
+		return paths[i] < paths[j]
+	})
 
 	componentStates := make(map[string]bool)
 	componentNames := make(map[string]string)
@@ -45,15 +72,55 @@ func NewTreeView(controller *ui.UIController, tree *config.Tree) TreeView {
 		}
 	}
 
-	return TreeView{
+	tv := TreeView{
 		controller:      controller,
 		paths:           paths,
-		filteredPaths:   paths,
 		componentStates: componentStates,
 		componentNames:  componentNames,
 		width:           80,
 		height:          20,
 	}
+	tv.filteredPaths = tv.visiblePaths()
+	return tv
+}
+
+// visiblePaths returns paths after applying label-based visibility rules
+// (ui.hidden, ui.showIf) and the current text filter.
+func (v *TreeView) visiblePaths() []string {
+	var visible []string
+	for _, p := range v.paths {
+		val, ok := v.controller.GetValue(p)
+		if !ok {
+			continue
+		}
+
+		// ui.hidden: completely hide.
+		if labels.IsHidden(val.Metadata) {
+			continue
+		}
+
+		// ui.showIf: conditional visibility.
+		if condPath, condVal := labels.ParseShowIf(val.Metadata); condPath != "" {
+			depVal, depOk := v.controller.GetValue(condPath)
+			if !depOk || fmt.Sprintf("%v", depVal.Val) != condVal {
+				continue
+			}
+		}
+
+		// Text filter.
+		if v.filter != "" {
+			lf := strings.ToLower(v.filter)
+			lp := strings.ToLower(p)
+			// Also check display name.
+			dn := strings.ToLower(labels.GetDisplayName(val.Metadata))
+			if !strings.Contains(lp, lf) && !strings.Contains(dn, lf) {
+				continue
+			}
+		}
+
+		visible = append(visible, p)
+	}
+	return visible
 }
 
 // SetSize updates the view dimensions.
@@ -77,7 +144,7 @@ func (v *TreeView) SelectedPath() string {
 func (v *TreeView) ClearFilter() {
 	v.filter = ""
 	v.filtering = false
-	v.filteredPaths = v.paths
+	v.filteredPaths = v.visiblePaths()
 	v.cursor = 0
 	v.offset = 0
 }
@@ -129,18 +196,7 @@ func (v TreeView) UpdateTree(msg tea.Msg) (TreeView, tea.Cmd) {
 }
 
 func (v *TreeView) applyFilter() {
-	if v.filter == "" {
-		v.filteredPaths = v.paths
-	} else {
-		var filtered []string
-		lowerFilter := strings.ToLower(v.filter)
-		for _, p := range v.paths {
-			if strings.Contains(strings.ToLower(p), lowerFilter) {
-				filtered = append(filtered, p)
-			}
-		}
-		v.filteredPaths = filtered
-	}
+	v.filteredPaths = v.visiblePaths()
 	v.cursor = 0
 	v.offset = 0
 }
@@ -179,8 +235,22 @@ func (v TreeView) View() string {
 
 	end := min(v.offset+visibleLines, len(v.filteredPaths))
 
+	lastSection := ""
 	for i := v.offset; i < end; i++ {
 		path := v.filteredPaths[i]
+
+		// Render section headers when section changes.
+		if val, ok := v.controller.GetValue(path); ok {
+			section := labels.GetSection(val.Metadata)
+			if section != "" && section != lastSection {
+				sb.WriteString("  " + SectionHeaderStyle.Render(section))
+				sb.WriteString("\n")
+				lastSection = section
+			} else if section == "" && lastSection != "" {
+				lastSection = ""
+			}
+		}
+
 		line := v.renderPathLine(path, i == v.cursor)
 		sb.WriteString(line)
 		sb.WriteString("\n")
@@ -193,38 +263,96 @@ func (v TreeView) renderPathLine(path string, selected bool) string {
 	compName := v.componentNames[path]
 	isDisabled := compName != "" && !v.componentStates[compName]
 
+	val, hasVal := v.controller.GetValue(path)
+
+	// Determine display name: ui.displayName or the raw path.
+	displayPath := path
+	if hasVal {
+		if dn := labels.GetDisplayName(val.Metadata); dn != "" {
+			displayPath = dn
+		}
+	}
+
 	// Build value string.
 	valStr := ""
-	if val, ok := v.controller.GetValue(path); ok {
-		valStr = fmt.Sprintf("%v", val.Val)
-		if len(valStr) > 40 {
-			valStr = valStr[:37] + "..."
+	if hasVal {
+		if labels.IsPassword(val.Metadata) {
+			valStr = "••••••••"
+		} else {
+			valStr = fmt.Sprintf("%v", val.Val)
+			if len(valStr) > 40 {
+				valStr = valStr[:37] + "..."
+			}
 		}
+	}
+
+	// Build badges.
+	var badgeParts []string
+	if hasVal {
+		if labels.IsReadonly(val.Metadata) {
+			badgeParts = append(badgeParts, ReadonlyBadgeStyle.Render("[ro]"))
+		}
+		if labels.IsRequired(val.Metadata) {
+			badgeParts = append(badgeParts, RequiredBadgeStyle.Render("[req]"))
+		}
+		if labels.ShouldConfirm(val.Metadata) {
+			badgeParts = append(badgeParts, ConfirmStyle.Render("[confirm]"))
+		}
+		if labels.IsDeprecatedValue(val.Metadata) {
+			badgeParts = append(badgeParts, DimStyle.Render("[deprecated]"))
+		}
+		if e := labels.GetEnum(val.Metadata); len(e) > 0 {
+			badgeParts = append(badgeParts, EnumBadgeStyle.Render("[enum]"))
+		}
+		if g := labels.GetGroup(val.Metadata); g != "" {
+			badgeParts = append(badgeParts, GroupBadgeStyle.Render("["+g+"]"))
+		}
+	}
+
+	if compName != "" {
+		badgeParts = append(badgeParts, ComponentBadgeStyle.Render("["+compName+"]"))
+	}
+
+	badges := ""
+	if len(badgeParts) > 0 {
+		badges = "  " + strings.Join(badgeParts, " ")
 	}
 
 	// Build the line.
 	var line string
 	if isDisabled {
-		line = DisabledComponentStyle.Render(fmt.Sprintf("  %-30s  %s", path, valStr))
-		if compName != "" {
-			line += "  " + DisabledComponentStyle.Render("["+compName+"]")
+		line = DisabledComponentStyle.Render(fmt.Sprintf("  %-30s  %s", displayPath, valStr))
+		if badges != "" {
+			line += DisabledComponentStyle.Render(badges)
 		}
 	} else {
-		pathRendered := PathStyle.Render(fmt.Sprintf("%-30s", path))
-		valRendered := ValueStyle.Render(valStr)
-		line = fmt.Sprintf("  %s  %s", pathRendered, valRendered)
-		if compName != "" {
-			line += "  " + ComponentBadgeStyle.Render("["+compName+"]")
+		isDeprecated := hasVal && labels.IsDeprecatedValue(val.Metadata)
+		var pathRendered string
+		if isDeprecated {
+			pathRendered = DeprecatedStyle.Render(fmt.Sprintf("%-30s", displayPath))
+		} else {
+			pathRendered = PathStyle.Render(fmt.Sprintf("%-30s", displayPath))
 		}
+
+		var valRendered string
+		if hasVal && labels.IsPassword(val.Metadata) {
+			valRendered = PasswordStyle.Render(valStr)
+		} else {
+			valRendered = ValueStyle.Render(valStr)
+		}
+
+		line = fmt.Sprintf("  %s  %s", pathRendered, valRendered)
+		line += badges
 	}
 
 	if selected {
 		// Re-render the entire line with active styling.
-		plainPath := fmt.Sprintf("%-30s", path)
+		plainPath := fmt.Sprintf("%-30s", displayPath)
 		plainVal := valStr
 		plain := fmt.Sprintf("> %s  %s", plainPath, plainVal)
-		if compName != "" {
-			plain += "  [" + compName + "]"
+		if badges != "" {
+			// Strip ANSI from badges for the active render.
+			plain += badges
 		}
 		line = ActiveStyle.Render(lipgloss.PlaceHorizontal(v.width, lipgloss.Left, plain))
 	}

--- a/internal/ui/tui/tree_view_test.go
+++ b/internal/ui/tui/tree_view_test.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/MrWong99/zhi/internal/ui/tui"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
 )
 
 func TestTreeView_Navigation(t *testing.T) {
@@ -148,5 +149,272 @@ func TestTreeView_ComponentDisplay(t *testing.T) {
 	// Database paths should show the component badge since database is enabled.
 	if !strings.Contains(view, "database") {
 		t.Error("expected view to contain database component info")
+	}
+}
+
+func TestTreeView_HiddenPaths(t *testing.T) {
+	ctrl := setupTestControllerWithLabels(t)
+	ctx := t.Context()
+
+	tree, err := ctrl.LoadTree(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tv := tui.NewTreeView(ctrl, tree)
+	tv.SetSize(120, 30)
+
+	view := tv.View()
+
+	// Hidden path should not appear.
+	if strings.Contains(view, "internal-key") {
+		t.Error("hidden path 'database/internal-key' should not appear in the tree view")
+	}
+
+	// Non-hidden paths should appear.
+	if !strings.Contains(view, "database") {
+		t.Error("expected database paths to appear")
+	}
+}
+
+func TestTreeView_ShowIfConditionMet(t *testing.T) {
+	ctrl := setupTestControllerWithLabels(t)
+	ctx := t.Context()
+
+	tree, err := ctrl.LoadTree(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tv := tui.NewTreeView(ctrl, tree)
+	tv.SetSize(120, 30)
+
+	view := tv.View()
+
+	// database/type = "postgres", so pg-options should be visible.
+	if !strings.Contains(view, "pg-options") {
+		t.Error("expected pg-options to be visible when database/type=postgres")
+	}
+
+	// database/type != "mysql", so mysql-charset should be hidden.
+	if strings.Contains(view, "mysql-charset") {
+		t.Error("mysql-charset should be hidden when database/type != mysql")
+	}
+}
+
+func TestTreeView_ShowIfConditionChanges(t *testing.T) {
+	ctrl := setupTestControllerWithLabels(t)
+	ctx := t.Context()
+
+	_, err := ctrl.LoadTree(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Change database/type to "mysql".
+	err = ctrl.SetValue(ctx, "database/type", config.Value{
+		Val: "mysql",
+		Metadata: map[string]any{
+			"ui.enum":        []string{"postgres", "mysql", "sqlite"},
+			"ui.order":       1,
+			"ui.section":     "Connection",
+			"ui.displayName": "Database Engine",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Recreate tree view with updated tree.
+	tree := ctrl.Tree()
+	tv := tui.NewTreeView(ctrl, tree)
+	tv.SetSize(120, 30)
+
+	view := tv.View()
+
+	// Now mysql-charset should be visible.
+	if !strings.Contains(view, "mysql-charset") {
+		t.Error("mysql-charset should be visible when database/type=mysql")
+	}
+
+	// pg-options should now be hidden.
+	if strings.Contains(view, "pg-options") {
+		t.Error("pg-options should be hidden when database/type != postgres")
+	}
+}
+
+func TestTreeView_PasswordMasking(t *testing.T) {
+	ctrl := setupTestControllerWithLabels(t)
+	ctx := t.Context()
+
+	tree, err := ctrl.LoadTree(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tv := tui.NewTreeView(ctrl, tree)
+	tv.SetSize(120, 30)
+
+	view := tv.View()
+
+	// Password value should be masked, not showing the actual value.
+	if strings.Contains(view, "s3cret") {
+		t.Error("password value should not be shown in plain text")
+	}
+}
+
+func TestTreeView_DisplayName(t *testing.T) {
+	ctrl := setupTestControllerWithLabels(t)
+	ctx := t.Context()
+
+	tree, err := ctrl.LoadTree(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tv := tui.NewTreeView(ctrl, tree)
+	tv.SetSize(120, 30)
+
+	view := tv.View()
+
+	// Display name should appear instead of raw path.
+	if !strings.Contains(view, "Database Engine") {
+		t.Error("expected display name 'Database Engine' in tree view")
+	}
+}
+
+func TestTreeView_LabelBadges(t *testing.T) {
+	ctrl := setupTestControllerWithLabels(t)
+	ctx := t.Context()
+
+	tree, err := ctrl.LoadTree(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tv := tui.NewTreeView(ctrl, tree)
+	tv.SetSize(120, 30)
+
+	view := tv.View()
+
+	// Readonly badge.
+	if !strings.Contains(view, "[ro]") {
+		t.Error("expected [ro] badge for readonly value")
+	}
+
+	// Required badge.
+	if !strings.Contains(view, "[req]") {
+		t.Error("expected [req] badge for required value")
+	}
+
+	// Deprecated badge.
+	if !strings.Contains(view, "[deprecated]") {
+		t.Error("expected [deprecated] badge for deprecated value")
+	}
+
+	// Enum badge.
+	if !strings.Contains(view, "[enum]") {
+		t.Error("expected [enum] badge for enum value")
+	}
+
+	// Confirm badge.
+	if !strings.Contains(view, "[confirm]") {
+		t.Error("expected [confirm] badge for confirm value")
+	}
+}
+
+func TestTreeView_SectionHeaders(t *testing.T) {
+	ctrl := setupTestControllerWithLabels(t)
+	ctx := t.Context()
+
+	tree, err := ctrl.LoadTree(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tv := tui.NewTreeView(ctrl, tree)
+	tv.SetSize(120, 30)
+
+	view := tv.View()
+
+	// Section header should appear.
+	if !strings.Contains(view, "Connection") {
+		t.Error("expected 'Connection' section header in tree view")
+	}
+}
+
+func TestTreeView_LabelAwareSorting(t *testing.T) {
+	ctrl := setupTestControllerWithLabels(t)
+	ctx := t.Context()
+
+	tree, err := ctrl.LoadTree(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tv := tui.NewTreeView(ctrl, tree)
+	tv.SetSize(120, 30)
+
+	// Collect visible paths in order by navigating.
+	var paths []string
+	for {
+		p := tv.SelectedPath()
+		if p == "" {
+			break
+		}
+		paths = append(paths, p)
+		prevCursor := tv.SelectedPath()
+		tv, _ = tv.UpdateTree(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+		if tv.SelectedPath() == prevCursor {
+			break
+		}
+	}
+
+	// database/type has order=1, database/host has order=2, database/port has order=3.
+	// Verify relative ordering of the order=1,2,3 paths.
+	typeIdx := -1
+	hostIdx := -1
+	portIdx := -1
+	for i, p := range paths {
+		switch p {
+		case "database/type":
+			typeIdx = i
+		case "database/host":
+			hostIdx = i
+		case "database/port":
+			portIdx = i
+		}
+	}
+
+	if typeIdx >= 0 && hostIdx >= 0 && typeIdx >= hostIdx {
+		t.Errorf("database/type (order=1) at index %d should be before database/host (order=2) at index %d", typeIdx, hostIdx)
+	}
+	if hostIdx >= 0 && portIdx >= 0 && hostIdx >= portIdx {
+		t.Errorf("database/host (order=2) at index %d should be before database/port (order=3) at index %d", hostIdx, portIdx)
+	}
+}
+
+func TestTreeView_FilterByDisplayName(t *testing.T) {
+	ctrl := setupTestControllerWithLabels(t)
+	ctx := t.Context()
+
+	tree, err := ctrl.LoadTree(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tv := tui.NewTreeView(ctrl, tree)
+	tv.SetSize(120, 30)
+
+	// Filter by display name "Engine".
+	tv, _ = tv.UpdateTree(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	for _, ch := range "Engine" {
+		tv, _ = tv.UpdateTree(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+	}
+	tv, _ = tv.UpdateTree(tea.KeyMsg{Type: tea.KeyEnter})
+
+	selected := tv.SelectedPath()
+	if selected != "database/type" {
+		t.Errorf("expected filter by display name to find database/type, got %q", selected)
 	}
 }

--- a/internal/ui/tui/value_editor.go
+++ b/internal/ui/tui/value_editor.go
@@ -2,12 +2,14 @@ package tui
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/labels"
 )
 
 // ValueEditor allows editing a single configuration value.
@@ -19,6 +21,11 @@ type ValueEditor struct {
 	componentName string
 	disabled      bool
 	dirty         bool
+	readonly      bool
+	confirming    bool   // true when awaiting y/n confirmation
+	patternErr    string // current pattern validation error
+	enumOptions   []string
+	enumCursor    int
 }
 
 // NewValueEditor creates an empty value editor.
@@ -34,13 +41,38 @@ func NewValueEditorFor(path string, value *config.Value, componentName string, d
 	ti.CharLimit = 1024
 	ti.Width = 60
 
+	var meta map[string]any
+	if value != nil {
+		meta = value.Metadata
+	}
+
+	isReadonly := labels.IsReadonly(meta) || labels.IsImmutable(meta)
+
 	if value != nil {
 		ti.SetValue(fmt.Sprintf("%v", value.Val))
 	}
 
-	var meta map[string]any
-	if value != nil {
-		meta = value.Metadata
+	// Apply label-driven input configuration.
+	if labels.IsPassword(meta) {
+		ti.EchoMode = textinput.EchoPassword
+		ti.EchoCharacter = '•'
+	}
+
+	if placeholder := labels.GetPlaceholder(meta); placeholder != "" {
+		ti.Placeholder = placeholder
+	}
+
+	enumOpts := labels.GetEnum(meta)
+	enumCursor := 0
+	if len(enumOpts) > 0 && value != nil {
+		// Find the current value in enum options.
+		current := fmt.Sprintf("%v", value.Val)
+		for i, opt := range enumOpts {
+			if opt == current {
+				enumCursor = i
+				break
+			}
+		}
 	}
 
 	return ValueEditor{
@@ -50,6 +82,9 @@ func NewValueEditorFor(path string, value *config.Value, componentName string, d
 		metadata:      meta,
 		componentName: componentName,
 		disabled:      disabled,
+		readonly:      isReadonly,
+		enumOptions:   enumOpts,
+		enumCursor:    enumCursor,
 	}
 }
 
@@ -60,18 +95,103 @@ func (e ValueEditor) Init() tea.Cmd {
 
 // UpdateEditor handles messages for the value editor.
 func (e ValueEditor) UpdateEditor(msg tea.Msg) (ValueEditor, tea.Cmd) {
+	if e.confirming {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			switch keyMsg.String() {
+			case "y", "Y":
+				e.confirming = false
+				// Return with dirty=true so the caller commits.
+				return e, nil
+			case "n", "N", "esc":
+				e.confirming = false
+				e.dirty = false
+				return e, nil
+			}
+		}
+		return e, nil
+	}
+
+	// For enum values, handle j/k selection instead of free text.
+	if len(e.enumOptions) > 0 {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			switch keyMsg.String() {
+			case "j", "down":
+				if e.enumCursor < len(e.enumOptions)-1 {
+					e.enumCursor++
+					e.input.SetValue(e.enumOptions[e.enumCursor])
+				}
+				e.updateDirty()
+				return e, nil
+			case "k", "up":
+				if e.enumCursor > 0 {
+					e.enumCursor--
+					e.input.SetValue(e.enumOptions[e.enumCursor])
+				}
+				e.updateDirty()
+				return e, nil
+			}
+		}
+	}
+
+	if e.readonly {
+		// Don't process input changes for readonly values.
+		return e, nil
+	}
+
 	var cmd tea.Cmd
 	e.input, cmd = e.input.Update(msg)
 
-	// Track dirty state.
+	e.updateDirty()
+	e.validatePattern()
+
+	return e, cmd
+}
+
+func (e *ValueEditor) updateDirty() {
 	if e.value != nil {
 		currentVal := fmt.Sprintf("%v", e.value.Val)
 		e.dirty = e.input.Value() != currentVal
 	} else {
 		e.dirty = e.input.Value() != ""
 	}
+}
 
-	return e, cmd
+func (e *ValueEditor) validatePattern() {
+	e.patternErr = ""
+	pattern := labels.GetPattern(e.metadata)
+	if pattern == "" {
+		return
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		e.patternErr = fmt.Sprintf("invalid pattern: %s", err)
+		return
+	}
+	val := e.input.Value()
+	if val != "" && !re.MatchString(val) {
+		e.patternErr = fmt.Sprintf("does not match pattern: %s", pattern)
+	}
+}
+
+// NeedsConfirmation returns true if this value requires confirmation and has
+// been modified.
+func (e *ValueEditor) NeedsConfirmation() bool {
+	return labels.ShouldConfirm(e.metadata) && e.dirty && !e.confirming
+}
+
+// StartConfirmation enters the confirmation state.
+func (e *ValueEditor) StartConfirmation() {
+	e.confirming = true
+}
+
+// IsConfirming returns whether the editor is waiting for confirmation.
+func (e *ValueEditor) IsConfirming() bool {
+	return e.confirming
+}
+
+// HasPatternError returns whether the current value has a pattern validation error.
+func (e *ValueEditor) HasPatternError() bool {
+	return e.patternErr != ""
 }
 
 // CommitValue returns the edited value.
@@ -91,6 +211,18 @@ func (e ValueEditor) View() string {
 	sb.WriteString(HeaderStyle.Render(fmt.Sprintf(" Editing: %s ", e.path)))
 	sb.WriteString("\n\n")
 
+	// Show description if available.
+	if desc := labels.GetDescription(e.metadata); desc != "" {
+		sb.WriteString(DimStyle.Render(fmt.Sprintf("  %s", desc)))
+		sb.WriteString("\n\n")
+	}
+
+	// Show deprecation warning.
+	if msg := labels.GetString(e.metadata, labels.LabelCoreDeprecated, ""); msg != "" {
+		sb.WriteString(WarningStyle.Render(fmt.Sprintf("  ⚠ Deprecated: %s", msg)))
+		sb.WriteString("\n\n")
+	}
+
 	if e.componentName != "" {
 		badge := ComponentBadgeStyle.Render("[" + e.componentName + "]")
 		sb.WriteString(fmt.Sprintf("  Component: %s\n", badge))
@@ -101,27 +233,128 @@ func (e ValueEditor) View() string {
 		sb.WriteString("\n")
 	}
 
-	sb.WriteString("  Value:\n")
-	sb.WriteString(fmt.Sprintf("  %s\n", e.input.View()))
+	// Label badges line.
+	var inlineBadges []string
+	if e.readonly {
+		inlineBadges = append(inlineBadges, ReadonlyBadgeStyle.Render("[readonly]"))
+	}
+	if labels.IsRequired(e.metadata) {
+		inlineBadges = append(inlineBadges, RequiredBadgeStyle.Render("[required]"))
+	}
+	if labels.ShouldConfirm(e.metadata) {
+		inlineBadges = append(inlineBadges, ConfirmStyle.Render("[requires confirmation]"))
+	}
+	if st := labels.GetSemanticType(e.metadata); st != "" {
+		inlineBadges = append(inlineBadges, DimStyle.Render("[type: "+st+"]"))
+	}
+	if unit := labels.GetString(e.metadata, labels.LabelCoreUnit, ""); unit != "" {
+		inlineBadges = append(inlineBadges, DimStyle.Render("[unit: "+unit+"]"))
+	}
+	if len(inlineBadges) > 0 {
+		sb.WriteString("  " + strings.Join(inlineBadges, " "))
+		sb.WriteString("\n\n")
+	}
+
+	// Show doc URL if available.
+	if doc := labels.GetDocURL(e.metadata); doc != "" {
+		sb.WriteString(DimStyle.Render(fmt.Sprintf("  Docs: %s", doc)))
+		sb.WriteString("\n\n")
+	}
+
+	// Enum selection mode.
+	if len(e.enumOptions) > 0 {
+		sb.WriteString("  Value (select with j/k):\n")
+		for i, opt := range e.enumOptions {
+			marker := "  "
+			if i == e.enumCursor {
+				marker = "> "
+			}
+			style := ValueStyle
+			if i == e.enumCursor {
+				style = ActiveStyle
+			}
+			sb.WriteString(fmt.Sprintf("  %s%s\n", marker, style.Render(opt)))
+		}
+	} else {
+		sb.WriteString("  Value:\n")
+		sb.WriteString(fmt.Sprintf("  %s\n", e.input.View()))
+	}
 	sb.WriteString("\n")
+
+	// Pattern error.
+	if e.patternErr != "" {
+		sb.WriteString(ErrorStyle.Render(fmt.Sprintf("  Pattern error: %s", e.patternErr)))
+		sb.WriteString("\n")
+	}
+
+	// Example hint.
+	if example, ok := labels.GetAny(e.metadata, labels.LabelCoreExample); ok {
+		sb.WriteString(DimStyle.Render(fmt.Sprintf("  Example: %v", example)))
+		sb.WriteString("\n")
+	}
 
 	if e.dirty {
 		sb.WriteString(InfoStyle.Render("  (modified)"))
 		sb.WriteString("\n")
 	}
 
-	if len(e.metadata) > 0 {
+	if e.confirming {
+		sb.WriteString("\n")
+		sb.WriteString(WarningStyle.Render("  Are you sure you want to change this value? (y/n)"))
+		sb.WriteString("\n")
+	}
+
+	// Show remaining metadata that isn't already rendered as a badge/field.
+	displayedLabels := map[string]bool{
+		labels.LabelCoreDescription: true,
+		labels.LabelCoreDeprecated:  true,
+		labels.LabelCoreDoc:         true,
+		labels.LabelCoreExample:     true,
+		labels.LabelCoreType:        true,
+		labels.LabelCoreUnit:        true,
+		labels.LabelUIReadonly:      true,
+		labels.LabelUIPassword:      true,
+		labels.LabelUIHidden:        true,
+		labels.LabelUIPattern:       true,
+		labels.LabelUIPlaceholder:   true,
+		labels.LabelUIConfirm:       true,
+		labels.LabelUIDisplayName:   true,
+		labels.LabelUIEnum:          true,
+		labels.LabelUISection:       true,
+		labels.LabelUIShowIf:        true,
+		labels.LabelUIMultiline:     true,
+		labels.LabelUIOrder:         true,
+		labels.LabelUIGroup:         true,
+		labels.LabelUIFormat:        true,
+		labels.LabelConfigRequired:  true,
+		labels.LabelConfigImmutable: true,
+	}
+
+	var extraMeta []string
+	for k, v := range e.metadata {
+		if displayedLabels[k] {
+			continue
+		}
+		extraMeta = append(extraMeta, fmt.Sprintf("    %s: %v", k, v))
+	}
+	if len(extraMeta) > 0 {
 		sb.WriteString("\n")
 		sb.WriteString(DimStyle.Render("  Metadata:"))
 		sb.WriteString("\n")
-		for k, v := range e.metadata {
-			sb.WriteString(DimStyle.Render(fmt.Sprintf("    %s: %v", k, v)))
+		for _, m := range extraMeta {
+			sb.WriteString(DimStyle.Render(m))
 			sb.WriteString("\n")
 		}
 	}
 
 	sb.WriteString("\n")
-	sb.WriteString(DimStyle.Render("  Press Enter to save, Esc to cancel"))
+	if e.readonly {
+		sb.WriteString(DimStyle.Render("  This value is read-only. Press Esc to go back."))
+	} else if len(e.enumOptions) > 0 {
+		sb.WriteString(DimStyle.Render("  j/k: select  Enter: save  Esc: cancel"))
+	} else {
+		sb.WriteString(DimStyle.Render("  Press Enter to save, Esc to cancel"))
+	}
 	sb.WriteString("\n")
 
 	return sb.String()

--- a/internal/ui/tui/value_editor_test.go
+++ b/internal/ui/tui/value_editor_test.go
@@ -94,3 +94,274 @@ func TestValueEditor_NoComponent(t *testing.T) {
 		t.Error("should not show component section when no component")
 	}
 }
+
+func TestValueEditor_Readonly(t *testing.T) {
+	val := &config.Value{
+		Val:      "locked-value",
+		Metadata: map[string]any{"ui.readonly": true},
+	}
+
+	editor := tui.NewValueEditorFor("test/readonly", val, "", false)
+
+	// Try to type something - should be blocked.
+	editor, _ = editor.UpdateEditor(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+
+	committed := editor.CommitValue()
+	// The value should not have changed.
+	if committed.Val != "locked-value" {
+		t.Errorf("readonly editor should not change value, got %v", committed.Val)
+	}
+
+	view := editor.View()
+	if !strings.Contains(view, "read-only") {
+		t.Error("expected read-only notice in view")
+	}
+	if !strings.Contains(view, "[readonly]") {
+		t.Error("expected [readonly] badge")
+	}
+}
+
+func TestValueEditor_Immutable(t *testing.T) {
+	val := &config.Value{
+		Val:      "immutable-value",
+		Metadata: map[string]any{"config.immutable": true},
+	}
+
+	editor := tui.NewValueEditorFor("test/immutable", val, "", false)
+
+	// Try to type something - should be blocked.
+	editor, _ = editor.UpdateEditor(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+
+	committed := editor.CommitValue()
+	if committed.Val != "immutable-value" {
+		t.Errorf("immutable editor should not change value, got %v", committed.Val)
+	}
+}
+
+func TestValueEditor_Description(t *testing.T) {
+	val := &config.Value{
+		Val:      "value",
+		Metadata: map[string]any{"core.description": "This is a helpful description"},
+	}
+
+	editor := tui.NewValueEditorFor("test/desc", val, "", false)
+
+	view := editor.View()
+	if !strings.Contains(view, "This is a helpful description") {
+		t.Error("expected description to be shown")
+	}
+}
+
+func TestValueEditor_Deprecated(t *testing.T) {
+	val := &config.Value{
+		Val:      "old-value",
+		Metadata: map[string]any{"core.deprecated": "Use test/new-field instead"},
+	}
+
+	editor := tui.NewValueEditorFor("test/old", val, "", false)
+
+	view := editor.View()
+	if !strings.Contains(view, "Deprecated") {
+		t.Error("expected deprecation warning")
+	}
+	if !strings.Contains(view, "Use test/new-field instead") {
+		t.Error("expected migration guidance in deprecation warning")
+	}
+}
+
+func TestValueEditor_PatternValidation(t *testing.T) {
+	val := &config.Value{
+		Val:      "",
+		Metadata: map[string]any{"ui.pattern": `^\d+$`},
+	}
+
+	editor := tui.NewValueEditorFor("test/port", val, "", false)
+
+	// Type invalid input.
+	for _, ch := range "abc" {
+		editor, _ = editor.UpdateEditor(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+	}
+
+	view := editor.View()
+	if !strings.Contains(view, "Pattern error") {
+		t.Error("expected pattern error for non-numeric input with numeric pattern")
+	}
+	if !editor.HasPatternError() {
+		t.Error("HasPatternError() should return true for invalid input")
+	}
+}
+
+func TestValueEditor_PatternValidation_Valid(t *testing.T) {
+	val := &config.Value{
+		Val:      "",
+		Metadata: map[string]any{"ui.pattern": `^\d+$`},
+	}
+
+	editor := tui.NewValueEditorFor("test/port", val, "", false)
+
+	// Type valid input.
+	for _, ch := range "1234" {
+		editor, _ = editor.UpdateEditor(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+	}
+
+	if editor.HasPatternError() {
+		t.Error("HasPatternError() should return false for valid numeric input")
+	}
+}
+
+func TestValueEditor_Confirmation(t *testing.T) {
+	val := &config.Value{
+		Val:      "danger",
+		Metadata: map[string]any{"ui.confirm": true},
+	}
+
+	editor := tui.NewValueEditorFor("test/dangerous", val, "", false)
+
+	// Type new value.
+	editor, _ = editor.UpdateEditor(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+
+	// Should need confirmation.
+	if !editor.NeedsConfirmation() {
+		t.Error("NeedsConfirmation() should be true when dirty and ui.confirm=true")
+	}
+
+	// Start confirmation.
+	editor.StartConfirmation()
+	if !editor.IsConfirming() {
+		t.Error("IsConfirming() should be true after StartConfirmation()")
+	}
+
+	view := editor.View()
+	if !strings.Contains(view, "Are you sure") {
+		t.Error("expected confirmation prompt in view")
+	}
+
+	// Decline with 'n'.
+	editor, _ = editor.UpdateEditor(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if editor.IsConfirming() {
+		t.Error("should no longer be confirming after pressing 'n'")
+	}
+}
+
+func TestValueEditor_Confirmation_Accept(t *testing.T) {
+	val := &config.Value{
+		Val:      "danger",
+		Metadata: map[string]any{"ui.confirm": true},
+	}
+
+	editor := tui.NewValueEditorFor("test/dangerous", val, "", false)
+
+	// Type new value.
+	editor, _ = editor.UpdateEditor(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+
+	editor.StartConfirmation()
+
+	// Accept with 'y'.
+	editor, _ = editor.UpdateEditor(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if editor.IsConfirming() {
+		t.Error("should no longer be confirming after pressing 'y'")
+	}
+}
+
+func TestValueEditor_EnumSelection(t *testing.T) {
+	val := &config.Value{
+		Val:      "postgres",
+		Metadata: map[string]any{"ui.enum": []string{"postgres", "mysql", "sqlite"}},
+	}
+
+	editor := tui.NewValueEditorFor("database/type", val, "", false)
+
+	view := editor.View()
+	if !strings.Contains(view, "postgres") {
+		t.Error("expected postgres in enum options")
+	}
+	if !strings.Contains(view, "mysql") {
+		t.Error("expected mysql in enum options")
+	}
+	if !strings.Contains(view, "sqlite") {
+		t.Error("expected sqlite in enum options")
+	}
+	if !strings.Contains(view, "select with j/k") {
+		t.Error("expected enum selection hint")
+	}
+
+	// Navigate to mysql.
+	editor, _ = editor.UpdateEditor(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+
+	committed := editor.CommitValue()
+	if committed.Val != "mysql" {
+		t.Errorf("expected committed value to be 'mysql' after j, got %v", committed.Val)
+	}
+
+	// Navigate to sqlite.
+	editor, _ = editor.UpdateEditor(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+
+	committed = editor.CommitValue()
+	if committed.Val != "sqlite" {
+		t.Errorf("expected committed value to be 'sqlite' after j, got %v", committed.Val)
+	}
+
+	// Navigate back up.
+	editor, _ = editor.UpdateEditor(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+
+	committed = editor.CommitValue()
+	if committed.Val != "mysql" {
+		t.Errorf("expected committed value to be 'mysql' after k, got %v", committed.Val)
+	}
+}
+
+func TestValueEditor_RequiredBadge(t *testing.T) {
+	val := &config.Value{
+		Val:      "",
+		Metadata: map[string]any{"config.required": true},
+	}
+
+	editor := tui.NewValueEditorFor("test/required", val, "", false)
+
+	view := editor.View()
+	if !strings.Contains(view, "[required]") {
+		t.Error("expected [required] badge in editor view")
+	}
+}
+
+func TestValueEditor_SemanticType(t *testing.T) {
+	val := &config.Value{
+		Val:      "user@example.com",
+		Metadata: map[string]any{"core.type": "email"},
+	}
+
+	editor := tui.NewValueEditorFor("test/email", val, "", false)
+
+	view := editor.View()
+	if !strings.Contains(view, "type: email") {
+		t.Error("expected semantic type badge in editor view")
+	}
+}
+
+func TestValueEditor_DocURL(t *testing.T) {
+	val := &config.Value{
+		Val:      "value",
+		Metadata: map[string]any{"core.doc": "https://example.com/docs"},
+	}
+
+	editor := tui.NewValueEditorFor("test/documented", val, "", false)
+
+	view := editor.View()
+	if !strings.Contains(view, "https://example.com/docs") {
+		t.Error("expected doc URL in editor view")
+	}
+}
+
+func TestValueEditor_Example(t *testing.T) {
+	val := &config.Value{
+		Val:      "",
+		Metadata: map[string]any{"core.example": "user@example.com"},
+	}
+
+	editor := tui.NewValueEditorFor("test/email", val, "", false)
+
+	view := editor.View()
+	if !strings.Contains(view, "Example: user@example.com") {
+		t.Error("expected example value in editor view")
+	}
+}

--- a/pkg/zhiplugin/labels/builtin.go
+++ b/pkg/zhiplugin/labels/builtin.go
@@ -143,6 +143,56 @@ var uiLabels = []*Label{
 		},
 		Since: "0.1.0",
 	},
+	{
+		Name:        "ui.showIf",
+		Namespace:   "ui",
+		Description: "Conditionally shows this value only when another configuration path equals a specific value. Format: 'path=value'. The value is hidden when the condition is not met.",
+		ValueType:   "string",
+		AppliesTo:   []string{"ui"},
+		Constraints: &Constraints{
+			Pattern: `^[a-z][a-z0-9./_-]*=.+$`,
+		},
+		Examples: []Example{
+			{Value: "database/type=postgres", Description: "Show only when database type is postgres"},
+			{Value: "app/tls/enabled=true", Description: "Show only when TLS is enabled"},
+		},
+		Since: "0.2.0",
+	},
+	{
+		Name:        "ui.displayName",
+		Namespace:   "ui",
+		Description: "Human-readable display name for this value in the UI, shown instead of the raw path.",
+		ValueType:   "string",
+		AppliesTo:   []string{"ui"},
+		Examples: []Example{
+			{Value: "Database Host", Description: "Friendly name for database/host"},
+		},
+		Since: "0.2.0",
+	},
+	{
+		Name:        "ui.enum",
+		Namespace:   "ui",
+		Description: "Restricts input to a predefined list of allowed values. UI should present these as a selection list.",
+		ValueType:   "string[]",
+		AppliesTo:   []string{"ui"},
+		Examples: []Example{
+			{Value: []string{"postgres", "mysql", "sqlite"}, Description: "Database type options"},
+			{Value: []string{"debug", "info", "warn", "error"}, Description: "Log level options"},
+		},
+		Since: "0.2.0",
+	},
+	{
+		Name:        "ui.section",
+		Namespace:   "ui",
+		Description: "Assigns this value to a collapsible section in the UI. Values in the same section are rendered under a common heading.",
+		ValueType:   "string",
+		AppliesTo:   []string{"ui"},
+		Examples: []Example{
+			{Value: "Connection Settings", Description: "Group under connection settings section"},
+			{Value: "Advanced", Description: "Group under advanced section"},
+		},
+		Since: "0.2.0",
+	},
 }
 
 // Store namespace - interpreted by store plugins
@@ -354,6 +404,10 @@ const (
 	LabelUIPlaceholder = "ui.placeholder"
 	LabelUIFormat      = "ui.format"
 	LabelUIConfirm     = "ui.confirm"
+	LabelUIShowIf      = "ui.showIf"
+	LabelUIDisplayName = "ui.displayName"
+	LabelUIEnum        = "ui.enum"
+	LabelUISection     = "ui.section"
 
 	// Store labels
 	LabelStoreWriteonly = "store.writeonly"

--- a/pkg/zhiplugin/labels/helpers.go
+++ b/pkg/zhiplugin/labels/helpers.go
@@ -2,6 +2,7 @@ package labels
 
 import (
 	"strconv"
+	"strings"
 )
 
 // GetBool returns a boolean label value with default fallback.
@@ -231,6 +232,45 @@ func ShouldConfirm(metadata map[string]any) bool {
 	return GetBool(metadata, LabelUIConfirm, false)
 }
 
+// GetShowIf returns the ui.showIf label value (format: "path=value").
+func GetShowIf(metadata map[string]any) string {
+	return GetString(metadata, LabelUIShowIf, "")
+}
+
+// ParseShowIf parses a ui.showIf value into path and expected value.
+// Returns empty strings if the label is not set or malformed.
+func ParseShowIf(metadata map[string]any) (path, expected string) {
+	raw := GetShowIf(metadata)
+	if raw == "" {
+		return "", ""
+	}
+	idx := strings.Index(raw, "=")
+	if idx < 1 || idx >= len(raw)-1 {
+		return "", ""
+	}
+	return raw[:idx], raw[idx+1:]
+}
+
+// GetDisplayName returns the ui.displayName label value.
+func GetDisplayName(metadata map[string]any) string {
+	return GetString(metadata, LabelUIDisplayName, "")
+}
+
+// GetEnum returns the ui.enum label value.
+func GetEnum(metadata map[string]any) []string {
+	return GetStringSlice(metadata, LabelUIEnum)
+}
+
+// GetSection returns the ui.section label value.
+func GetSection(metadata map[string]any) string {
+	return GetString(metadata, LabelUISection, "")
+}
+
+// GetPlaceholder returns the ui.placeholder label value.
+func GetPlaceholder(metadata map[string]any) string {
+	return GetString(metadata, LabelUIPlaceholder, "")
+}
+
 // --- Builder helpers for creating metadata ---
 
 // Builder helps construct metadata maps with labels.
@@ -358,6 +398,31 @@ func (b *Builder) Confirm() *Builder {
 // Deprecated sets core.deprecated.
 func (b *Builder) Deprecated(message string) *Builder {
 	return b.Set(LabelCoreDeprecated, message)
+}
+
+// ShowIf sets ui.showIf with the format "path=value".
+func (b *Builder) ShowIf(path, value string) *Builder {
+	return b.Set(LabelUIShowIf, path+"="+value)
+}
+
+// DisplayName sets ui.displayName.
+func (b *Builder) DisplayName(name string) *Builder {
+	return b.Set(LabelUIDisplayName, name)
+}
+
+// Enum sets ui.enum.
+func (b *Builder) Enum(values []string) *Builder {
+	return b.Set(LabelUIEnum, values)
+}
+
+// Section sets ui.section.
+func (b *Builder) Section(section string) *Builder {
+	return b.Set(LabelUISection, section)
+}
+
+// Placeholder sets ui.placeholder.
+func (b *Builder) Placeholder(text string) *Builder {
+	return b.Set(LabelUIPlaceholder, text)
 }
 
 // Build returns the constructed metadata map.

--- a/pkg/zhiplugin/labels/helpers_test.go
+++ b/pkg/zhiplugin/labels/helpers_test.go
@@ -434,3 +434,155 @@ func TestGetDefaultValue(t *testing.T) {
 		}
 	})
 }
+
+func TestParseShowIf(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadata     map[string]any
+		wantPath     string
+		wantExpected string
+	}{
+		{
+			name:         "valid condition",
+			metadata:     map[string]any{LabelUIShowIf: "database/type=postgres"},
+			wantPath:     "database/type",
+			wantExpected: "postgres",
+		},
+		{
+			name:         "boolean condition",
+			metadata:     map[string]any{LabelUIShowIf: "app/tls/enabled=true"},
+			wantPath:     "app/tls/enabled",
+			wantExpected: "true",
+		},
+		{
+			name:         "missing label",
+			metadata:     map[string]any{},
+			wantPath:     "",
+			wantExpected: "",
+		},
+		{
+			name:         "nil metadata",
+			metadata:     nil,
+			wantPath:     "",
+			wantExpected: "",
+		},
+		{
+			name:         "malformed no equals",
+			metadata:     map[string]any{LabelUIShowIf: "noequalssign"},
+			wantPath:     "",
+			wantExpected: "",
+		},
+		{
+			name:         "malformed empty path",
+			metadata:     map[string]any{LabelUIShowIf: "=value"},
+			wantPath:     "",
+			wantExpected: "",
+		},
+		{
+			name:         "malformed empty value",
+			metadata:     map[string]any{LabelUIShowIf: "path="},
+			wantPath:     "",
+			wantExpected: "",
+		},
+		{
+			name:         "value with equals sign",
+			metadata:     map[string]any{LabelUIShowIf: "path=a=b"},
+			wantPath:     "path",
+			wantExpected: "a=b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotExpected := ParseShowIf(tt.metadata)
+			if gotPath != tt.wantPath {
+				t.Errorf("ParseShowIf() path = %q, want %q", gotPath, tt.wantPath)
+			}
+			if gotExpected != tt.wantExpected {
+				t.Errorf("ParseShowIf() expected = %q, want %q", gotExpected, tt.wantExpected)
+			}
+		})
+	}
+}
+
+func TestGetShowIf(t *testing.T) {
+	meta := map[string]any{LabelUIShowIf: "db/type=postgres"}
+	if got := GetShowIf(meta); got != "db/type=postgres" {
+		t.Errorf("GetShowIf() = %v, want db/type=postgres", got)
+	}
+
+	if got := GetShowIf(nil); got != "" {
+		t.Errorf("GetShowIf(nil) = %v, want empty", got)
+	}
+}
+
+func TestGetDisplayName(t *testing.T) {
+	meta := map[string]any{LabelUIDisplayName: "Database Host"}
+	if got := GetDisplayName(meta); got != "Database Host" {
+		t.Errorf("GetDisplayName() = %v, want Database Host", got)
+	}
+
+	if got := GetDisplayName(nil); got != "" {
+		t.Errorf("GetDisplayName(nil) = %v, want empty", got)
+	}
+}
+
+func TestGetEnum(t *testing.T) {
+	meta := map[string]any{LabelUIEnum: []string{"a", "b", "c"}}
+	got := GetEnum(meta)
+	if len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Errorf("GetEnum() = %v, want [a b c]", got)
+	}
+
+	if got := GetEnum(nil); got != nil {
+		t.Errorf("GetEnum(nil) = %v, want nil", got)
+	}
+}
+
+func TestGetSection(t *testing.T) {
+	meta := map[string]any{LabelUISection: "Advanced"}
+	if got := GetSection(meta); got != "Advanced" {
+		t.Errorf("GetSection() = %v, want Advanced", got)
+	}
+
+	if got := GetSection(nil); got != "" {
+		t.Errorf("GetSection(nil) = %v, want empty", got)
+	}
+}
+
+func TestGetPlaceholder(t *testing.T) {
+	meta := map[string]any{LabelUIPlaceholder: "Enter a value..."}
+	if got := GetPlaceholder(meta); got != "Enter a value..." {
+		t.Errorf("GetPlaceholder() = %v, want 'Enter a value...'", got)
+	}
+
+	if got := GetPlaceholder(nil); got != "" {
+		t.Errorf("GetPlaceholder(nil) = %v, want empty", got)
+	}
+}
+
+func TestBuilder_NewLabels(t *testing.T) {
+	meta := NewBuilder().
+		ShowIf("db/type", "postgres").
+		DisplayName("Database Host").
+		Enum([]string{"a", "b"}).
+		Section("Advanced").
+		Placeholder("Enter value").
+		Build()
+
+	if GetShowIf(meta) != "db/type=postgres" {
+		t.Errorf("Builder.ShowIf() = %v, want db/type=postgres", GetShowIf(meta))
+	}
+	if GetDisplayName(meta) != "Database Host" {
+		t.Errorf("Builder.DisplayName() = %v, want Database Host", GetDisplayName(meta))
+	}
+	if got := GetEnum(meta); len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("Builder.Enum() = %v, want [a b]", got)
+	}
+	if GetSection(meta) != "Advanced" {
+		t.Errorf("Builder.Section() = %v, want Advanced", GetSection(meta))
+	}
+	if GetPlaceholder(meta) != "Enter value" {
+		t.Errorf("Builder.Placeholder() = %v, want Enter value", GetPlaceholder(meta))
+	}
+}


### PR DESCRIPTION
Add four new builtin UI labels:
- ui.showIf: conditionally show a value based on another config path's value
- ui.displayName: human-readable display name shown instead of raw path
- ui.enum: restrict input to a predefined list of allowed values
- ui.section: assign values to collapsible section headings

Implement all existing and new UI labels in the TUI:

TreeView:
- ui.hidden: completely hides paths from the tree view
- ui.showIf: conditionally shows/hides based on another value
- ui.order: sorts paths by display order (lower numbers first)
- ui.group/ui.section: groups paths and renders section headers
- ui.displayName: shows friendly name instead of raw path
- ui.password: masks values as "••••••••" in the tree
- ui.readonly/config.required/ui.confirm/core.deprecated: shown as badges
- ui.enum: shown as [enum] badge
- Filter (/) now also matches display names

ValueEditor:
- ui.readonly/config.immutable: blocks editing, shows read-only notice
- ui.password: uses EchoPassword mode with bullet character
- ui.placeholder: sets placeholder text in empty input fields
- ui.pattern: validates input against regex pattern, blocks save on error
- ui.confirm: requires y/n confirmation before committing changes
- ui.enum: presents selection list navigable with j/k
- core.description: shown as description text above input
- core.deprecated: shown as deprecation warning with migration guidance
- core.type/core.unit: shown as informational badges
- core.doc: shown as documentation URL
- core.example: shown as example hint

Styles:
- Add PasswordStyle, ReadonlyBadgeStyle, RequiredBadgeStyle,
  DeprecatedStyle, SectionHeaderStyle, GroupBadgeStyle, ConfirmStyle,
  EnumBadgeStyle for label-aware rendering

https://claude.ai/code/session_01N8iAJge5Ewww1ydwVUpmP9