### PR TITLE
feat(core): add SessionManager for store authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -72,7 +73,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/certificate-transparency-go v1.3.2 // indirect
 	github.com/google/go-containerregistry v0.20.7 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.8 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -22,6 +22,7 @@ type Engine struct {
 	transformPlugins []transform.Plugin
 	storePlugin      store.Plugin // nil if no store is configured
 	components       *ComponentManager
+	session          *SessionManager // nil if no store is configured
 }
 
 // NewEngine resolves all providers from the workspace config using the
@@ -55,6 +56,11 @@ func NewEngine(registry *Registry, workspace *WorkspaceConfig) (*Engine, error) 
 			return nil, fmt.Errorf("resolving store provider: %w", err)
 		}
 		e.storePlugin = sp
+	}
+
+	// Initialize session manager for authenticated stores.
+	if e.storePlugin != nil {
+		e.session = NewSessionManager(e.storePlugin)
 	}
 
 	// Initialize component manager.
@@ -397,6 +403,12 @@ func (e *Engine) FilteredTree(ctx context.Context) (*config.Tree, error) {
 // configured.
 func (e *Engine) StorePlugin() store.Plugin {
 	return e.storePlugin
+}
+
+// Session returns the session manager for the active store plugin, or
+// nil if no store is configured.
+func (e *Engine) Session() *SessionManager {
+	return e.session
 }
 
 // WorkspaceDir returns the directory containing the workspace config file.

--- a/internal/core/session.go
+++ b/internal/core/session.go
@@ -1,0 +1,137 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/MrWong99/zhi/pkg/zhiplugin/store"
+	"github.com/google/uuid"
+)
+
+// SessionStatus represents the current authentication state.
+type SessionStatus int
+
+const (
+	SessionNone            SessionStatus = iota // no auth required by store
+	SessionUnauthenticated                      // auth required, not logged in
+	SessionAuthenticated                        // logged in
+	SessionExpired                              // was authenticated, token expired
+)
+
+// Session holds the current authentication state for a store plugin.
+type Session struct {
+	ID        string // opaque session identifier (UUID)
+	Status    SessionStatus
+	ExpiresAt time.Time         // zero value = no expiry
+	Metadata  map[string]string // informational (e.g. username, auth method)
+}
+
+// SessionManager manages the authentication lifecycle for the active
+// store plugin within a single workspace session.
+type SessionManager struct {
+	mu      sync.RWMutex
+	session *Session
+	store   store.Plugin
+}
+
+// NewSessionManager creates a new SessionManager for the given store plugin.
+func NewSessionManager(s store.Plugin) *SessionManager {
+	return &SessionManager{
+		store: s,
+		session: &Session{
+			Status: SessionUnauthenticated,
+		},
+	}
+}
+
+// AuthRequired checks store capabilities and returns whether login is needed.
+func (m *SessionManager) AuthRequired(ctx context.Context) (bool, error) {
+	caps, err := m.store.Capabilities(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !caps.Auth {
+		m.mu.Lock()
+		m.session.Status = SessionNone
+		m.mu.Unlock()
+		return false, nil
+	}
+	return true, nil
+}
+
+// AuthMethods returns the auth methods supported by the store.
+func (m *SessionManager) AuthMethods(ctx context.Context) ([]store.AuthMethod, error) {
+	return m.store.AuthMethods(ctx)
+}
+
+// Login authenticates with the store using the given method and credentials.
+// On success, creates a new session with the returned token.
+func (m *SessionManager) Login(ctx context.Context, method string, credentials map[string]string) (*Session, error) {
+	cred, err := m.store.Login(ctx, method, credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	var expiresAt time.Time
+	if cred.ExpiresAt != "" {
+		t, err := time.Parse(time.RFC3339, cred.ExpiresAt)
+		if err == nil {
+			expiresAt = t
+		}
+	}
+
+	m.mu.Lock()
+	m.session = &Session{
+		ID:        uuid.New().String(),
+		Status:    SessionAuthenticated,
+		ExpiresAt: expiresAt,
+		Metadata:  cred.Metadata,
+	}
+	s := *m.session
+	m.mu.Unlock()
+
+	return &s, nil
+}
+
+// Status returns the current session state. It lazily checks expiry:
+// if the session has an expiry time that is in the past, it transitions
+// to SessionExpired.
+func (m *SessionManager) Status() *Session {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.session.Status == SessionAuthenticated &&
+		!m.session.ExpiresAt.IsZero() &&
+		time.Now().After(m.session.ExpiresAt) {
+		m.session.Status = SessionExpired
+	}
+
+	s := *m.session
+	return &s
+}
+
+// Logout clears the current session, transitioning to Unauthenticated.
+func (m *SessionManager) Logout() {
+	m.mu.Lock()
+	m.session = &Session{
+		Status: SessionUnauthenticated,
+	}
+	m.mu.Unlock()
+}
+
+// HandleAuthError checks if an error is an auth error and transitions
+// the session to Expired if so. Returns true if the error was auth-related.
+func (m *SessionManager) HandleAuthError(err error) bool {
+	if !store.IsAuthRequired(err) {
+		return false
+	}
+
+	m.mu.Lock()
+	if m.session.Status == SessionAuthenticated || m.session.Status == SessionExpired {
+		m.session.Status = SessionExpired
+	}
+	m.mu.Unlock()
+
+	return true
+}

--- a/internal/core/session_test.go
+++ b/internal/core/session_test.go
@@ -1,0 +1,325 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/zhi/pkg/zhiplugin/store"
+)
+
+// authMockStore is a store.Plugin mock that supports authentication.
+type authMockStore struct {
+	mockStore
+	authRequired bool
+	methods      []store.AuthMethod
+	loginErr     error
+	credential   *store.Credential
+}
+
+func newAuthMockStore(authRequired bool) *authMockStore {
+	return &authMockStore{
+		mockStore:    *newMockStore(),
+		authRequired: authRequired,
+		methods: []store.AuthMethod{
+			{
+				Type:        "userpass",
+				Description: "Username and password",
+				Fields: []store.AuthField{
+					{Name: "username", Required: true},
+					{Name: "password", Required: true, Secret: true},
+				},
+			},
+		},
+		credential: &store.Credential{
+			Token:    "test-token",
+			Metadata: map[string]string{"username": "admin"},
+		},
+	}
+}
+
+func (m *authMockStore) Capabilities(context.Context) (*store.Capabilities, error) {
+	return &store.Capabilities{
+		Auth: m.authRequired,
+	}, nil
+}
+
+func (m *authMockStore) AuthMethods(context.Context) ([]store.AuthMethod, error) {
+	return m.methods, nil
+}
+
+func (m *authMockStore) Login(_ context.Context, _ string, _ map[string]string) (*store.Credential, error) {
+	if m.loginErr != nil {
+		return nil, m.loginErr
+	}
+	return m.credential, nil
+}
+
+func TestSessionManager_AuthRequired_True(t *testing.T) {
+	ms := newAuthMockStore(true)
+	sm := NewSessionManager(ms)
+
+	required, err := sm.AuthRequired(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !required {
+		t.Fatal("expected auth to be required")
+	}
+
+	s := sm.Status()
+	if s.Status != SessionUnauthenticated {
+		t.Fatalf("expected SessionUnauthenticated, got %d", s.Status)
+	}
+}
+
+func TestSessionManager_AuthRequired_False(t *testing.T) {
+	ms := newAuthMockStore(false)
+	sm := NewSessionManager(ms)
+
+	required, err := sm.AuthRequired(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if required {
+		t.Fatal("expected auth not to be required")
+	}
+
+	s := sm.Status()
+	if s.Status != SessionNone {
+		t.Fatalf("expected SessionNone, got %d", s.Status)
+	}
+}
+
+func TestSessionManager_LoginSuccess(t *testing.T) {
+	ms := newAuthMockStore(true)
+	sm := NewSessionManager(ms)
+
+	s, err := sm.Login(context.Background(), "userpass", map[string]string{
+		"username": "admin",
+		"password": "secret",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Status != SessionAuthenticated {
+		t.Fatalf("expected SessionAuthenticated, got %d", s.Status)
+	}
+	if s.ID == "" {
+		t.Fatal("expected session ID to be set")
+	}
+	if s.Metadata["username"] != "admin" {
+		t.Fatalf("expected metadata username=admin, got %q", s.Metadata["username"])
+	}
+}
+
+func TestSessionManager_LoginFailure(t *testing.T) {
+	ms := newAuthMockStore(true)
+	ms.loginErr = fmt.Errorf("invalid credentials")
+	sm := NewSessionManager(ms)
+
+	_, err := sm.Login(context.Background(), "userpass", map[string]string{
+		"username": "admin",
+		"password": "wrong",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	s := sm.Status()
+	if s.Status != SessionUnauthenticated {
+		t.Fatalf("expected SessionUnauthenticated after failed login, got %d", s.Status)
+	}
+}
+
+func TestSessionManager_LoginWithExpiry(t *testing.T) {
+	ms := newAuthMockStore(true)
+	expiry := time.Now().Add(time.Hour)
+	ms.credential = &store.Credential{
+		Token:     "expiring-token",
+		ExpiresAt: expiry.Format(time.RFC3339),
+	}
+	sm := NewSessionManager(ms)
+
+	s, err := sm.Login(context.Background(), "userpass", map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.ExpiresAt.IsZero() {
+		t.Fatal("expected ExpiresAt to be set")
+	}
+
+	// Status should still be authenticated since expiry is in the future.
+	s = sm.Status()
+	if s.Status != SessionAuthenticated {
+		t.Fatalf("expected SessionAuthenticated, got %d", s.Status)
+	}
+}
+
+func TestSessionManager_ExpiryDetection(t *testing.T) {
+	ms := newAuthMockStore(true)
+	// Set expiry in the past.
+	ms.credential = &store.Credential{
+		Token:     "expired-token",
+		ExpiresAt: time.Now().Add(-time.Second).Format(time.RFC3339),
+	}
+	sm := NewSessionManager(ms)
+
+	_, err := sm.Login(context.Background(), "userpass", map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Status should lazily detect expiry.
+	s := sm.Status()
+	if s.Status != SessionExpired {
+		t.Fatalf("expected SessionExpired, got %d", s.Status)
+	}
+}
+
+func TestSessionManager_Logout(t *testing.T) {
+	ms := newAuthMockStore(true)
+	sm := NewSessionManager(ms)
+
+	_, err := sm.Login(context.Background(), "userpass", map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sm.Logout()
+	s := sm.Status()
+	if s.Status != SessionUnauthenticated {
+		t.Fatalf("expected SessionUnauthenticated after logout, got %d", s.Status)
+	}
+	if s.ID != "" {
+		t.Fatal("expected session ID to be cleared")
+	}
+}
+
+func TestSessionManager_HandleAuthError(t *testing.T) {
+	ms := newAuthMockStore(true)
+	sm := NewSessionManager(ms)
+
+	// Login first.
+	_, err := sm.Login(context.Background(), "userpass", map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Non-auth error should not affect session.
+	handled := sm.HandleAuthError(fmt.Errorf("some other error"))
+	if handled {
+		t.Fatal("expected non-auth error to return false")
+	}
+	s := sm.Status()
+	if s.Status != SessionAuthenticated {
+		t.Fatalf("expected SessionAuthenticated, got %d", s.Status)
+	}
+
+	// Auth error should transition to Expired.
+	authErr := &store.ErrAuthRequired{Reason: "token expired"}
+	handled = sm.HandleAuthError(authErr)
+	if !handled {
+		t.Fatal("expected auth error to return true")
+	}
+	s = sm.Status()
+	if s.Status != SessionExpired {
+		t.Fatalf("expected SessionExpired, got %d", s.Status)
+	}
+}
+
+func TestSessionManager_HandleAuthError_Wrapped(t *testing.T) {
+	ms := newAuthMockStore(true)
+	sm := NewSessionManager(ms)
+
+	_, err := sm.Login(context.Background(), "userpass", map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Wrapped auth error should still be detected.
+	wrapped := fmt.Errorf("store operation failed: %w", &store.ErrAuthRequired{Reason: "expired"})
+	handled := sm.HandleAuthError(wrapped)
+	if !handled {
+		t.Fatal("expected wrapped auth error to return true")
+	}
+	s := sm.Status()
+	if s.Status != SessionExpired {
+		t.Fatalf("expected SessionExpired, got %d", s.Status)
+	}
+}
+
+func TestSessionManager_FullLifecycle(t *testing.T) {
+	ms := newAuthMockStore(true)
+	sm := NewSessionManager(ms)
+
+	// Start: Unauthenticated.
+	s := sm.Status()
+	if s.Status != SessionUnauthenticated {
+		t.Fatalf("expected SessionUnauthenticated, got %d", s.Status)
+	}
+
+	// Login -> Authenticated.
+	s, err := sm.Login(context.Background(), "userpass", map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Status != SessionAuthenticated {
+		t.Fatalf("expected SessionAuthenticated, got %d", s.Status)
+	}
+
+	// HandleAuthError -> Expired.
+	sm.HandleAuthError(&store.ErrAuthRequired{Reason: "expired"})
+	s = sm.Status()
+	if s.Status != SessionExpired {
+		t.Fatalf("expected SessionExpired, got %d", s.Status)
+	}
+
+	// Logout -> Unauthenticated.
+	sm.Logout()
+	s = sm.Status()
+	if s.Status != SessionUnauthenticated {
+		t.Fatalf("expected SessionUnauthenticated, got %d", s.Status)
+	}
+}
+
+func TestSessionManager_ConcurrentAccess(t *testing.T) {
+	ms := newAuthMockStore(true)
+	sm := NewSessionManager(ms)
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			sm.Status()
+		}()
+		go func() {
+			defer wg.Done()
+			sm.Login(context.Background(), "userpass", map[string]string{})
+		}()
+		go func() {
+			defer wg.Done()
+			sm.Logout()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSessionManager_AuthMethods(t *testing.T) {
+	ms := newAuthMockStore(true)
+	sm := NewSessionManager(ms)
+
+	methods, err := sm.AuthMethods(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(methods) != 1 {
+		t.Fatalf("expected 1 method, got %d", len(methods))
+	}
+	if methods[0].Type != "userpass" {
+		t.Fatalf("expected userpass method, got %q", methods[0].Type)
+	}
+}


### PR DESCRIPTION
## Phase 1: Core Session Manager

Implements the `SessionManager` in `internal/core/` that manages authentication state for the store plugin. This is the foundation that all UI implementations depend on.

### Changes

**New files:**
- `internal/core/session.go` — `SessionManager` struct with `Session`, `SessionStatus` types and all methods (`AuthRequired`, `AuthMethods`, `Login`, `Status`, `Logout`, `HandleAuthError`)
- `internal/core/session_test.go` — Unit tests covering state transitions, auth required detection, login success/failure, expiry detection, concurrent access safety, and wrapped error handling

**Modified files:**
- `internal/core/engine.go` — Added `session *SessionManager` field to `Engine`, initialized when a store plugin is present, with `Session()` accessor
- `go.mod` — Promoted `google/uuid` from indirect to direct dependency

### Acceptance Criteria
- [x] SessionManager correctly transitions between all states (None/Unauthenticated/Authenticated/Expired)
- [x] All operations are safe for concurrent use (mutex-protected)
- [x] `HandleAuthError` correctly identifies `store.ErrAuthRequired` in error chains
- [x] Expiry is lazily checked — no background goroutines
- [x] Unit tests pass with `-race -count=1`
- [x] `make check` passes (fmt + vet + lint + test)

Ref: `plans/login/roadmap/phase1-core-session.md`