### PR TITLE
Configure separate release archives for each binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,10 +54,32 @@ builds:
       - -s -w
 
 archives:
-  - id: default
+  - id: zhi
+    builds:
+      - zhi
     formats:
       - tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "zhi_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+
+  - id: zhi-marketplace
+    builds:
+      - zhi-marketplace
+    formats:
+      - tar.gz
+    name_template: "zhi-marketplace_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+
+  - id: zhi-mirror
+    builds:
+      - zhi-mirror
+    formats:
+      - tar.gz
+    name_template: "zhi-mirror_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
## What does this PR do?

Updates the `.goreleaser.yaml` configuration to generate separate release archives for each of the three binaries (`zhi`, `zhi-marketplace`, and `zhi-mirror`) instead of using a single default archive configuration. Each binary now has its own archive definition with a specific naming template that includes the binary name.

## Why is this change needed?

This change improves the release process by:
- Creating distinct, clearly-named archives for each binary distribution
- Making it easier for users to identify and download the correct binary for their use case
- Allowing independent configuration of each binary's release artifacts if needed in the future
- Providing better organization of release assets on the releases page

## How was this tested?

- [ ] `make check` passes
- [ ] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [x] Build / CI / tooling

## Checklist

- [x] My code follows the project's code style (`gofmt`, `go vet`)
- [ ] I have added/updated tests for my changes
- [ ] I have updated documentation if needed
- [ ] If I changed `.proto` files, I ran `make proto` and committed the generated code
- [x] My commits are focused and have clear messages

## Additional Notes

This is a configuration-only change to the release build process. The actual binaries and their build configurations remain unchanged.

https://claude.ai/code/session_01XNnoyb45aDHmCtdSgwfACQ