### PR TITLE
feat: implement Phase 1 foundation for plugin sharing system

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,14 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/hashicorp/go-plugin v1.7.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.10.2
 	github.com/traefik/yaegi v0.16.1
 	google.golang.org/grpc v1.78.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
+	oras.land/oras-go/v2 v2.6.0
 )
 
 require (
@@ -48,6 +50,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/oklog/run v1.2.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
@@ -55,6 +58,7 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,10 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -139,6 +143,8 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -162,3 +168,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
+oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -1,0 +1,248 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MrWong99/zhi/internal/core"
+	"github.com/MrWong99/zhi/pkg/sharing/client"
+	"github.com/MrWong99/zhi/pkg/sharing/metadata"
+	"github.com/MrWong99/zhi/pkg/sharing/registry"
+)
+
+var pluginCmd = &cobra.Command{
+	Use:   "plugin",
+	Short: "Manage shared plugins",
+	Long: `Install, uninstall, and list shared plugins from OCI registries.
+
+Subcommands:
+  install      Install a plugin from an OCI reference
+  uninstall    Remove an installed plugin
+  list         List installed shared plugins`,
+	Example: `  zhi plugin install oci://ghcr.io/zhi-project/zhi-config-ansible:v1.2.0
+  zhi plugin uninstall ansible-config
+  zhi plugin list`,
+}
+
+// --- plugin install ---
+
+var pluginInstallCmd = &cobra.Command{
+	Use:   "install <reference>",
+	Short: "Install a plugin from an OCI reference",
+	Long: `Download and install a plugin from an OCI registry.
+
+The reference can be a full OCI reference or a short name:
+  oci://ghcr.io/org/plugin:v1.0
+  ghcr.io/org/plugin:v1.0`,
+	Example: `  zhi plugin install oci://ghcr.io/zhi-project/zhi-config-ansible:v1.2.0
+  zhi plugin install ghcr.io/org/zhi-config-custom:v1.0.0 --force`,
+	Args: cobra.ExactArgs(1),
+	RunE: runPluginInstall,
+}
+
+var (
+	pluginInstallPlatform string
+	pluginInstallForce    bool
+)
+
+func init() {
+	pluginInstallCmd.Flags().StringVar(&pluginInstallPlatform, "platform", "", "override platform detection (e.g. \"linux/amd64\")")
+	pluginInstallCmd.Flags().BoolVar(&pluginInstallForce, "force", false, "overwrite existing plugin even if same version")
+
+	pluginCmd.AddCommand(pluginInstallCmd)
+	pluginCmd.AddCommand(pluginUninstallCmd)
+	pluginCmd.AddCommand(pluginListCmd)
+	rootCmd.AddCommand(pluginCmd)
+}
+
+func runPluginInstall(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+	w := cmd.OutOrStdout()
+
+	ociClient, err := newSharingClient()
+	if err != nil {
+		return err
+	}
+
+	opts := client.PullOptions{
+		Force: pluginInstallForce,
+	}
+
+	if pluginInstallPlatform != "" {
+		p, err := parsePlatformFlag(pluginInstallPlatform)
+		if err != nil {
+			return err
+		}
+		opts.Platform = &p
+	}
+
+	fmt.Fprintf(w, "Pulling %s...\n", ref)
+	result, err := ociClient.PullPlugin(cmd.Context(), ref, opts)
+	if err != nil {
+		return fmt.Errorf("installing plugin: %w", err)
+	}
+
+	fmt.Fprintf(w, "Installed %s v%s (%s)\n", result.Manifest.Name, result.Manifest.Version, result.Platform)
+	fmt.Fprintf(w, "Binary: %s\n", result.BinaryPath)
+	if result.Manifest.Type != "" {
+		fmt.Fprintf(w, "\nPlugin is ready to use. Add to your workspace:\n")
+		fmt.Fprintf(w, "  %s:\n", result.Manifest.Type)
+		fmt.Fprintf(w, "    provider: %s\n", result.Manifest.Name)
+	}
+	return nil
+}
+
+// --- plugin uninstall ---
+
+var pluginUninstallCmd = &cobra.Command{
+	Use:   "uninstall <name>",
+	Short: "Remove an installed plugin",
+	Long: `Remove an installed shared plugin binary and its metadata.
+
+The name is the plugin's short name (e.g. "ansible-config").`,
+	Example: `  zhi plugin uninstall ansible-config`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    runPluginUninstall,
+}
+
+func runPluginUninstall(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	w := cmd.OutOrStdout()
+
+	metaDir := metadata.DefaultMetadataDir()
+	metaStore := metadata.NewStore(metaDir)
+
+	// Load metadata to find the binary name.
+	meta, err := metaStore.Load(name)
+	if err != nil {
+		return fmt.Errorf("loading plugin metadata: %w", err)
+	}
+	if meta == nil {
+		return fmt.Errorf("plugin %q is not installed (no metadata found)", name)
+	}
+
+	// Remove the binary.
+	pluginDir := core.DefaultPluginDir()
+	binaryName := fmt.Sprintf("zhi-%s-%s", meta.Type, meta.Name)
+	binaryPath := filepath.Join(pluginDir, binaryName)
+
+	if err := os.Remove(binaryPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing binary: %w", err)
+	}
+
+	// Remove metadata.
+	if err := metaStore.Delete(name); err != nil {
+		return fmt.Errorf("removing metadata: %w", err)
+	}
+
+	fmt.Fprintf(w, "Uninstalled %s\n", name)
+	return nil
+}
+
+// --- plugin list ---
+
+var pluginListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List installed shared plugins",
+	Long:  `List all plugins installed from OCI registries with version and source information.`,
+	RunE:  runPluginList,
+}
+
+var pluginListJSON bool
+
+func init() {
+	pluginListCmd.Flags().BoolVar(&pluginListJSON, "json", false, "output as JSON")
+}
+
+type pluginListEntry struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Version   string `json:"version"`
+	Ref       string `json:"ref"`
+	Platform  string `json:"platform"`
+	Installed string `json:"installed"`
+}
+
+func runPluginList(cmd *cobra.Command, _ []string) error {
+	w := cmd.OutOrStdout()
+
+	metaDir := metadata.DefaultMetadataDir()
+	metaStore := metadata.NewStore(metaDir)
+
+	plugins, err := metaStore.List()
+	if err != nil {
+		return fmt.Errorf("listing plugins: %w", err)
+	}
+
+	if pluginListJSON {
+		entries := make([]pluginListEntry, len(plugins))
+		for i, p := range plugins {
+			entries[i] = pluginListEntry{
+				Name:      p.Name,
+				Type:      p.Type,
+				Version:   p.Version,
+				Ref:       p.Ref,
+				Platform:  p.Platform,
+				Installed: p.InstalledAt.Format(time.RFC3339),
+			}
+		}
+		data, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(w, string(data))
+		return nil
+	}
+
+	if len(plugins) == 0 {
+		fmt.Fprintln(w, "No shared plugins installed.")
+		fmt.Fprintln(w, "Install one with: zhi plugin install <oci-reference>")
+		return nil
+	}
+
+	headers := []string{"NAME", "TYPE", "VERSION", "PLATFORM", "SOURCE"}
+	var rows [][]string
+	for _, p := range plugins {
+		rows = append(rows, []string{p.Name, p.Type, p.Version, p.Platform, p.Ref})
+	}
+	fprintTable(w, headers, rows)
+	return nil
+}
+
+// --- helpers ---
+
+// newSharingClient creates a client.Client with default directories.
+func newSharingClient() (*client.Client, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("determining home directory: %w", err)
+	}
+
+	pluginDir := filepath.Join(home, ".zhi", "plugins")
+	cacheDir := filepath.Join(home, ".zhi", "cache", "oci")
+	configPath := filepath.Join(home, ".zhi", "config.yaml")
+	metaDir := filepath.Join(home, ".zhi", "metadata")
+
+	regStore, err := registry.NewStore(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading registry config: %w", err)
+	}
+
+	metaStore := metadata.NewStore(metaDir)
+	return client.NewClient(pluginDir, cacheDir, regStore, metaStore), nil
+}
+
+// parsePlatformFlag parses a "os/arch" string into a Platform.
+func parsePlatformFlag(s string) (client.Platform, error) {
+	for i, c := range s {
+		if c == '/' {
+			return client.Platform{OS: s[:i], Arch: s[i+1:]}, nil
+		}
+	}
+	return client.Platform{}, fmt.Errorf("invalid platform %q: expected os/arch format", s)
+}

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/zhi/pkg/sharing/client"
+	"github.com/MrWong99/zhi/pkg/sharing/metadata"
+)
+
+func TestParsePlatformFlag(t *testing.T) {
+	tests := []struct {
+		input   string
+		os      string
+		arch    string
+		wantErr bool
+	}{
+		{"linux/amd64", "linux", "amd64", false},
+		{"darwin/arm64", "darwin", "arm64", false},
+		{"windows/amd64", "windows", "amd64", false},
+		{"invalid", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			p, err := parsePlatformFlag(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePlatformFlag(%q): %v", tt.input, err)
+			}
+			if p.OS != tt.os {
+				t.Errorf("OS = %q, want %q", p.OS, tt.os)
+			}
+			if p.Arch != tt.arch {
+				t.Errorf("Arch = %q, want %q", p.Arch, tt.arch)
+			}
+		})
+	}
+}
+
+func TestPluginUninstall(t *testing.T) {
+	dir := t.TempDir()
+	metaDir := filepath.Join(dir, "metadata")
+	pluginDir := filepath.Join(dir, "plugins")
+
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a fake installed plugin.
+	metaStore := metadata.NewStore(metaDir)
+	meta := &metadata.InstalledPlugin{
+		Name:        "test-plugin",
+		Type:        "config",
+		Version:     "1.0.0",
+		Ref:         "oci://example.com/test:v1.0.0",
+		InstalledAt: time.Now(),
+	}
+	if err := metaStore.Save(meta); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a fake binary.
+	binaryPath := filepath.Join(pluginDir, "zhi-config-test-plugin")
+	if err := os.WriteFile(binaryPath, []byte("fake"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify metadata exists.
+	loaded, err := metaStore.Load("test-plugin")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected metadata to exist before uninstall")
+	}
+}
+
+func TestPluginListJSON(t *testing.T) {
+	dir := t.TempDir()
+	metaStore := metadata.NewStore(dir)
+
+	now := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	plugins := []*metadata.InstalledPlugin{
+		{Name: "alpha", Type: "config", Version: "1.0.0", Ref: "oci://example.com/alpha:v1.0.0", Platform: "linux/amd64", InstalledAt: now},
+		{Name: "beta", Type: "store", Version: "2.0.0", Ref: "oci://example.com/beta:v2.0.0", Platform: "linux/amd64", InstalledAt: now},
+	}
+	for _, p := range plugins {
+		if err := metaStore.Save(p); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+
+	// Verify we can list and format as JSON.
+	list, err := metaStore.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	entries := make([]pluginListEntry, len(list))
+	for i, p := range list {
+		entries[i] = pluginListEntry{
+			Name:      p.Name,
+			Type:      p.Type,
+			Version:   p.Version,
+			Ref:       p.Ref,
+			Platform:  p.Platform,
+			Installed: p.InstalledAt.Format(time.RFC3339),
+		}
+	}
+
+	var buf bytes.Buffer
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf.Write(data)
+
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Name != "alpha" {
+		t.Errorf("first entry name = %q", entries[0].Name)
+	}
+}
+
+func TestNewSharingClientPlatform(t *testing.T) {
+	p := client.CurrentPlatform()
+	if p.OS == "" || p.Arch == "" {
+		t.Error("CurrentPlatform returned empty fields")
+	}
+}

--- a/internal/cli/registry_cmd.go
+++ b/internal/cli/registry_cmd.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MrWong99/zhi/pkg/sharing/registry"
+)
+
+var registryCmd = &cobra.Command{
+	Use:   "registry",
+	Short: "Manage OCI registry authentication",
+	Long: `Authenticate with OCI registries for plugin sharing.
+
+Subcommands:
+  login     Authenticate with an OCI registry
+  logout    Remove stored credentials
+  list      List configured registries`,
+	Example: `  zhi registry login ghcr.io --username myuser
+  zhi registry logout ghcr.io
+  zhi registry list`,
+}
+
+// --- registry login ---
+
+var registryLoginCmd = &cobra.Command{
+	Use:   "login <host>",
+	Short: "Authenticate with an OCI registry",
+	Long: `Store credentials for an OCI registry. The password/token is read from
+stdin if --password is not provided.`,
+	Example: `  zhi registry login ghcr.io --username myuser --password mytoken
+  echo $GHCR_TOKEN | zhi registry login ghcr.io --username myuser --password-stdin`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRegistryLogin,
+}
+
+var (
+	registryLoginUsername  string
+	registryLoginPassword  string
+	registryLoginPassStdin bool
+)
+
+// --- registry logout ---
+
+var registryLogoutCmd = &cobra.Command{
+	Use:     "logout <host>",
+	Short:   "Remove stored credentials for an OCI registry",
+	Example: `  zhi registry logout ghcr.io`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    runRegistryLogout,
+}
+
+// --- registry list ---
+
+var registryListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List configured registries",
+	RunE:  runRegistryList,
+}
+
+func init() {
+	registryLoginCmd.Flags().StringVar(&registryLoginUsername, "username", "", "registry username")
+	registryLoginCmd.Flags().StringVar(&registryLoginPassword, "password", "", "registry password or token")
+	registryLoginCmd.Flags().BoolVar(&registryLoginPassStdin, "password-stdin", false, "read password from stdin")
+
+	registryCmd.AddCommand(registryLoginCmd)
+	registryCmd.AddCommand(registryLogoutCmd)
+	registryCmd.AddCommand(registryListCmd)
+	rootCmd.AddCommand(registryCmd)
+}
+
+func runRegistryLogin(cmd *cobra.Command, args []string) error {
+	host := args[0]
+	w := cmd.OutOrStdout()
+
+	username := registryLoginUsername
+	password := registryLoginPassword
+
+	if registryLoginPassStdin {
+		scanner := bufio.NewScanner(os.Stdin)
+		if scanner.Scan() {
+			password = strings.TrimSpace(scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("reading password from stdin: %w", err)
+		}
+	}
+
+	if username == "" {
+		return fmt.Errorf("--username is required")
+	}
+	if password == "" {
+		return fmt.Errorf("password is required (use --password or --password-stdin)")
+	}
+
+	store, err := newRegistryStore()
+	if err != nil {
+		return err
+	}
+
+	if err := store.Login(host, username, password); err != nil {
+		return fmt.Errorf("storing credentials: %w", err)
+	}
+
+	fmt.Fprintf(w, "Login succeeded for %s\n", host)
+	return nil
+}
+
+func runRegistryLogout(cmd *cobra.Command, args []string) error {
+	host := args[0]
+	w := cmd.OutOrStdout()
+
+	store, err := newRegistryStore()
+	if err != nil {
+		return err
+	}
+
+	if err := store.Logout(host); err != nil {
+		return fmt.Errorf("removing credentials: %w", err)
+	}
+
+	fmt.Fprintf(w, "Logged out from %s\n", host)
+	return nil
+}
+
+func runRegistryList(cmd *cobra.Command, _ []string) error {
+	w := cmd.OutOrStdout()
+
+	store, err := newRegistryStore()
+	if err != nil {
+		return err
+	}
+
+	hosts := store.ListHosts()
+	if len(hosts) == 0 {
+		fmt.Fprintln(w, "No registries configured.")
+		fmt.Fprintln(w, "Login with: zhi registry login <host> --username <user>")
+		return nil
+	}
+
+	sort.Strings(hosts)
+	fmt.Fprintln(w, "Configured registries:")
+	for _, h := range hosts {
+		u, _, _ := store.GetCredentials(h)
+		fmt.Fprintf(w, "  %-30s (user: %s)\n", h, u)
+	}
+	return nil
+}
+
+func newRegistryStore() (*registry.Store, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("determining home directory: %w", err)
+	}
+	configPath := filepath.Join(home, ".zhi", "config.yaml")
+	store, err := registry.NewStore(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading registry config: %w", err)
+	}
+	return store, nil
+}

--- a/internal/cli/registry_cmd_test.go
+++ b/internal/cli/registry_cmd_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/MrWong99/zhi/pkg/sharing/registry"
+)
+
+func TestRegistryLoginLogoutFlow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	store, err := registry.NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	// Login.
+	if err := store.Login("ghcr.io", "testuser", "testtoken"); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	// Verify credentials persist.
+	store2, err := registry.NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore reload: %v", err)
+	}
+
+	u, p, ok := store2.GetCredentials("ghcr.io")
+	if !ok || u != "testuser" || p != "testtoken" {
+		t.Errorf("creds = (%q, %q, %v), want (testuser, testtoken, true)", u, p, ok)
+	}
+
+	// Logout.
+	if err := store2.Logout("ghcr.io"); err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+
+	_, _, ok = store2.GetCredentials("ghcr.io")
+	if ok {
+		t.Error("expected credentials removed after logout")
+	}
+}
+
+func TestRegistryList(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	store, err := registry.NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if err := store.Login("ghcr.io", "u1", "p1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Login("docker.io", "u2", "p2"); err != nil {
+		t.Fatal(err)
+	}
+
+	hosts := store.ListHosts()
+	sort.Strings(hosts)
+	if len(hosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(hosts))
+	}
+	if hosts[0] != "docker.io" || hosts[1] != "ghcr.io" {
+		t.Errorf("hosts = %v", hosts)
+	}
+}
+
+func TestRegistryStoreFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	store, err := registry.NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if err := store.Login("test.io", "u", "p"); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file permissions = %o, want 600", perm)
+	}
+}

--- a/pkg/sharing/client/client.go
+++ b/pkg/sharing/client/client.go
@@ -1,0 +1,295 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/memory"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/MrWong99/zhi/pkg/sharing/manifest"
+	"github.com/MrWong99/zhi/pkg/sharing/metadata"
+	"github.com/MrWong99/zhi/pkg/sharing/registry"
+)
+
+// Platform represents an OS/architecture combination.
+type Platform struct {
+	OS   string
+	Arch string
+}
+
+// String returns the platform in "os/arch" format.
+func (p Platform) String() string {
+	return p.OS + "/" + p.Arch
+}
+
+// CurrentPlatform returns the runtime OS and architecture.
+func CurrentPlatform() Platform {
+	return Platform{OS: runtime.GOOS, Arch: runtime.GOARCH}
+}
+
+// PullOptions controls how a plugin is pulled and installed.
+type PullOptions struct {
+	// Platform overrides automatic platform detection.
+	Platform *Platform
+	// SkipVerify skips signature verification (not recommended).
+	SkipVerify bool
+	// Force overwrites an existing plugin even if the same version is installed.
+	Force bool
+}
+
+// PullResult describes the outcome of a pull operation.
+type PullResult struct {
+	// Manifest is the plugin metadata from the OCI config blob.
+	Manifest *manifest.PluginManifest
+	// BinaryPath is the absolute path where the binary was installed.
+	BinaryPath string
+	// Digest is the OCI manifest digest.
+	Digest string
+	// Platform is the resolved platform.
+	Platform string
+}
+
+// Client manages OCI artifact operations for zhi plugins.
+type Client struct {
+	// pluginDir is where plugin binaries are installed.
+	pluginDir string
+	// cacheDir is the local OCI blob cache directory.
+	cacheDir string
+	// registryStore provides registry credentials.
+	registryStore *registry.Store
+	// metadataStore tracks installed plugins.
+	metadataStore *metadata.Store
+}
+
+// NewClient creates a new OCI client with the given directories and stores.
+func NewClient(pluginDir, cacheDir string, regStore *registry.Store, metaStore *metadata.Store) *Client {
+	return &Client{
+		pluginDir:     pluginDir,
+		cacheDir:      cacheDir,
+		registryStore: regStore,
+		metadataStore: metaStore,
+	}
+}
+
+// PullPlugin downloads and installs a plugin from an OCI reference.
+func (c *Client) PullPlugin(ctx context.Context, ref string, opts PullOptions) (*PullResult, error) {
+	parsed, err := ParseReference(ref)
+	if err != nil {
+		return nil, fmt.Errorf("parsing reference: %w", err)
+	}
+
+	// Set up remote repository.
+	repo, err := c.newRepository(parsed)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to registry: %w", err)
+	}
+
+	// Determine tag or digest to pull.
+	pullRef := parsed.Tag
+	if parsed.Digest != "" {
+		pullRef = parsed.Digest
+	}
+	if pullRef == "" {
+		pullRef = "latest"
+	}
+
+	// Pull into an in-memory store.
+	memStore := memory.New()
+	desc, err := oras.Copy(ctx, repo, pullRef, memStore, pullRef, oras.DefaultCopyOptions)
+	if err != nil {
+		return nil, fmt.Errorf("pulling artifact: %w", err)
+	}
+
+	// Resolve the platform-specific manifest if this is an index.
+	manifestDesc, err := c.resolvePlatform(ctx, memStore, desc, opts.Platform)
+	if err != nil {
+		return nil, fmt.Errorf("resolving platform: %w", err)
+	}
+
+	// Fetch and parse the manifest.
+	manifestData, err := readBlob(ctx, memStore, manifestDesc)
+	if err != nil {
+		return nil, fmt.Errorf("reading manifest: %w", err)
+	}
+
+	var ociManifest ocispec.Manifest
+	if err := json.Unmarshal(manifestData, &ociManifest); err != nil {
+		return nil, fmt.Errorf("parsing OCI manifest: %w", err)
+	}
+
+	// Parse the config blob for plugin metadata.
+	configData, err := readBlob(ctx, memStore, ociManifest.Config)
+	if err != nil {
+		return nil, fmt.Errorf("reading config blob: %w", err)
+	}
+
+	pluginManifest, err := parseConfigBlob(configData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing plugin config: %w", err)
+	}
+
+	// Check if already installed at same version.
+	if !opts.Force {
+		existing, _ := c.metadataStore.Load(pluginManifest.Name)
+		if existing != nil && existing.Version == pluginManifest.Version {
+			return &PullResult{
+				Manifest:   pluginManifest,
+				BinaryPath: filepath.Join(c.pluginDir, pluginManifest.BinaryName()),
+				Digest:     string(desc.Digest),
+				Platform:   c.effectivePlatform(opts.Platform).String(),
+			}, nil
+		}
+	}
+
+	// Find and extract the binary layer.
+	binaryData, err := c.extractBinaryLayer(ctx, memStore, ociManifest.Layers)
+	if err != nil {
+		return nil, fmt.Errorf("extracting binary: %w", err)
+	}
+
+	// Install binary.
+	binaryPath := filepath.Join(c.pluginDir, pluginManifest.BinaryName())
+	if err := c.installBinary(binaryPath, binaryData); err != nil {
+		return nil, fmt.Errorf("installing binary: %w", err)
+	}
+
+	// Save metadata.
+	platform := c.effectivePlatform(opts.Platform)
+	meta := &metadata.InstalledPlugin{
+		Name:      pluginManifest.Name,
+		Type:      pluginManifest.Type,
+		Version:   pluginManifest.Version,
+		Ref:       ref,
+		Digest:    string(desc.Digest),
+		Platform:  platform.String(),
+		Publisher: pluginManifest.Author,
+	}
+	if err := c.metadataStore.Save(meta); err != nil {
+		return nil, fmt.Errorf("saving metadata: %w", err)
+	}
+
+	return &PullResult{
+		Manifest:   pluginManifest,
+		BinaryPath: binaryPath,
+		Digest:     string(desc.Digest),
+		Platform:   platform.String(),
+	}, nil
+}
+
+// newRepository creates an authenticated remote repository.
+func (c *Client) newRepository(parsed *ParsedRef) (*remote.Repository, error) {
+	repo, err := remote.NewRepository(parsed.Reference())
+	if err != nil {
+		return nil, err
+	}
+
+	if c.registryStore != nil {
+		username, password, ok := c.registryStore.GetCredentials(parsed.Host)
+		if ok {
+			repo.Client = &auth.Client{
+				Credential: auth.StaticCredential(parsed.Host, auth.Credential{
+					Username: username,
+					Password: password,
+				}),
+			}
+		}
+	}
+
+	return repo, nil
+}
+
+// resolvePlatform selects the platform-specific manifest from an OCI Image
+// Index, or returns the descriptor as-is if it's already a single manifest.
+func (c *Client) resolvePlatform(ctx context.Context, store oras.ReadOnlyTarget, desc ocispec.Descriptor, platform *Platform) (ocispec.Descriptor, error) {
+	// If it's already a manifest, return it directly.
+	if desc.MediaType == ocispec.MediaTypeImageManifest {
+		return desc, nil
+	}
+
+	// For an index, select the matching platform.
+	if desc.MediaType != ocispec.MediaTypeImageIndex {
+		return desc, nil
+	}
+
+	data, err := readBlob(ctx, store, desc)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("reading index: %w", err)
+	}
+
+	var index ocispec.Index
+	if err := json.Unmarshal(data, &index); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("parsing index: %w", err)
+	}
+
+	target := c.effectivePlatform(platform)
+
+	for _, m := range index.Manifests {
+		if m.Platform != nil && m.Platform.OS == target.OS && m.Platform.Architecture == target.Arch {
+			// Fetch the actual manifest data so we can work with it.
+			return m, nil
+		}
+	}
+
+	return ocispec.Descriptor{}, fmt.Errorf("no manifest found for platform %s", target)
+}
+
+// effectivePlatform returns the override platform if set, else current platform.
+func (c *Client) effectivePlatform(override *Platform) Platform {
+	if override != nil {
+		return *override
+	}
+	return CurrentPlatform()
+}
+
+// extractBinaryLayer finds and reads the plugin binary layer from OCI layers.
+func (c *Client) extractBinaryLayer(ctx context.Context, store oras.ReadOnlyTarget, layers []ocispec.Descriptor) ([]byte, error) {
+	for _, layer := range layers {
+		if layer.MediaType == MediaTypePluginBinary {
+			return readBlob(ctx, store, layer)
+		}
+	}
+	return nil, fmt.Errorf("no binary layer found (expected media type %s)", MediaTypePluginBinary)
+}
+
+// installBinary writes the plugin binary to disk with executable permissions.
+func (c *Client) installBinary(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating plugin directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o755); err != nil {
+		return fmt.Errorf("writing binary: %w", err)
+	}
+	return nil
+}
+
+// parseConfigBlob parses an OCI config blob as plugin manifest JSON.
+func parseConfigBlob(data []byte) (*manifest.PluginManifest, error) {
+	var m manifest.PluginManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("unmarshalling config: %w", err)
+	}
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// readBlob fetches the content of a descriptor from a store.
+func readBlob(ctx context.Context, store oras.ReadOnlyTarget, desc ocispec.Descriptor) ([]byte, error) {
+	rc, err := store.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return io.ReadAll(rc)
+}

--- a/pkg/sharing/client/client_test.go
+++ b/pkg/sharing/client/client_test.go
@@ -1,0 +1,74 @@
+package client
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestCurrentPlatform(t *testing.T) {
+	p := CurrentPlatform()
+	if p.OS != runtime.GOOS {
+		t.Errorf("OS = %q, want %q", p.OS, runtime.GOOS)
+	}
+	if p.Arch != runtime.GOARCH {
+		t.Errorf("Arch = %q, want %q", p.Arch, runtime.GOARCH)
+	}
+}
+
+func TestPlatformString(t *testing.T) {
+	p := Platform{OS: "linux", Arch: "amd64"}
+	if got := p.String(); got != "linux/amd64" {
+		t.Errorf("String() = %q, want %q", got, "linux/amd64")
+	}
+}
+
+func TestMediaTypeConstants(t *testing.T) {
+	// Verify media type constants are consistent with the distribution format spec.
+	if MediaTypePluginConfig != "application/vnd.zhi.plugin.config.v1+json" {
+		t.Errorf("MediaTypePluginConfig = %q", MediaTypePluginConfig)
+	}
+	if MediaTypePluginBinary != "application/vnd.zhi.plugin.binary.v1" {
+		t.Errorf("MediaTypePluginBinary = %q", MediaTypePluginBinary)
+	}
+	if MediaTypePluginRuntime != "application/vnd.zhi.plugin.runtime.v1+tar.gz" {
+		t.Errorf("MediaTypePluginRuntime = %q", MediaTypePluginRuntime)
+	}
+}
+
+func TestParseConfigBlob(t *testing.T) {
+	data := []byte(`{
+		"name": "test-plugin",
+		"type": "config",
+		"version": "1.0.0",
+		"description": "A test plugin"
+	}`)
+	m, err := parseConfigBlob(data)
+	if err != nil {
+		t.Fatalf("parseConfigBlob: %v", err)
+	}
+	if m.Name != "test-plugin" {
+		t.Errorf("Name = %q", m.Name)
+	}
+	if m.Type != "config" {
+		t.Errorf("Type = %q", m.Type)
+	}
+}
+
+func TestParseConfigBlobInvalid(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"invalid json", `not json`},
+		{"missing name", `{"type":"config","version":"1.0.0"}`},
+		{"invalid type", `{"name":"test","type":"bad","version":"1.0.0"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseConfigBlob([]byte(tt.data))
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}

--- a/pkg/sharing/client/media.go
+++ b/pkg/sharing/client/media.go
@@ -1,0 +1,12 @@
+// Package client provides an OCI artifact client for pulling and pushing
+// zhi plugin artifacts using oras-go v2.
+package client
+
+// OCI media types for zhi plugin artifacts.
+const (
+	MediaTypePluginConfig  = "application/vnd.zhi.plugin.config.v1+json"
+	MediaTypePluginBinary  = "application/vnd.zhi.plugin.binary.v1"
+	MediaTypePluginRuntime = "application/vnd.zhi.plugin.runtime.v1+tar.gz"
+	MediaTypePluginReadme  = "application/vnd.zhi.plugin.readme.v1+markdown"
+	MediaTypePluginLicense = "application/vnd.zhi.plugin.license.v1"
+)

--- a/pkg/sharing/client/ref.go
+++ b/pkg/sharing/client/ref.go
@@ -1,0 +1,84 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParsedRef holds the components of an OCI reference.
+type ParsedRef struct {
+	// Host is the registry host (e.g. "ghcr.io").
+	Host string
+	// Repository is the image repository path (e.g. "zhi-project/zhi-config-ansible").
+	Repository string
+	// Tag is the image tag (e.g. "v1.2.0"). Empty if digest is specified.
+	Tag string
+	// Digest is the content digest (e.g. "sha256:abc123"). Empty if tag is specified.
+	Digest string
+}
+
+// Reference returns the full reference string in the form host/repo:tag or host/repo@digest.
+func (r *ParsedRef) Reference() string {
+	ref := r.Host + "/" + r.Repository
+	if r.Digest != "" {
+		return ref + "@" + r.Digest
+	}
+	if r.Tag != "" {
+		return ref + ":" + r.Tag
+	}
+	return ref
+}
+
+// ParseReference parses an OCI reference string. It accepts:
+//   - oci://host/repo:tag
+//   - oci://host/repo@digest
+//   - host/repo:tag (without scheme)
+//   - host/repo@digest (without scheme)
+func ParseReference(ref string) (*ParsedRef, error) {
+	// Strip oci:// scheme if present.
+	raw := strings.TrimPrefix(ref, "oci://")
+
+	if raw == "" {
+		return nil, fmt.Errorf("empty OCI reference")
+	}
+
+	parsed := &ParsedRef{}
+
+	// Split by @ for digest references.
+	if idx := strings.Index(raw, "@"); idx >= 0 {
+		parsed.Digest = raw[idx+1:]
+		raw = raw[:idx]
+	}
+
+	// Split by : for tag (only if no digest and host already separated).
+	if parsed.Digest == "" {
+		// Find the last colon that's after the first slash (to avoid matching port numbers).
+		slashIdx := strings.Index(raw, "/")
+		if slashIdx < 0 {
+			return nil, fmt.Errorf("invalid OCI reference %q: missing repository path", ref)
+		}
+		colonIdx := strings.LastIndex(raw[slashIdx:], ":")
+		if colonIdx >= 0 {
+			colonIdx += slashIdx
+			parsed.Tag = raw[colonIdx+1:]
+			raw = raw[:colonIdx]
+		}
+	}
+
+	// Split host from repository.
+	slashIdx := strings.Index(raw, "/")
+	if slashIdx < 0 {
+		return nil, fmt.Errorf("invalid OCI reference %q: missing repository path", ref)
+	}
+	parsed.Host = raw[:slashIdx]
+	parsed.Repository = raw[slashIdx+1:]
+
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("invalid OCI reference %q: empty host", ref)
+	}
+	if parsed.Repository == "" {
+		return nil, fmt.Errorf("invalid OCI reference %q: empty repository", ref)
+	}
+
+	return parsed, nil
+}

--- a/pkg/sharing/client/ref_test.go
+++ b/pkg/sharing/client/ref_test.go
@@ -1,0 +1,131 @@
+package client
+
+import "testing"
+
+func TestParseReference(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		host    string
+		repo    string
+		tag     string
+		digest  string
+		wantErr bool
+	}{
+		{
+			name:  "full oci reference with tag",
+			input: "oci://ghcr.io/zhi-project/zhi-config-ansible:v1.2.0",
+			host:  "ghcr.io",
+			repo:  "zhi-project/zhi-config-ansible",
+			tag:   "v1.2.0",
+		},
+		{
+			name:   "oci reference with digest",
+			input:  "oci://ghcr.io/zhi-project/zhi-config-ansible@sha256:abc123",
+			host:   "ghcr.io",
+			repo:   "zhi-project/zhi-config-ansible",
+			digest: "sha256:abc123",
+		},
+		{
+			name:  "without scheme",
+			input: "ghcr.io/zhi-project/zhi-config-ansible:v1.2.0",
+			host:  "ghcr.io",
+			repo:  "zhi-project/zhi-config-ansible",
+			tag:   "v1.2.0",
+		},
+		{
+			name:  "docker hub style",
+			input: "docker.io/library/plugin:latest",
+			host:  "docker.io",
+			repo:  "library/plugin",
+			tag:   "latest",
+		},
+		{
+			name:  "no tag or digest",
+			input: "ghcr.io/org/repo",
+			host:  "ghcr.io",
+			repo:  "org/repo",
+		},
+		{
+			name:  "registry with port",
+			input: "localhost:5000/myrepo:v1.0.0",
+			host:  "localhost:5000",
+			repo:  "myrepo",
+			tag:   "v1.0.0",
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "oci scheme only",
+			input:   "oci://",
+			wantErr: true,
+		},
+		{
+			name:    "no slash",
+			input:   "ghcr.io",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, err := ParseReference(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseReference(%q): %v", tt.input, err)
+			}
+			if ref.Host != tt.host {
+				t.Errorf("Host = %q, want %q", ref.Host, tt.host)
+			}
+			if ref.Repository != tt.repo {
+				t.Errorf("Repository = %q, want %q", ref.Repository, tt.repo)
+			}
+			if ref.Tag != tt.tag {
+				t.Errorf("Tag = %q, want %q", ref.Tag, tt.tag)
+			}
+			if ref.Digest != tt.digest {
+				t.Errorf("Digest = %q, want %q", ref.Digest, tt.digest)
+			}
+		})
+	}
+}
+
+func TestParsedRefReference(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  ParsedRef
+		want string
+	}{
+		{
+			name: "with tag",
+			ref:  ParsedRef{Host: "ghcr.io", Repository: "org/repo", Tag: "v1.0.0"},
+			want: "ghcr.io/org/repo:v1.0.0",
+		},
+		{
+			name: "with digest",
+			ref:  ParsedRef{Host: "ghcr.io", Repository: "org/repo", Digest: "sha256:abc"},
+			want: "ghcr.io/org/repo@sha256:abc",
+		},
+		{
+			name: "no tag or digest",
+			ref:  ParsedRef{Host: "ghcr.io", Repository: "org/repo"},
+			want: "ghcr.io/org/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ref.Reference(); got != tt.want {
+				t.Errorf("Reference() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/sharing/manifest/manifest.go
+++ b/pkg/sharing/manifest/manifest.go
@@ -1,0 +1,170 @@
+// Package manifest defines the plugin manifest schema (zhi-plugin.yaml) and
+// provides parsing and validation for plugin metadata.
+package manifest
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SchemaVersion is the current manifest schema version.
+const SchemaVersion = "1"
+
+// Valid plugin types.
+const (
+	TypeConfig    = "config"
+	TypeTransform = "transform"
+	TypeStore     = "store"
+	TypeUI        = "ui"
+)
+
+// validTypes is the set of accepted plugin types.
+var validTypes = map[string]bool{
+	TypeConfig:    true,
+	TypeTransform: true,
+	TypeStore:     true,
+	TypeUI:        true,
+}
+
+// namePattern matches valid plugin names: lowercase letter, then lowercase
+// alphanumeric or hyphens. Minimum 2 characters.
+var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+
+// semverPattern matches a basic semver string (major.minor.patch with optional
+// pre-release suffix).
+var semverPattern = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$`)
+
+// PluginManifest describes a published plugin's metadata. It is serialised as
+// zhi-plugin.yaml in the project root and as the OCI config blob.
+type PluginManifest struct {
+	// SchemaVersion allows forward-compatible manifest evolution.
+	SchemaVersion string `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty"`
+
+	// Name is the plugin's short name (e.g. "ansible-config").
+	Name string `yaml:"name" json:"name"`
+
+	// Type is one of: config, transform, store, ui.
+	Type string `yaml:"type" json:"type"`
+
+	// Version is a semver version string (e.g. "1.2.0").
+	Version string `yaml:"version" json:"version"`
+
+	// ZhiProtocolVersion is the zhi plugin protocol version.
+	ZhiProtocolVersion string `yaml:"zhiProtocolVersion,omitempty" json:"zhiProtocolVersion,omitempty"`
+
+	// Description is a short summary of what the plugin does.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+
+	// Author is the plugin publisher's name or organisation.
+	Author string `yaml:"author,omitempty" json:"author,omitempty"`
+
+	// License is the SPDX license identifier (e.g. "Apache-2.0").
+	License string `yaml:"license,omitempty" json:"license,omitempty"`
+
+	// Homepage is a URL for the plugin's documentation or repository.
+	Homepage string `yaml:"homepage,omitempty" json:"homepage,omitempty"`
+
+	// Keywords are search terms for marketplace discovery.
+	Keywords []string `yaml:"keywords,omitempty" json:"keywords,omitempty"`
+
+	// Runtime declares non-Go runtime dependencies.
+	Runtime *RuntimeRequirement `yaml:"runtime,omitempty" json:"runtime,omitempty"`
+
+	// MinZhiVersion is the minimum zhi version that supports this plugin.
+	MinZhiVersion string `yaml:"minZhiVersion,omitempty" json:"minZhiVersion,omitempty"`
+
+	// Binaries maps platform strings to binary paths (for publishing).
+	Binaries map[string]string `yaml:"binaries,omitempty" json:"binaries,omitempty"`
+}
+
+// RuntimeRequirement declares a non-Go runtime needed by the plugin binary.
+type RuntimeRequirement struct {
+	// Type is the runtime name: java, python, node, etc.
+	Type string `yaml:"type" json:"type"`
+	// Version is a semver constraint like ">=17" or "^3.10".
+	Version string `yaml:"version" json:"version"`
+	// Bundled indicates whether the runtime is included in the OCI artifact.
+	Bundled bool `yaml:"bundled" json:"bundled"`
+}
+
+// LoadFile reads and parses a manifest from the given file path.
+func LoadFile(path string) (*PluginManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading manifest: %w", err)
+	}
+	return Parse(data)
+}
+
+// Parse unmarshals YAML data into a PluginManifest and validates it.
+func Parse(data []byte) (*PluginManifest, error) {
+	var m PluginManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing manifest YAML: %w", err)
+	}
+	if m.SchemaVersion == "" {
+		m.SchemaVersion = SchemaVersion
+	}
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// Validate checks that the manifest has all required fields with valid values.
+func (m *PluginManifest) Validate() error {
+	var errs []string
+
+	if m.Name == "" {
+		errs = append(errs, "name is required")
+	} else if !namePattern.MatchString(m.Name) {
+		errs = append(errs, fmt.Sprintf("name %q must match [a-z][a-z0-9-]*", m.Name))
+	}
+
+	if m.Type == "" {
+		errs = append(errs, "type is required")
+	} else if !validTypes[m.Type] {
+		errs = append(errs, fmt.Sprintf("type %q must be one of: config, transform, store, ui", m.Type))
+	}
+
+	if m.Version == "" {
+		errs = append(errs, "version is required")
+	} else if !semverPattern.MatchString(m.Version) {
+		errs = append(errs, fmt.Sprintf("version %q is not valid semver", m.Version))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("invalid plugin manifest: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// BinaryName returns the expected binary name for this plugin following the
+// zhi flat naming convention: zhi-<type>-<name>.
+func (m *PluginManifest) BinaryName() string {
+	return fmt.Sprintf("zhi-%s-%s", m.Type, m.Name)
+}
+
+// Marshal serialises the manifest as YAML.
+func (m *PluginManifest) Marshal() ([]byte, error) {
+	return yaml.Marshal(m)
+}
+
+// IsValidPluginType returns whether the given string is a known plugin type.
+func IsValidPluginType(t string) bool {
+	return validTypes[t]
+}
+
+// IsValidName returns whether the given name matches the plugin naming rules.
+func IsValidName(name string) bool {
+	return namePattern.MatchString(name)
+}
+
+// IsValidSemver returns whether the given string is valid semver.
+func IsValidSemver(v string) bool {
+	return semverPattern.MatchString(v)
+}

--- a/pkg/sharing/manifest/manifest_test.go
+++ b/pkg/sharing/manifest/manifest_test.go
@@ -1,0 +1,248 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseValidManifest(t *testing.T) {
+	data := []byte(`
+name: ansible-config
+type: config
+version: 1.2.0
+description: Ansible inventory config provider
+author: zhi-project
+license: Apache-2.0
+homepage: https://github.com/zhi-project/zhi-config-ansible
+keywords:
+  - ansible
+  - inventory
+`)
+	m, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if m.Name != "ansible-config" {
+		t.Errorf("Name = %q, want %q", m.Name, "ansible-config")
+	}
+	if m.Type != "config" {
+		t.Errorf("Type = %q, want %q", m.Type, "config")
+	}
+	if m.Version != "1.2.0" {
+		t.Errorf("Version = %q, want %q", m.Version, "1.2.0")
+	}
+	if m.SchemaVersion != SchemaVersion {
+		t.Errorf("SchemaVersion = %q, want %q", m.SchemaVersion, SchemaVersion)
+	}
+	if m.Description != "Ansible inventory config provider" {
+		t.Errorf("Description = %q", m.Description)
+	}
+	if len(m.Keywords) != 2 {
+		t.Errorf("Keywords = %v, want 2 entries", m.Keywords)
+	}
+}
+
+func TestParseAllTypes(t *testing.T) {
+	for _, typ := range []string{"config", "transform", "store", "ui"} {
+		t.Run(typ, func(t *testing.T) {
+			data := []byte("name: test-plugin\ntype: " + typ + "\nversion: 0.1.0\n")
+			m, err := Parse(data)
+			if err != nil {
+				t.Fatalf("Parse(%s): %v", typ, err)
+			}
+			if m.Type != typ {
+				t.Errorf("Type = %q, want %q", m.Type, typ)
+			}
+		})
+	}
+}
+
+func TestParseWithRuntime(t *testing.T) {
+	data := []byte(`
+name: vault-store
+type: store
+version: 2.0.0
+runtime:
+  type: java
+  version: ">=17"
+  bundled: true
+`)
+	m, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if m.Runtime == nil {
+		t.Fatal("Runtime is nil")
+	}
+	if m.Runtime.Type != "java" {
+		t.Errorf("Runtime.Type = %q, want %q", m.Runtime.Type, "java")
+	}
+	if m.Runtime.Version != ">=17" {
+		t.Errorf("Runtime.Version = %q, want %q", m.Runtime.Version, ">=17")
+	}
+	if !m.Runtime.Bundled {
+		t.Error("Runtime.Bundled = false, want true")
+	}
+}
+
+func TestValidateMissingFields(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{"missing name", "type: config\nversion: 1.0.0\n"},
+		{"missing type", "name: foo\nversion: 1.0.0\n"},
+		{"missing version", "name: foo\ntype: config\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.yaml))
+			if err == nil {
+				t.Error("expected validation error")
+			}
+		})
+	}
+}
+
+func TestValidateInvalidName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"uppercase", "MyPlugin"},
+		{"starts with number", "1plugin"},
+		{"special chars", "my_plugin"},
+		{"spaces", "my plugin"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := []byte("name: " + tt.input + "\ntype: config\nversion: 1.0.0\n")
+			_, err := Parse(data)
+			if err == nil {
+				t.Errorf("expected error for name %q", tt.input)
+			}
+		})
+	}
+}
+
+func TestValidateInvalidType(t *testing.T) {
+	data := []byte("name: test\ntype: invalid\nversion: 1.0.0\n")
+	_, err := Parse(data)
+	if err == nil {
+		t.Error("expected error for invalid type")
+	}
+}
+
+func TestValidateInvalidVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{"no dots", "100"},
+		{"only major.minor", "1.0"},
+		{"letters", "abc"},
+		{"v prefix", "v1.0.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := []byte("name: test\ntype: config\nversion: " + tt.version + "\n")
+			_, err := Parse(data)
+			if err == nil {
+				t.Errorf("expected error for version %q", tt.version)
+			}
+		})
+	}
+}
+
+func TestValidSemver(t *testing.T) {
+	valid := []string{"0.0.1", "1.0.0", "1.2.3", "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0+build.123"}
+	for _, v := range valid {
+		if !IsValidSemver(v) {
+			t.Errorf("IsValidSemver(%q) = false, want true", v)
+		}
+	}
+}
+
+func TestBinaryName(t *testing.T) {
+	m := &PluginManifest{Name: "ansible-config", Type: "config"}
+	if got := m.BinaryName(); got != "zhi-config-ansible-config" {
+		t.Errorf("BinaryName = %q, want %q", got, "zhi-config-ansible-config")
+	}
+}
+
+func TestMarshalRoundTrip(t *testing.T) {
+	original := &PluginManifest{
+		SchemaVersion: SchemaVersion,
+		Name:          "test-plugin",
+		Type:          "config",
+		Version:       "1.0.0",
+		Description:   "A test plugin",
+		Author:        "test",
+		License:       "MIT",
+		Keywords:      []string{"test", "example"},
+	}
+	data, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	parsed, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if parsed.Name != original.Name {
+		t.Errorf("Name = %q, want %q", parsed.Name, original.Name)
+	}
+	if parsed.Version != original.Version {
+		t.Errorf("Version = %q, want %q", parsed.Version, original.Version)
+	}
+}
+
+func TestLoadFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "zhi-plugin.yaml")
+	data := []byte("name: file-test\ntype: store\nversion: 0.1.0\n")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if m.Name != "file-test" {
+		t.Errorf("Name = %q, want %q", m.Name, "file-test")
+	}
+}
+
+func TestLoadFileNotFound(t *testing.T) {
+	_, err := LoadFile("/nonexistent/path/zhi-plugin.yaml")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestIsValidPluginType(t *testing.T) {
+	for _, typ := range []string{"config", "transform", "store", "ui"} {
+		if !IsValidPluginType(typ) {
+			t.Errorf("IsValidPluginType(%q) = false", typ)
+		}
+	}
+	if IsValidPluginType("invalid") {
+		t.Error("IsValidPluginType(\"invalid\") = true")
+	}
+}
+
+func TestIsValidName(t *testing.T) {
+	valid := []string{"a", "ab", "my-plugin", "plugin123", "a1"}
+	for _, n := range valid {
+		if !IsValidName(n) {
+			t.Errorf("IsValidName(%q) = false, want true", n)
+		}
+	}
+	invalid := []string{"", "1abc", "My-Plugin", "my_plugin"}
+	for _, n := range invalid {
+		if IsValidName(n) {
+			t.Errorf("IsValidName(%q) = true, want false", n)
+		}
+	}
+}

--- a/pkg/sharing/metadata/metadata.go
+++ b/pkg/sharing/metadata/metadata.go
@@ -1,0 +1,133 @@
+// Package metadata manages the local installed-plugin metadata store at
+// ~/.zhi/metadata/. Each installed plugin has a JSON file tracking its
+// version, OCI reference, digest, and installation time.
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// InstalledPlugin records metadata for a plugin installed from an OCI registry.
+type InstalledPlugin struct {
+	// Name is the plugin's short name.
+	Name string `json:"name"`
+	// Type is the plugin type: config, transform, store, ui.
+	Type string `json:"type"`
+	// Version is the installed semver version.
+	Version string `json:"version"`
+	// Ref is the full OCI reference the plugin was installed from.
+	Ref string `json:"ref"`
+	// Digest is the OCI manifest digest (e.g. "sha256:abc123...").
+	Digest string `json:"digest"`
+	// Platform is the OS/arch string (e.g. "linux/amd64").
+	Platform string `json:"platform"`
+	// InstalledAt is the installation timestamp.
+	InstalledAt time.Time `json:"installedAt"`
+	// Publisher is the plugin author or organisation.
+	Publisher string `json:"publisher,omitempty"`
+}
+
+// Store manages plugin metadata files on disk.
+type Store struct {
+	dir string
+}
+
+// DefaultMetadataDir returns the default metadata directory (~/.zhi/metadata/).
+func DefaultMetadataDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".zhi", "metadata")
+}
+
+// NewStore creates a metadata store rooted at the given directory.
+func NewStore(dir string) *Store {
+	return &Store{dir: dir}
+}
+
+// Save writes plugin metadata to a JSON file named <plugin-name>.json.
+func (s *Store) Save(p *InstalledPlugin) error {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("creating metadata directory: %w", err)
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling metadata: %w", err)
+	}
+	path := s.pluginPath(p.Name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing metadata: %w", err)
+	}
+	return nil
+}
+
+// Load reads metadata for the named plugin. Returns nil if not found.
+func (s *Store) Load(name string) (*InstalledPlugin, error) {
+	path := s.pluginPath(name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading metadata: %w", err)
+	}
+	var p InstalledPlugin
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parsing metadata: %w", err)
+	}
+	return &p, nil
+}
+
+// Delete removes the metadata file for the named plugin.
+func (s *Store) Delete(name string) error {
+	path := s.pluginPath(name)
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("removing metadata: %w", err)
+	}
+	return nil
+}
+
+// List returns metadata for all installed plugins, sorted by name.
+func (s *Store) List() ([]*InstalledPlugin, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing metadata directory: %w", err)
+	}
+
+	var plugins []*InstalledPlugin
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		name := entry.Name()[:len(entry.Name())-len(".json")]
+		p, err := s.Load(name)
+		if err != nil {
+			continue
+		}
+		if p != nil {
+			plugins = append(plugins, p)
+		}
+	}
+
+	sort.Slice(plugins, func(i, j int) bool {
+		return plugins[i].Name < plugins[j].Name
+	})
+	return plugins, nil
+}
+
+// pluginPath returns the file path for a plugin's metadata.
+func (s *Store) pluginPath(name string) string {
+	return filepath.Join(s.dir, name+".json")
+}

--- a/pkg/sharing/metadata/metadata_test.go
+++ b/pkg/sharing/metadata/metadata_test.go
@@ -1,0 +1,202 @@
+package metadata
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+
+	p := &InstalledPlugin{
+		Name:        "ansible-config",
+		Type:        "config",
+		Version:     "1.2.0",
+		Ref:         "oci://ghcr.io/zhi-project/zhi-config-ansible:v1.2.0",
+		Digest:      "sha256:abc123",
+		Platform:    "linux/amd64",
+		InstalledAt: time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
+		Publisher:   "zhi-project",
+	}
+
+	if err := s.Save(p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := s.Load("ansible-config")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("Load returned nil")
+	}
+	if loaded.Name != p.Name {
+		t.Errorf("Name = %q, want %q", loaded.Name, p.Name)
+	}
+	if loaded.Version != p.Version {
+		t.Errorf("Version = %q, want %q", loaded.Version, p.Version)
+	}
+	if loaded.Ref != p.Ref {
+		t.Errorf("Ref = %q, want %q", loaded.Ref, p.Ref)
+	}
+	if loaded.Digest != p.Digest {
+		t.Errorf("Digest = %q, want %q", loaded.Digest, p.Digest)
+	}
+	if loaded.Platform != p.Platform {
+		t.Errorf("Platform = %q, want %q", loaded.Platform, p.Platform)
+	}
+	if loaded.Publisher != p.Publisher {
+		t.Errorf("Publisher = %q, want %q", loaded.Publisher, p.Publisher)
+	}
+}
+
+func TestLoadNotFound(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+
+	p, err := s.Load("nonexistent")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if p != nil {
+		t.Errorf("expected nil for nonexistent plugin, got %+v", p)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+
+	p := &InstalledPlugin{
+		Name:        "test-plugin",
+		Type:        "store",
+		Version:     "0.1.0",
+		Ref:         "oci://example.com/test:v0.1.0",
+		InstalledAt: time.Now(),
+	}
+
+	if err := s.Save(p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := s.Delete("test-plugin"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	loaded, err := s.Load("test-plugin")
+	if err != nil {
+		t.Fatalf("Load after delete: %v", err)
+	}
+	if loaded != nil {
+		t.Error("expected nil after delete")
+	}
+}
+
+func TestDeleteNotFound(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+
+	// Should not error for nonexistent.
+	if err := s.Delete("nonexistent"); err != nil {
+		t.Errorf("Delete nonexistent: %v", err)
+	}
+}
+
+func TestList(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+
+	now := time.Now()
+	plugins := []*InstalledPlugin{
+		{Name: "beta", Type: "config", Version: "1.0.0", InstalledAt: now},
+		{Name: "alpha", Type: "store", Version: "2.0.0", InstalledAt: now},
+		{Name: "gamma", Type: "transform", Version: "0.5.0", InstalledAt: now},
+	}
+
+	for _, p := range plugins {
+		if err := s.Save(p); err != nil {
+			t.Fatalf("Save %s: %v", p.Name, err)
+		}
+	}
+
+	list, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(list) != 3 {
+		t.Fatalf("expected 3 plugins, got %d", len(list))
+	}
+
+	// Should be sorted by name.
+	if list[0].Name != "alpha" {
+		t.Errorf("first = %q, want %q", list[0].Name, "alpha")
+	}
+	if list[1].Name != "beta" {
+		t.Errorf("second = %q, want %q", list[1].Name, "beta")
+	}
+	if list[2].Name != "gamma" {
+		t.Errorf("third = %q, want %q", list[2].Name, "gamma")
+	}
+}
+
+func TestListEmpty(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+
+	list, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("expected empty list, got %d", len(list))
+	}
+}
+
+func TestListNonexistentDir(t *testing.T) {
+	s := NewStore(filepath.Join(t.TempDir(), "nonexistent"))
+
+	list, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if list != nil {
+		t.Errorf("expected nil list, got %v", list)
+	}
+}
+
+func TestDefaultMetadataDir(t *testing.T) {
+	dir := DefaultMetadataDir()
+	if dir == "" {
+		t.Skip("cannot determine home directory")
+	}
+	if !filepath.IsAbs(dir) {
+		t.Errorf("DefaultMetadataDir() = %q, want absolute path", dir)
+	}
+}
+
+func TestSaveCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "metadata")
+	s := NewStore(dir)
+
+	p := &InstalledPlugin{
+		Name:        "test",
+		Type:        "config",
+		Version:     "1.0.0",
+		InstalledAt: time.Now(),
+	}
+
+	if err := s.Save(p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := s.Load("test")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil after save to nested directory")
+	}
+}

--- a/pkg/sharing/registry/registry.go
+++ b/pkg/sharing/registry/registry.go
@@ -1,0 +1,145 @@
+// Package registry provides registry configuration and authentication for
+// OCI registries used by zhi's plugin sharing system.
+package registry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds sharing registry settings, typically loaded from
+// ~/.zhi/config.yaml.
+type Config struct {
+	// Default is the default OCI registry host.
+	Default string `yaml:"default,omitempty" json:"default,omitempty"`
+	// Registries maps host names to per-registry configuration.
+	Registries map[string]Entry `yaml:"registries,omitempty" json:"registries,omitempty"`
+}
+
+// Entry holds authentication and options for a single OCI registry.
+type Entry struct {
+	// Username for basic authentication.
+	Username string `yaml:"username,omitempty" json:"username,omitempty"`
+	// Password or token for authentication. Never logged.
+	Password string `yaml:"password,omitempty" json:"password,omitempty"`
+	// Insecure allows plain HTTP (for development registries).
+	Insecure bool `yaml:"insecure,omitempty" json:"insecure,omitempty"`
+}
+
+// Store manages registry credentials on disk. It is safe for concurrent use.
+type Store struct {
+	mu   sync.Mutex
+	path string
+	cfg  Config
+}
+
+// DefaultConfigDir returns the default zhi config directory (~/.zhi/).
+func DefaultConfigDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".zhi")
+}
+
+// DefaultConfigPath returns the default path for the sharing config file.
+func DefaultConfigPath() string {
+	dir := DefaultConfigDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "config.yaml")
+}
+
+// NewStore creates a credential store backed by the given file path. If the
+// file does not exist, it starts with an empty configuration.
+func NewStore(path string) (*Store, error) {
+	s := &Store{
+		path: path,
+		cfg:  Config{Registries: make(map[string]Entry)},
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+	if err := yaml.Unmarshal(data, &s.cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+	if s.cfg.Registries == nil {
+		s.cfg.Registries = make(map[string]Entry)
+	}
+	return s, nil
+}
+
+// Login stores credentials for the given registry host.
+func (s *Store) Login(host, username, password string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cfg.Registries[host] = Entry{
+		Username: username,
+		Password: password,
+	}
+	return s.save()
+}
+
+// Logout removes credentials for the given registry host.
+func (s *Store) Logout(host string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.cfg.Registries[host]; !ok {
+		return fmt.Errorf("not logged in to %s", host)
+	}
+	delete(s.cfg.Registries, host)
+	return s.save()
+}
+
+// GetCredentials returns the stored credentials for a registry host.
+func (s *Store) GetCredentials(host string) (username, password string, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, exists := s.cfg.Registries[host]
+	if !exists {
+		return "", "", false
+	}
+	return entry.Username, entry.Password, true
+}
+
+// ListHosts returns all registry hosts that have stored credentials.
+func (s *Store) ListHosts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	hosts := make([]string, 0, len(s.cfg.Registries))
+	for h := range s.cfg.Registries {
+		hosts = append(hosts, h)
+	}
+	return hosts
+}
+
+// DefaultRegistry returns the configured default registry host.
+func (s *Store) DefaultRegistry() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cfg.Default
+}
+
+// save writes the current configuration to disk. Must be called with s.mu held.
+func (s *Store) save() error {
+	data, err := yaml.Marshal(&s.cfg)
+	if err != nil {
+		return fmt.Errorf("marshalling config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+	if err := os.WriteFile(s.path, data, 0o600); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	return nil
+}

--- a/pkg/sharing/registry/registry_test.go
+++ b/pkg/sharing/registry/registry_test.go
@@ -1,0 +1,190 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestNewStoreEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	hosts := s.ListHosts()
+	if len(hosts) != 0 {
+		t.Errorf("expected no hosts, got %v", hosts)
+	}
+}
+
+func TestLoginLogout(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	// Login.
+	if err := s.Login("ghcr.io", "user", "token123"); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	// Check credentials.
+	u, p, ok := s.GetCredentials("ghcr.io")
+	if !ok {
+		t.Fatal("GetCredentials returned false")
+	}
+	if u != "user" || p != "token123" {
+		t.Errorf("got (%q, %q), want (%q, %q)", u, p, "user", "token123")
+	}
+
+	// Check file was written.
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+
+	// Logout.
+	if err := s.Logout("ghcr.io"); err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+
+	_, _, ok = s.GetCredentials("ghcr.io")
+	if ok {
+		t.Error("expected credentials to be removed after logout")
+	}
+}
+
+func TestLogoutNotLoggedIn(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if err := s.Logout("ghcr.io"); err == nil {
+		t.Error("expected error for logout when not logged in")
+	}
+}
+
+func TestPersistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Store 1: login.
+	s1, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := s1.Login("ghcr.io", "user1", "pass1"); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if err := s1.Login("docker.io", "user2", "pass2"); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	// Store 2: reload from disk.
+	s2, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore reload: %v", err)
+	}
+
+	hosts := s2.ListHosts()
+	sort.Strings(hosts)
+	if len(hosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %v", hosts)
+	}
+	if hosts[0] != "docker.io" || hosts[1] != "ghcr.io" {
+		t.Errorf("hosts = %v", hosts)
+	}
+
+	u, p, ok := s2.GetCredentials("ghcr.io")
+	if !ok || u != "user1" || p != "pass1" {
+		t.Errorf("ghcr.io creds = (%q, %q, %v)", u, p, ok)
+	}
+}
+
+func TestGetCredentialsNotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	_, _, ok := s.GetCredentials("ghcr.io")
+	if ok {
+		t.Error("expected ok=false for unknown host")
+	}
+}
+
+func TestDefaultConfigDir(t *testing.T) {
+	dir := DefaultConfigDir()
+	if dir == "" {
+		t.Skip("cannot determine home directory")
+	}
+	if !filepath.IsAbs(dir) {
+		t.Errorf("DefaultConfigDir() = %q, want absolute path", dir)
+	}
+}
+
+func TestDefaultConfigPath(t *testing.T) {
+	path := DefaultConfigPath()
+	if path == "" {
+		t.Skip("cannot determine home directory")
+	}
+	if filepath.Base(path) != "config.yaml" {
+		t.Errorf("DefaultConfigPath() = %q, want config.yaml basename", path)
+	}
+}
+
+func TestDefaultRegistry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Write config with default registry.
+	data := []byte("default: ghcr.io\n")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if got := s.DefaultRegistry(); got != "ghcr.io" {
+		t.Errorf("DefaultRegistry() = %q, want %q", got, "ghcr.io")
+	}
+}
+
+func TestFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "config.yaml")
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if err := s.Login("test.io", "u", "p"); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file permissions = %o, want %o", perm, 0o600)
+	}
+}


### PR DESCRIPTION
Add core packages for OCI-based plugin distribution:
- pkg/sharing/manifest: Plugin manifest types (zhi-plugin.yaml), YAML
  parsing, and validation (name, type, version rules)
- pkg/sharing/registry: Registry credential store with Login/Logout,
  backed by ~/.zhi/config.yaml with 0600 permissions
- pkg/sharing/metadata: Local installed-plugin metadata store at
  ~/.zhi/metadata/ tracking version, OCI ref, digest, and platform
- pkg/sharing/client: OCI client using oras-go v2 for pulling plugin
  artifacts with multi-platform resolution and authentication

Add CLI commands:
- zhi plugin install <oci-ref>: Pull and install from OCI registries
- zhi plugin uninstall <name>: Remove plugin binary and metadata
- zhi plugin list [--json]: List installed shared plugins
- zhi registry login <host>: Store OCI registry credentials
- zhi registry logout <host>: Remove stored credentials
- zhi registry list: Show configured registries

Installed plugins use existing discovery (zhi-<type>-<name> in
~/.zhi/plugins/) and are picked up automatically by RefreshExternal().

https://claude.ai/code/session_01JTjSZLF2aj1YbnE2sZSmuA