### PR TITLE
feat(ui): add store authentication to Controller API

### DIFF
--- a/api/proto/zhiplugin/v1/ui.proto
+++ b/api/proto/zhiplugin/v1/ui.proto
@@ -65,6 +65,17 @@ service UIControllerService {
   rpc UpdatePlugin(CtrlUpdatePluginRequest) returns (CtrlUpdatePluginResponse);
   // RatePlugin submits a rating for a marketplace plugin.
   rpc RatePlugin(CtrlRatePluginRequest) returns (CtrlRatePluginResponse);
+
+  // --- Store Authentication -------------------------------------------------
+
+  // StoreAuthMethods returns the auth methods supported by the configured store.
+  rpc StoreAuthMethods(CtrlStoreAuthMethodsRequest) returns (CtrlStoreAuthMethodsResponse);
+  // StoreLogin authenticates with the store using the given method and credentials.
+  rpc StoreLogin(CtrlStoreLoginRequest) returns (CtrlStoreLoginResponse);
+  // StoreAuthStatus returns the current authentication status.
+  rpc StoreAuthStatus(CtrlStoreAuthStatusRequest) returns (CtrlStoreAuthStatusResponse);
+  // StoreLogout clears the current authentication session.
+  rpc StoreLogout(CtrlStoreLogoutRequest) returns (CtrlStoreLogoutResponse);
 }
 
 // ---------------------------------------------------------------------------
@@ -399,3 +410,63 @@ message CtrlRatePluginRequest {
 
 // CtrlRatePluginResponse is intentionally empty.
 message CtrlRatePluginResponse {}
+
+// ---------------------------------------------------------------------------
+// Store Authentication messages
+// ---------------------------------------------------------------------------
+
+message CtrlStoreAuthFieldMsg {
+  string name = 1;
+  string description = 2;
+  bool required = 3;
+  bool secret = 4;
+}
+
+message CtrlStoreAuthMethodMsg {
+  string type = 1;
+  string description = 2;
+  repeated CtrlStoreAuthFieldMsg fields = 3;
+}
+
+// -- StoreAuthMethods -------------------------------------------------------
+
+// CtrlStoreAuthMethodsRequest is intentionally empty.
+message CtrlStoreAuthMethodsRequest {}
+
+message CtrlStoreAuthMethodsResponse {
+  repeated CtrlStoreAuthMethodMsg methods = 1;
+}
+
+// -- StoreLogin -------------------------------------------------------------
+
+message CtrlStoreLoginRequest {
+  string method = 1;
+  map<string, string> credentials = 2;
+}
+
+message CtrlStoreLoginResponse {
+  string session_id = 1;
+  string status = 2; // "none", "unauthenticated", "authenticated", "expired"
+  string expires_at = 3; // RFC3339 or empty
+  map<string, string> metadata = 4;
+}
+
+// -- StoreAuthStatus --------------------------------------------------------
+
+// CtrlStoreAuthStatusRequest is intentionally empty.
+message CtrlStoreAuthStatusRequest {}
+
+message CtrlStoreAuthStatusResponse {
+  string session_id = 1;
+  string status = 2;
+  string expires_at = 3;
+  map<string, string> metadata = 4;
+}
+
+// -- StoreLogout ------------------------------------------------------------
+
+// CtrlStoreLogoutRequest is intentionally empty.
+message CtrlStoreLogoutRequest {}
+
+// CtrlStoreLogoutResponse is intentionally empty.
+message CtrlStoreLogoutResponse {}

--- a/examples/zhi-ui-httpapi/main_test.go
+++ b/examples/zhi-ui-httpapi/main_test.go
@@ -146,6 +146,22 @@ func (m *mockController) RatePlugin(_ context.Context, _, _, _ string, _ ui.Rati
 	return nil
 }
 
+func (m *mockController) StoreAuthMethods(_ context.Context) ([]ui.StoreAuthMethod, error) {
+	return nil, nil
+}
+
+func (m *mockController) StoreLogin(_ context.Context, _ string, _ map[string]string) (*ui.StoreSession, error) {
+	return &ui.StoreSession{Status: ui.StoreSessionNone}, nil
+}
+
+func (m *mockController) StoreAuthStatus(_ context.Context) (*ui.StoreSession, error) {
+	return &ui.StoreSession{Status: ui.StoreSessionNone}, nil
+}
+
+func (m *mockController) StoreLogout(_ context.Context) error {
+	return nil
+}
+
 // ---------- test helpers ----------
 
 // startTestServer starts the HTTP UI plugin directly (no gRPC) and

--- a/internal/ui/adapter.go
+++ b/internal/ui/adapter.go
@@ -204,3 +204,19 @@ func (c *ControllerAdapter) UpdatePlugin(ctx context.Context, name string, versi
 func (c *ControllerAdapter) RatePlugin(ctx context.Context, pluginType, publisher, name string, rating zhiui.Rating) error {
 	return c.Inner.RatePlugin(ctx, pluginType, publisher, name, rating)
 }
+
+func (c *ControllerAdapter) StoreAuthMethods(ctx context.Context) ([]zhiui.StoreAuthMethod, error) {
+	return c.Inner.StoreAuthMethods(ctx)
+}
+
+func (c *ControllerAdapter) StoreLogin(ctx context.Context, method string, credentials map[string]string) (*zhiui.StoreSession, error) {
+	return c.Inner.StoreLogin(ctx, method, credentials)
+}
+
+func (c *ControllerAdapter) StoreAuthStatus(ctx context.Context) (*zhiui.StoreSession, error) {
+	return c.Inner.StoreAuthStatus(ctx)
+}
+
+func (c *ControllerAdapter) StoreLogout(ctx context.Context) error {
+	return c.Inner.StoreLogout(ctx)
+}

--- a/internal/ui/adapter_test.go
+++ b/internal/ui/adapter_test.go
@@ -1,0 +1,116 @@
+package ui_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MrWong99/zhi/internal/core"
+	"github.com/MrWong99/zhi/internal/ui"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/store"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/transform"
+	zhiui "github.com/MrWong99/zhi/pkg/zhiplugin/ui"
+)
+
+func TestControllerAdapter_StoreAuthMethods(t *testing.T) {
+	ctrl := setupTestController(t)
+	adapter := &ui.ControllerAdapter{Inner: ctrl}
+	ctx := context.Background()
+
+	methods, err := adapter.StoreAuthMethods(ctx)
+	if err != nil {
+		t.Fatalf("StoreAuthMethods: %v", err)
+	}
+	// Default mock store has no auth methods.
+	if len(methods) != 0 {
+		t.Errorf("expected 0 methods, got %d", len(methods))
+	}
+}
+
+func TestControllerAdapter_StoreAuthStatus(t *testing.T) {
+	ctrl := setupTestController(t)
+	adapter := &ui.ControllerAdapter{Inner: ctrl}
+	ctx := context.Background()
+
+	session, err := adapter.StoreAuthStatus(ctx)
+	if err != nil {
+		t.Fatalf("StoreAuthStatus: %v", err)
+	}
+	if session == nil {
+		t.Fatal("expected non-nil session")
+	}
+}
+
+func TestControllerAdapter_StoreLogout(t *testing.T) {
+	ctrl := setupTestController(t)
+	adapter := &ui.ControllerAdapter{Inner: ctrl}
+	ctx := context.Background()
+
+	if err := adapter.StoreLogout(ctx); err != nil {
+		t.Fatalf("StoreLogout: %v", err)
+	}
+
+	session, err := adapter.StoreAuthStatus(ctx)
+	if err != nil {
+		t.Fatalf("StoreAuthStatus: %v", err)
+	}
+	if session.Status != zhiui.StoreSessionUnauthenticated {
+		t.Errorf("expected unauthenticated, got %q", session.Status)
+	}
+}
+
+func TestControllerAdapter_StoreLogin(t *testing.T) {
+	// Use the auth mock store so Login actually returns a credential.
+	reg := core.NewRegistry()
+	mc := newMockConfig()
+	ms := &authMockStore{mockStore: newMockStore()}
+
+	if err := reg.RegisterConfig("mock", func(string, map[string]any) (config.Plugin, error) {
+		return mc, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.RegisterTransform("mock", func(string, map[string]any) (transform.Plugin, error) {
+		return &mockTransform{}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.RegisterStore("mock", func(string, map[string]any) (store.Plugin, error) {
+		return ms, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := &core.WorkspaceConfig{
+		Version: "1",
+		Config:  core.ProviderRef{Provider: "mock"},
+		Transform: []core.ProviderRef{
+			{Provider: "mock"},
+		},
+		Store: core.ProviderRef{Provider: "mock"},
+		Dir:   t.TempDir(),
+	}
+
+	eng, err := core.NewEngine(reg, ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inner := ui.NewUIController(eng)
+	adapter := &ui.ControllerAdapter{Inner: inner}
+	ctx := context.Background()
+
+	session, err := adapter.StoreLogin(ctx, "userpass", map[string]string{
+		"username": "admin",
+		"password": "secret",
+	})
+	if err != nil {
+		t.Fatalf("StoreLogin: %v", err)
+	}
+	if session == nil {
+		t.Fatal("expected non-nil session")
+	}
+	if session.Status != zhiui.StoreSessionAuthenticated {
+		t.Errorf("expected authenticated, got %q", session.Status)
+	}
+}

--- a/internal/ui/driver.go
+++ b/internal/ui/driver.go
@@ -59,6 +59,7 @@ func (c *UIController) SetMarketplaceError(err error) {
 func (c *UIController) LoadTree(ctx context.Context) (*config.Tree, error) {
 	tree, err := c.engine.LoadTree(ctx)
 	if err != nil {
+		c.handleAuthError(err)
 		return nil, fmt.Errorf("loading tree: %w", err)
 	}
 	if err := c.engine.TransformForDisplay(ctx, tree); err != nil {
@@ -126,7 +127,11 @@ func (c *UIController) SaveTree(ctx context.Context) error {
 	if err := c.engine.TransformForSave(ctx, c.tree); err != nil {
 		return fmt.Errorf("transforming tree for save: %w", err)
 	}
-	return c.engine.SaveTree(ctx, c.tree)
+	err := c.engine.SaveTree(ctx, c.tree)
+	if err != nil {
+		c.handleAuthError(err)
+	}
+	return err
 }
 
 // ListComponents returns all components with their current state.
@@ -266,6 +271,105 @@ func (c *UIController) WorkspaceName() string {
 // SaveComponentState persists the current component state to the workspace.
 func (c *UIController) SaveComponentState() map[string]bool {
 	return c.engine.Components().SaveState()
+}
+
+// StoreAuthMethods returns the authentication methods supported by the
+// configured store plugin.
+func (c *UIController) StoreAuthMethods(ctx context.Context) ([]zhiui.StoreAuthMethod, error) {
+	sess := c.engine.Session()
+	if sess == nil {
+		return nil, nil
+	}
+	methods, err := sess.AuthMethods(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]zhiui.StoreAuthMethod, 0, len(methods))
+	for _, m := range methods {
+		fields := make([]zhiui.StoreAuthField, 0, len(m.Fields))
+		for _, f := range m.Fields {
+			fields = append(fields, zhiui.StoreAuthField{
+				Name:        f.Name,
+				Description: f.Description,
+				Required:    f.Required,
+				Secret:      f.Secret,
+			})
+		}
+		result = append(result, zhiui.StoreAuthMethod{
+			Type:        m.Type,
+			Description: m.Description,
+			Fields:      fields,
+		})
+	}
+	return result, nil
+}
+
+// StoreLogin authenticates with the store using the specified method
+// and credentials.
+func (c *UIController) StoreLogin(ctx context.Context, method string, credentials map[string]string) (*zhiui.StoreSession, error) {
+	sess := c.engine.Session()
+	if sess == nil {
+		return &zhiui.StoreSession{Status: zhiui.StoreSessionNone}, nil
+	}
+	s, err := sess.Login(ctx, method, credentials)
+	if err != nil {
+		return nil, err
+	}
+	return coreSessionToUI(s), nil
+}
+
+// StoreAuthStatus returns the current authentication status.
+func (c *UIController) StoreAuthStatus(_ context.Context) (*zhiui.StoreSession, error) {
+	sess := c.engine.Session()
+	if sess == nil {
+		return &zhiui.StoreSession{Status: zhiui.StoreSessionNone}, nil
+	}
+	return coreSessionToUI(sess.Status()), nil
+}
+
+// StoreLogout clears the current authentication session.
+func (c *UIController) StoreLogout(_ context.Context) error {
+	sess := c.engine.Session()
+	if sess == nil {
+		return nil
+	}
+	sess.Logout()
+	return nil
+}
+
+// handleAuthError delegates to the session manager's HandleAuthError if
+// a session manager is available.
+func (c *UIController) handleAuthError(err error) {
+	if sess := c.engine.Session(); sess != nil {
+		sess.HandleAuthError(err)
+	}
+}
+
+// coreSessionToUI converts a core.Session to a UI-facing StoreSession.
+func coreSessionToUI(s *core.Session) *zhiui.StoreSession {
+	var status zhiui.StoreSessionStatus
+	switch s.Status {
+	case core.SessionNone:
+		status = zhiui.StoreSessionNone
+	case core.SessionUnauthenticated:
+		status = zhiui.StoreSessionUnauthenticated
+	case core.SessionAuthenticated:
+		status = zhiui.StoreSessionAuthenticated
+	case core.SessionExpired:
+		status = zhiui.StoreSessionExpired
+	default:
+		status = zhiui.StoreSessionNone
+	}
+	var expiresAt string
+	if !s.ExpiresAt.IsZero() {
+		expiresAt = s.ExpiresAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	return &zhiui.StoreSession{
+		SessionID: s.ID,
+		Status:    status,
+		ExpiresAt: expiresAt,
+		Metadata:  s.Metadata,
+	}
 }
 
 func (c *UIController) prepareTreeData(ctx context.Context, allComponents bool, prefix string) (*core.TreeData, error) {

--- a/internal/ui/driver_test.go
+++ b/internal/ui/driver_test.go
@@ -369,3 +369,175 @@ func TestUIController_WorkspaceName(t *testing.T) {
 		t.Errorf("expected non-empty workspace name, got %q", name)
 	}
 }
+
+func TestUIController_StoreAuthMethods_NoAuth(t *testing.T) {
+	ctrl := setupTestController(t)
+	ctx := context.Background()
+
+	methods, err := ctrl.StoreAuthMethods(ctx)
+	if err != nil {
+		t.Fatalf("StoreAuthMethods: %v", err)
+	}
+	// mockStore returns nil for AuthMethods, so result should be empty.
+	if len(methods) != 0 {
+		t.Errorf("expected 0 methods, got %d", len(methods))
+	}
+}
+
+func TestUIController_StoreAuthStatus_NoAuth(t *testing.T) {
+	ctrl := setupTestController(t)
+	ctx := context.Background()
+
+	session, err := ctrl.StoreAuthStatus(ctx)
+	if err != nil {
+		t.Fatalf("StoreAuthStatus: %v", err)
+	}
+	// mockStore doesn't require auth, so after AuthRequired check the
+	// session should reflect that. But since setupTestController doesn't
+	// call AuthRequired, the session defaults to Unauthenticated.
+	if session == nil {
+		t.Fatal("expected non-nil session")
+	}
+}
+
+func TestUIController_StoreLogout(t *testing.T) {
+	ctrl := setupTestController(t)
+	ctx := context.Background()
+
+	err := ctrl.StoreLogout(ctx)
+	if err != nil {
+		t.Fatalf("StoreLogout: %v", err)
+	}
+
+	// After logout, status should be unauthenticated.
+	session, err := ctrl.StoreAuthStatus(ctx)
+	if err != nil {
+		t.Fatalf("StoreAuthStatus after logout: %v", err)
+	}
+	if session.Status != "unauthenticated" {
+		t.Errorf("expected unauthenticated status after logout, got %q", session.Status)
+	}
+}
+
+func TestUIController_StoreAuthMethods_WithAuthStore(t *testing.T) {
+	reg := core.NewRegistry()
+	mc := newMockConfig()
+	ms := &authMockStore{mockStore: newMockStore()}
+
+	if err := reg.RegisterConfig("mock", func(string, map[string]any) (config.Plugin, error) {
+		return mc, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.RegisterTransform("mock", func(string, map[string]any) (transform.Plugin, error) {
+		return &mockTransform{}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.RegisterStore("mock", func(string, map[string]any) (store.Plugin, error) {
+		return ms, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := &core.WorkspaceConfig{
+		Version: "1",
+		Config:  core.ProviderRef{Provider: "mock"},
+		Transform: []core.ProviderRef{
+			{Provider: "mock"},
+		},
+		Store: core.ProviderRef{Provider: "mock"},
+		Dir:   t.TempDir(),
+	}
+
+	eng, err := core.NewEngine(reg, ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl := ui.NewUIController(eng)
+	ctx := context.Background()
+
+	methods, err := ctrl.StoreAuthMethods(ctx)
+	if err != nil {
+		t.Fatalf("StoreAuthMethods: %v", err)
+	}
+	if len(methods) != 1 {
+		t.Fatalf("expected 1 method, got %d", len(methods))
+	}
+	if methods[0].Type != "userpass" {
+		t.Errorf("expected userpass method, got %q", methods[0].Type)
+	}
+	if len(methods[0].Fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(methods[0].Fields))
+	}
+
+	// Login
+	session, err := ctrl.StoreLogin(ctx, "userpass", map[string]string{
+		"username": "admin",
+		"password": "secret",
+	})
+	if err != nil {
+		t.Fatalf("StoreLogin: %v", err)
+	}
+	if session.Status != "authenticated" {
+		t.Errorf("expected authenticated, got %q", session.Status)
+	}
+	if session.SessionID == "" {
+		t.Error("expected non-empty session ID")
+	}
+
+	// Status check
+	status, err := ctrl.StoreAuthStatus(ctx)
+	if err != nil {
+		t.Fatalf("StoreAuthStatus: %v", err)
+	}
+	if status.Status != "authenticated" {
+		t.Errorf("expected authenticated, got %q", status.Status)
+	}
+
+	// Logout
+	if err := ctrl.StoreLogout(ctx); err != nil {
+		t.Fatalf("StoreLogout: %v", err)
+	}
+	status, err = ctrl.StoreAuthStatus(ctx)
+	if err != nil {
+		t.Fatalf("StoreAuthStatus after logout: %v", err)
+	}
+	if status.Status != "unauthenticated" {
+		t.Errorf("expected unauthenticated after logout, got %q", status.Status)
+	}
+}
+
+// authMockStore wraps mockStore and adds auth support.
+type authMockStore struct {
+	*mockStore
+}
+
+func (m *authMockStore) Capabilities(_ context.Context) (*store.Capabilities, error) {
+	return &store.Capabilities{
+		Versioning: store.VersioningNone,
+		Encryption: store.EncryptionNone,
+		Auth:       true,
+	}, nil
+}
+
+func (m *authMockStore) AuthMethods(_ context.Context) ([]store.AuthMethod, error) {
+	return []store.AuthMethod{
+		{
+			Type:        "userpass",
+			Description: "Username and password",
+			Fields: []store.AuthField{
+				{Name: "username", Description: "Username", Required: true},
+				{Name: "password", Description: "Password", Required: true, Secret: true},
+			},
+		},
+	}, nil
+}
+
+func (m *authMockStore) Login(_ context.Context, _ string, _ map[string]string) (*store.Credential, error) {
+	return &store.Credential{
+		Token:    "mock-token",
+		Metadata: map[string]string{"username": "admin"},
+	}, nil
+}

--- a/pkg/providers/ui/webui/webui_test.go
+++ b/pkg/providers/ui/webui/webui_test.go
@@ -201,6 +201,22 @@ func (m *mockController) RatePlugin(_ context.Context, _, _, _ string, _ ui.Rati
 	return nil
 }
 
+func (m *mockController) StoreAuthMethods(_ context.Context) ([]ui.StoreAuthMethod, error) {
+	return nil, nil
+}
+
+func (m *mockController) StoreLogin(_ context.Context, _ string, _ map[string]string) (*ui.StoreSession, error) {
+	return &ui.StoreSession{Status: ui.StoreSessionNone}, nil
+}
+
+func (m *mockController) StoreAuthStatus(_ context.Context) (*ui.StoreSession, error) {
+	return &ui.StoreSession{Status: ui.StoreSessionNone}, nil
+}
+
+func (m *mockController) StoreLogout(_ context.Context) error {
+	return nil
+}
+
 // ---------- test helpers ----------
 
 func startTestServer(t *testing.T) (string, context.CancelFunc) {

--- a/pkg/zhiplugin/ui/auth.go
+++ b/pkg/zhiplugin/ui/auth.go
@@ -1,0 +1,35 @@
+package ui
+
+// StoreAuthMethod describes an authentication method supported by the store.
+type StoreAuthMethod struct {
+	Type        string
+	Description string
+	Fields      []StoreAuthField
+}
+
+// StoreAuthField describes a single credential field for an auth method.
+type StoreAuthField struct {
+	Name        string
+	Description string
+	Required    bool
+	Secret      bool
+}
+
+// StoreSessionStatus represents the current authentication state as seen
+// by the UI layer.
+type StoreSessionStatus string
+
+const (
+	StoreSessionNone            StoreSessionStatus = "none"
+	StoreSessionUnauthenticated StoreSessionStatus = "unauthenticated"
+	StoreSessionAuthenticated   StoreSessionStatus = "authenticated"
+	StoreSessionExpired         StoreSessionStatus = "expired"
+)
+
+// StoreSession holds the authentication state exposed to UI plugins.
+type StoreSession struct {
+	SessionID string
+	Status    StoreSessionStatus
+	ExpiresAt string            // RFC3339 or empty
+	Metadata  map[string]string // informational only
+}

--- a/pkg/zhiplugin/ui/controller_client.go
+++ b/pkg/zhiplugin/ui/controller_client.go
@@ -319,3 +319,62 @@ func (c *controllerGRPCClient) RatePlugin(ctx context.Context, pluginType, publi
 	})
 	return err
 }
+
+func (c *controllerGRPCClient) StoreAuthMethods(ctx context.Context) ([]StoreAuthMethod, error) {
+	resp, err := c.client.StoreAuthMethods(ctx, &pb.CtrlStoreAuthMethodsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	methods := make([]StoreAuthMethod, 0, len(resp.GetMethods()))
+	for _, m := range resp.GetMethods() {
+		fields := make([]StoreAuthField, 0, len(m.GetFields()))
+		for _, f := range m.GetFields() {
+			fields = append(fields, StoreAuthField{
+				Name:        f.GetName(),
+				Description: f.GetDescription(),
+				Required:    f.GetRequired(),
+				Secret:      f.GetSecret(),
+			})
+		}
+		methods = append(methods, StoreAuthMethod{
+			Type:        m.GetType(),
+			Description: m.GetDescription(),
+			Fields:      fields,
+		})
+	}
+	return methods, nil
+}
+
+func (c *controllerGRPCClient) StoreLogin(ctx context.Context, method string, credentials map[string]string) (*StoreSession, error) {
+	resp, err := c.client.StoreLogin(ctx, &pb.CtrlStoreLoginRequest{
+		Method:      method,
+		Credentials: credentials,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &StoreSession{
+		SessionID: resp.GetSessionId(),
+		Status:    StoreSessionStatus(resp.GetStatus()),
+		ExpiresAt: resp.GetExpiresAt(),
+		Metadata:  resp.GetMetadata(),
+	}, nil
+}
+
+func (c *controllerGRPCClient) StoreAuthStatus(ctx context.Context) (*StoreSession, error) {
+	resp, err := c.client.StoreAuthStatus(ctx, &pb.CtrlStoreAuthStatusRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return &StoreSession{
+		SessionID: resp.GetSessionId(),
+		Status:    StoreSessionStatus(resp.GetStatus()),
+		ExpiresAt: resp.GetExpiresAt(),
+		Metadata:  resp.GetMetadata(),
+	}, nil
+}
+
+func (c *controllerGRPCClient) StoreLogout(ctx context.Context) error {
+	_, err := c.client.StoreLogout(ctx, &pb.CtrlStoreLogoutRequest{})
+	return err
+}

--- a/pkg/zhiplugin/ui/controller_server.go
+++ b/pkg/zhiplugin/ui/controller_server.go
@@ -298,3 +298,61 @@ func (s *controllerGRPCServer) RatePlugin(ctx context.Context, req *pb.CtrlRateP
 	}
 	return &pb.CtrlRatePluginResponse{}, nil
 }
+
+func (s *controllerGRPCServer) StoreAuthMethods(ctx context.Context, _ *pb.CtrlStoreAuthMethodsRequest) (*pb.CtrlStoreAuthMethodsResponse, error) {
+	methods, err := s.impl.StoreAuthMethods(ctx)
+	if err != nil {
+		return nil, err
+	}
+	msgs := make([]*pb.CtrlStoreAuthMethodMsg, 0, len(methods))
+	for _, m := range methods {
+		fields := make([]*pb.CtrlStoreAuthFieldMsg, 0, len(m.Fields))
+		for _, f := range m.Fields {
+			fields = append(fields, &pb.CtrlStoreAuthFieldMsg{
+				Name:        f.Name,
+				Description: f.Description,
+				Required:    f.Required,
+				Secret:      f.Secret,
+			})
+		}
+		msgs = append(msgs, &pb.CtrlStoreAuthMethodMsg{
+			Type:        m.Type,
+			Description: m.Description,
+			Fields:      fields,
+		})
+	}
+	return &pb.CtrlStoreAuthMethodsResponse{Methods: msgs}, nil
+}
+
+func (s *controllerGRPCServer) StoreLogin(ctx context.Context, req *pb.CtrlStoreLoginRequest) (*pb.CtrlStoreLoginResponse, error) {
+	session, err := s.impl.StoreLogin(ctx, req.GetMethod(), req.GetCredentials())
+	if err != nil {
+		return nil, err
+	}
+	return &pb.CtrlStoreLoginResponse{
+		SessionId: session.SessionID,
+		Status:    string(session.Status),
+		ExpiresAt: session.ExpiresAt,
+		Metadata:  session.Metadata,
+	}, nil
+}
+
+func (s *controllerGRPCServer) StoreAuthStatus(ctx context.Context, _ *pb.CtrlStoreAuthStatusRequest) (*pb.CtrlStoreAuthStatusResponse, error) {
+	session, err := s.impl.StoreAuthStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.CtrlStoreAuthStatusResponse{
+		SessionId: session.SessionID,
+		Status:    string(session.Status),
+		ExpiresAt: session.ExpiresAt,
+		Metadata:  session.Metadata,
+	}, nil
+}
+
+func (s *controllerGRPCServer) StoreLogout(ctx context.Context, _ *pb.CtrlStoreLogoutRequest) (*pb.CtrlStoreLogoutResponse, error) {
+	if err := s.impl.StoreLogout(ctx); err != nil {
+		return nil, err
+	}
+	return &pb.CtrlStoreLogoutResponse{}, nil
+}

--- a/pkg/zhiplugin/ui/plugin.go
+++ b/pkg/zhiplugin/ui/plugin.go
@@ -58,6 +58,18 @@ type Controller interface {
 	UpdatePlugin(ctx context.Context, name string, version string) (*InstallResult, error)
 	// RatePlugin submits a rating for a marketplace plugin.
 	RatePlugin(ctx context.Context, pluginType, publisher, name string, rating Rating) error
+
+	// StoreAuthMethods returns the authentication methods supported by the
+	// configured store plugin. Returns nil if no store is configured or
+	// authentication is not required.
+	StoreAuthMethods(ctx context.Context) ([]StoreAuthMethod, error)
+	// StoreLogin authenticates with the store using the specified method
+	// and credentials. Returns the session status after the attempt.
+	StoreLogin(ctx context.Context, method string, credentials map[string]string) (*StoreSession, error)
+	// StoreAuthStatus returns the current authentication status.
+	StoreAuthStatus(ctx context.Context) (*StoreSession, error)
+	// StoreLogout clears the current authentication session.
+	StoreLogout(ctx context.Context) error
 }
 
 // Plugin is the interface every zhi UI plugin must implement.

--- a/pkg/zhiplugin/ui/proto/ui.pb.go
+++ b/pkg/zhiplugin/ui/proto/ui.pb.go
@@ -2832,6 +2832,514 @@ func (*CtrlRatePluginResponse) Descriptor() ([]byte, []int) {
 	return file_zhiplugin_v1_ui_proto_rawDescGZIP(), []int{49}
 }
 
+type CtrlStoreAuthFieldMsg struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Description   string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	Required      bool                   `protobuf:"varint,3,opt,name=required,proto3" json:"required,omitempty"`
+	Secret        bool                   `protobuf:"varint,4,opt,name=secret,proto3" json:"secret,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CtrlStoreAuthFieldMsg) Reset() {
+	*x = CtrlStoreAuthFieldMsg{}
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CtrlStoreAuthFieldMsg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CtrlStoreAuthFieldMsg) ProtoMessage() {}
+
+func (x *CtrlStoreAuthFieldMsg) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CtrlStoreAuthFieldMsg.ProtoReflect.Descriptor instead.
+func (*CtrlStoreAuthFieldMsg) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_ui_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *CtrlStoreAuthFieldMsg) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *CtrlStoreAuthFieldMsg) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *CtrlStoreAuthFieldMsg) GetRequired() bool {
+	if x != nil {
+		return x.Required
+	}
+	return false
+}
+
+func (x *CtrlStoreAuthFieldMsg) GetSecret() bool {
+	if x != nil {
+		return x.Secret
+	}
+	return false
+}
+
+type CtrlStoreAuthMethodMsg struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Type          string                   `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	Description   string                   `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	Fields        []*CtrlStoreAuthFieldMsg `protobuf:"bytes,3,rep,name=fields,proto3" json:"fields,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CtrlStoreAuthMethodMsg) Reset() {
+	*x = CtrlStoreAuthMethodMsg{}
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CtrlStoreAuthMethodMsg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CtrlStoreAuthMethodMsg) ProtoMessage() {}
+
+func (x *CtrlStoreAuthMethodMsg) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CtrlStoreAuthMethodMsg.ProtoReflect.Descriptor instead.
+func (*CtrlStoreAuthMethodMsg) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_ui_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *CtrlStoreAuthMethodMsg) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *CtrlStoreAuthMethodMsg) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *CtrlStoreAuthMethodMsg) GetFields() []*CtrlStoreAuthFieldMsg {
+	if x != nil {
+		return x.Fields
+	}
+	return nil
+}
+
+// CtrlStoreAuthMethodsRequest is intentionally empty.
+type CtrlStoreAuthMethodsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CtrlStoreAuthMethodsRequest) Reset() {
+	*x = CtrlStoreAuthMethodsRequest{}
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CtrlStoreAuthMethodsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CtrlStoreAuthMethodsRequest) ProtoMessage() {}
+
+func (x *CtrlStoreAuthMethodsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CtrlStoreAuthMethodsRequest.ProtoReflect.Descriptor instead.
+func (*CtrlStoreAuthMethodsRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_ui_proto_rawDescGZIP(), []int{52}
+}
+
+type CtrlStoreAuthMethodsResponse struct {
+	state         protoimpl.MessageState    `protogen:"open.v1"`
+	Methods       []*CtrlStoreAuthMethodMsg `protobuf:"bytes,1,rep,name=methods,proto3" json:"methods,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CtrlStoreAuthMethodsResponse) Reset() {
+	*x = CtrlStoreAuthMethodsResponse{}
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CtrlStoreAuthMethodsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CtrlStoreAuthMethodsResponse) ProtoMessage() {}
+
+func (x *CtrlStoreAuthMethodsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CtrlStoreAuthMethodsResponse.ProtoReflect.Descriptor instead.
+func (*CtrlStoreAuthMethodsResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_ui_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *CtrlStoreAuthMethodsResponse) GetMethods() []*CtrlStoreAuthMethodMsg {
+	if x != nil {
+		return x.Methods
+	}
+	return nil
+}
+
+type CtrlStoreLoginRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Method        string                 `protobuf:"bytes,1,opt,name=method,proto3" json:"method,omitempty"`
+	Credentials   map[string]string      `protobuf:"bytes,2,rep,name=credentials,proto3" json:"credentials,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CtrlStoreLoginRequest) Reset() {
+	*x = CtrlStoreLoginRequest{}
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CtrlStoreLoginRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CtrlStoreLoginRequest) ProtoMessage() {}
+
+func (x *CtrlStoreLoginRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CtrlStoreLoginRequest.ProtoReflect.Descriptor instead.
+func (*CtrlStoreLoginRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_ui_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *CtrlStoreLoginRequest) GetMethod() string {
+	if x != nil {
+		return x.Method
+	}
+	return ""
+}
+
+func (x *CtrlStoreLoginRequest) GetCredentials() map[string]string {
+	if x != nil {
+		return x.Credentials
+	}
+	return nil
+}
+
+type CtrlStoreLoginResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`                        // "none", "unauthenticated", "authenticated", "expired"
+	ExpiresAt     string                 `protobuf:"bytes,3,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"` // RFC3339 or empty
+	Metadata      map[string]string      `protobuf:"bytes,4,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CtrlStoreLoginResponse) Reset() {
+	*x = CtrlStoreLoginResponse{}
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CtrlStoreLoginResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CtrlStoreLoginResponse) ProtoMessage() {}
+
+func (x *CtrlStoreLoginResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CtrlStoreLoginResponse.ProtoReflect.Descriptor instead.
+func (*CtrlStoreLoginResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_ui_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *CtrlStoreLoginResponse) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *CtrlStoreLoginResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *CtrlStoreLoginResponse) GetExpiresAt() string {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return ""
+}
+
+func (x *CtrlStoreLoginResponse) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+// CtrlStoreAuthStatusRequest is intentionally empty.
+type CtrlStoreAuthStatusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CtrlStoreAuthStatusRequest) Reset() {
+	*x = CtrlStoreAuthStatusRequest{}
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CtrlStoreAuthStatusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CtrlStoreAuthStatusRequest) ProtoMessage() {}
+
+func (x *CtrlStoreAuthStatusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CtrlStoreAuthStatusRequest.ProtoReflect.Descriptor instead.
+func (*CtrlStoreAuthStatusRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_ui_proto_rawDescGZIP(), []int{56}
+}
+
+type CtrlStoreAuthStatusResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	ExpiresAt     string                 `protobuf:"bytes,3,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	Metadata      map[string]string      `protobuf:"bytes,4,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CtrlStoreAuthStatusResponse) Reset() {
+	*x = CtrlStoreAuthStatusResponse{}
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CtrlStoreAuthStatusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CtrlStoreAuthStatusResponse) ProtoMessage() {}
+
+func (x *CtrlStoreAuthStatusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CtrlStoreAuthStatusResponse.ProtoReflect.Descriptor instead.
+func (*CtrlStoreAuthStatusResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_ui_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *CtrlStoreAuthStatusResponse) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *CtrlStoreAuthStatusResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *CtrlStoreAuthStatusResponse) GetExpiresAt() string {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return ""
+}
+
+func (x *CtrlStoreAuthStatusResponse) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+// CtrlStoreLogoutRequest is intentionally empty.
+type CtrlStoreLogoutRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CtrlStoreLogoutRequest) Reset() {
+	*x = CtrlStoreLogoutRequest{}
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[58]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CtrlStoreLogoutRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CtrlStoreLogoutRequest) ProtoMessage() {}
+
+func (x *CtrlStoreLogoutRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[58]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CtrlStoreLogoutRequest.ProtoReflect.Descriptor instead.
+func (*CtrlStoreLogoutRequest) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_ui_proto_rawDescGZIP(), []int{58}
+}
+
+// CtrlStoreLogoutResponse is intentionally empty.
+type CtrlStoreLogoutResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CtrlStoreLogoutResponse) Reset() {
+	*x = CtrlStoreLogoutResponse{}
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[59]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CtrlStoreLogoutResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CtrlStoreLogoutResponse) ProtoMessage() {}
+
+func (x *CtrlStoreLogoutResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_zhiplugin_v1_ui_proto_msgTypes[59]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CtrlStoreLogoutResponse.ProtoReflect.Descriptor instead.
+func (*CtrlStoreLogoutResponse) Descriptor() ([]byte, []int) {
+	return file_zhiplugin_v1_ui_proto_rawDescGZIP(), []int{59}
+}
+
 var File_zhiplugin_v1_ui_proto protoreflect.FileDescriptor
 
 const file_zhiplugin_v1_ui_proto_rawDesc = "" +
@@ -3021,10 +3529,51 @@ const file_zhiplugin_v1_ui_proto_rawDesc = "" +
 	"\acomment\x18\x04 \x01(\tR\acomment\x12\x1f\n" +
 	"\vplugin_type\x18\x05 \x01(\tR\n" +
 	"pluginType\"\x18\n" +
-	"\x16CtrlRatePluginResponse2\x9e\x01\n" +
+	"\x16CtrlRatePluginResponse\"\x81\x01\n" +
+	"\x15CtrlStoreAuthFieldMsg\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x1a\n" +
+	"\brequired\x18\x03 \x01(\bR\brequired\x12\x16\n" +
+	"\x06secret\x18\x04 \x01(\bR\x06secret\"\x8b\x01\n" +
+	"\x16CtrlStoreAuthMethodMsg\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12 \n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12;\n" +
+	"\x06fields\x18\x03 \x03(\v2#.zhiplugin.v1.CtrlStoreAuthFieldMsgR\x06fields\"\x1d\n" +
+	"\x1bCtrlStoreAuthMethodsRequest\"^\n" +
+	"\x1cCtrlStoreAuthMethodsResponse\x12>\n" +
+	"\amethods\x18\x01 \x03(\v2$.zhiplugin.v1.CtrlStoreAuthMethodMsgR\amethods\"\xc7\x01\n" +
+	"\x15CtrlStoreLoginRequest\x12\x16\n" +
+	"\x06method\x18\x01 \x01(\tR\x06method\x12V\n" +
+	"\vcredentials\x18\x02 \x03(\v24.zhiplugin.v1.CtrlStoreLoginRequest.CredentialsEntryR\vcredentials\x1a>\n" +
+	"\x10CredentialsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xfb\x01\n" +
+	"\x16CtrlStoreLoginResponse\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\x12\x1d\n" +
+	"\n" +
+	"expires_at\x18\x03 \x01(\tR\texpiresAt\x12N\n" +
+	"\bmetadata\x18\x04 \x03(\v22.zhiplugin.v1.CtrlStoreLoginResponse.MetadataEntryR\bmetadata\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x1c\n" +
+	"\x1aCtrlStoreAuthStatusRequest\"\x85\x02\n" +
+	"\x1bCtrlStoreAuthStatusResponse\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\x12\x1d\n" +
+	"\n" +
+	"expires_at\x18\x03 \x01(\tR\texpiresAt\x12S\n" +
+	"\bmetadata\x18\x04 \x03(\v27.zhiplugin.v1.CtrlStoreAuthStatusResponse.MetadataEntryR\bmetadata\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x18\n" +
+	"\x16CtrlStoreLogoutRequest\"\x19\n" +
+	"\x17CtrlStoreLogoutResponse2\x9e\x01\n" +
 	"\tUIService\x12:\n" +
 	"\x03Run\x12\x18.zhiplugin.v1.RunRequest\x1a\x19.zhiplugin.v1.RunResponse\x12U\n" +
-	"\fCapabilities\x12!.zhiplugin.v1.CapabilitiesRequest\x1a\".zhiplugin.v1.CapabilitiesResponse2\xb9\x0e\n" +
+	"\fCapabilities\x12!.zhiplugin.v1.CapabilitiesRequest\x1a\".zhiplugin.v1.CapabilitiesResponse2\xc1\x11\n" +
 	"\x13UIControllerService\x12Q\n" +
 	"\bLoadTree\x12!.zhiplugin.v1.CtrlLoadTreeRequest\x1a\".zhiplugin.v1.CtrlLoadTreeResponse\x12Q\n" +
 	"\bSetValue\x12!.zhiplugin.v1.CtrlSetValueRequest\x1a\".zhiplugin.v1.CtrlSetValueResponse\x12Q\n" +
@@ -3045,7 +3594,12 @@ const file_zhiplugin_v1_ui_proto_rawDesc = "" +
 	"\fCheckUpdates\x12%.zhiplugin.v1.CtrlCheckUpdatesRequest\x1a&.zhiplugin.v1.CtrlCheckUpdatesResponse\x12]\n" +
 	"\fUpdatePlugin\x12%.zhiplugin.v1.CtrlUpdatePluginRequest\x1a&.zhiplugin.v1.CtrlUpdatePluginResponse\x12W\n" +
 	"\n" +
-	"RatePlugin\x12#.zhiplugin.v1.CtrlRatePluginRequest\x1a$.zhiplugin.v1.CtrlRatePluginResponseB0Z.github.com/MrWong99/zhi/pkg/zhiplugin/ui/protob\x06proto3"
+	"RatePlugin\x12#.zhiplugin.v1.CtrlRatePluginRequest\x1a$.zhiplugin.v1.CtrlRatePluginResponse\x12i\n" +
+	"\x10StoreAuthMethods\x12).zhiplugin.v1.CtrlStoreAuthMethodsRequest\x1a*.zhiplugin.v1.CtrlStoreAuthMethodsResponse\x12W\n" +
+	"\n" +
+	"StoreLogin\x12#.zhiplugin.v1.CtrlStoreLoginRequest\x1a$.zhiplugin.v1.CtrlStoreLoginResponse\x12f\n" +
+	"\x0fStoreAuthStatus\x12(.zhiplugin.v1.CtrlStoreAuthStatusRequest\x1a).zhiplugin.v1.CtrlStoreAuthStatusResponse\x12Z\n" +
+	"\vStoreLogout\x12$.zhiplugin.v1.CtrlStoreLogoutRequest\x1a%.zhiplugin.v1.CtrlStoreLogoutResponseB0Z.github.com/MrWong99/zhi/pkg/zhiplugin/ui/protob\x06proto3"
 
 var (
 	file_zhiplugin_v1_ui_proto_rawDescOnce sync.Once
@@ -3059,7 +3613,7 @@ func file_zhiplugin_v1_ui_proto_rawDescGZIP() []byte {
 	return file_zhiplugin_v1_ui_proto_rawDescData
 }
 
-var file_zhiplugin_v1_ui_proto_msgTypes = make([]protoimpl.MessageInfo, 50)
+var file_zhiplugin_v1_ui_proto_msgTypes = make([]protoimpl.MessageInfo, 63)
 var file_zhiplugin_v1_ui_proto_goTypes = []any{
 	(*RunRequest)(nil),                       // 0: zhiplugin.v1.RunRequest
 	(*RunResponse)(nil),                      // 1: zhiplugin.v1.RunResponse
@@ -3111,12 +3665,25 @@ var file_zhiplugin_v1_ui_proto_goTypes = []any{
 	(*CtrlUpdatePluginResponse)(nil),         // 47: zhiplugin.v1.CtrlUpdatePluginResponse
 	(*CtrlRatePluginRequest)(nil),            // 48: zhiplugin.v1.CtrlRatePluginRequest
 	(*CtrlRatePluginResponse)(nil),           // 49: zhiplugin.v1.CtrlRatePluginResponse
-	(*proto.TreeEntry)(nil),                  // 50: zhiplugin.v1.TreeEntry
-	(*proto.ValidationResultMsg)(nil),        // 51: zhiplugin.v1.ValidationResultMsg
+	(*CtrlStoreAuthFieldMsg)(nil),            // 50: zhiplugin.v1.CtrlStoreAuthFieldMsg
+	(*CtrlStoreAuthMethodMsg)(nil),           // 51: zhiplugin.v1.CtrlStoreAuthMethodMsg
+	(*CtrlStoreAuthMethodsRequest)(nil),      // 52: zhiplugin.v1.CtrlStoreAuthMethodsRequest
+	(*CtrlStoreAuthMethodsResponse)(nil),     // 53: zhiplugin.v1.CtrlStoreAuthMethodsResponse
+	(*CtrlStoreLoginRequest)(nil),            // 54: zhiplugin.v1.CtrlStoreLoginRequest
+	(*CtrlStoreLoginResponse)(nil),           // 55: zhiplugin.v1.CtrlStoreLoginResponse
+	(*CtrlStoreAuthStatusRequest)(nil),       // 56: zhiplugin.v1.CtrlStoreAuthStatusRequest
+	(*CtrlStoreAuthStatusResponse)(nil),      // 57: zhiplugin.v1.CtrlStoreAuthStatusResponse
+	(*CtrlStoreLogoutRequest)(nil),           // 58: zhiplugin.v1.CtrlStoreLogoutRequest
+	(*CtrlStoreLogoutResponse)(nil),          // 59: zhiplugin.v1.CtrlStoreLogoutResponse
+	nil,                                      // 60: zhiplugin.v1.CtrlStoreLoginRequest.CredentialsEntry
+	nil,                                      // 61: zhiplugin.v1.CtrlStoreLoginResponse.MetadataEntry
+	nil,                                      // 62: zhiplugin.v1.CtrlStoreAuthStatusResponse.MetadataEntry
+	(*proto.TreeEntry)(nil),                  // 63: zhiplugin.v1.TreeEntry
+	(*proto.ValidationResultMsg)(nil),        // 64: zhiplugin.v1.ValidationResultMsg
 }
 var file_zhiplugin_v1_ui_proto_depIdxs = []int32{
-	50, // 0: zhiplugin.v1.CtrlLoadTreeResponse.tree:type_name -> zhiplugin.v1.TreeEntry
-	51, // 1: zhiplugin.v1.CtrlValidateResponse.results:type_name -> zhiplugin.v1.ValidationResultMsg
+	63, // 0: zhiplugin.v1.CtrlLoadTreeResponse.tree:type_name -> zhiplugin.v1.TreeEntry
+	64, // 1: zhiplugin.v1.CtrlValidateResponse.results:type_name -> zhiplugin.v1.ValidationResultMsg
 	13, // 2: zhiplugin.v1.CtrlExportTemplatesResponse.templates:type_name -> zhiplugin.v1.CtrlExportTemplateMsg
 	20, // 3: zhiplugin.v1.CtrlListComponentsResponse.components:type_name -> zhiplugin.v1.CtrlComponentInfoMsg
 	29, // 4: zhiplugin.v1.CtrlSearchMarketplaceResponse.results:type_name -> zhiplugin.v1.CtrlMarketplaceEntryMsg
@@ -3126,53 +3693,66 @@ var file_zhiplugin_v1_ui_proto_depIdxs = []int32{
 	34, // 8: zhiplugin.v1.CtrlGetMarketplaceDetailResponse.dependencies:type_name -> zhiplugin.v1.CtrlDependencyEntryMsg
 	41, // 9: zhiplugin.v1.CtrlListInstalledPluginsResponse.plugins:type_name -> zhiplugin.v1.CtrlInstalledPluginMsg
 	44, // 10: zhiplugin.v1.CtrlCheckUpdatesResponse.updates:type_name -> zhiplugin.v1.CtrlPluginUpdateMsg
-	0,  // 11: zhiplugin.v1.UIService.Run:input_type -> zhiplugin.v1.RunRequest
-	2,  // 12: zhiplugin.v1.UIService.Capabilities:input_type -> zhiplugin.v1.CapabilitiesRequest
-	4,  // 13: zhiplugin.v1.UIControllerService.LoadTree:input_type -> zhiplugin.v1.CtrlLoadTreeRequest
-	6,  // 14: zhiplugin.v1.UIControllerService.SetValue:input_type -> zhiplugin.v1.CtrlSetValueRequest
-	8,  // 15: zhiplugin.v1.UIControllerService.Validate:input_type -> zhiplugin.v1.CtrlValidateRequest
-	10, // 16: zhiplugin.v1.UIControllerService.SaveTree:input_type -> zhiplugin.v1.CtrlSaveTreeRequest
-	12, // 17: zhiplugin.v1.UIControllerService.ExportTemplates:input_type -> zhiplugin.v1.CtrlExportTemplatesRequest
-	15, // 18: zhiplugin.v1.UIControllerService.Export:input_type -> zhiplugin.v1.CtrlExportRequest
-	17, // 19: zhiplugin.v1.UIControllerService.Apply:input_type -> zhiplugin.v1.CtrlApplyRequest
-	19, // 20: zhiplugin.v1.UIControllerService.ListComponents:input_type -> zhiplugin.v1.CtrlListComponentsRequest
-	22, // 21: zhiplugin.v1.UIControllerService.EnableComponent:input_type -> zhiplugin.v1.CtrlEnableComponentRequest
-	24, // 22: zhiplugin.v1.UIControllerService.DisableComponent:input_type -> zhiplugin.v1.CtrlDisableComponentRequest
-	26, // 23: zhiplugin.v1.UIControllerService.WorkspaceName:input_type -> zhiplugin.v1.CtrlWorkspaceNameRequest
-	28, // 24: zhiplugin.v1.UIControllerService.SearchMarketplace:input_type -> zhiplugin.v1.CtrlSearchMarketplaceRequest
-	31, // 25: zhiplugin.v1.UIControllerService.GetMarketplaceDetail:input_type -> zhiplugin.v1.CtrlGetMarketplaceDetailRequest
-	36, // 26: zhiplugin.v1.UIControllerService.InstallPlugin:input_type -> zhiplugin.v1.CtrlInstallPluginRequest
-	38, // 27: zhiplugin.v1.UIControllerService.UninstallPlugin:input_type -> zhiplugin.v1.CtrlUninstallPluginRequest
-	40, // 28: zhiplugin.v1.UIControllerService.ListInstalledPlugins:input_type -> zhiplugin.v1.CtrlListInstalledPluginsRequest
-	43, // 29: zhiplugin.v1.UIControllerService.CheckUpdates:input_type -> zhiplugin.v1.CtrlCheckUpdatesRequest
-	46, // 30: zhiplugin.v1.UIControllerService.UpdatePlugin:input_type -> zhiplugin.v1.CtrlUpdatePluginRequest
-	48, // 31: zhiplugin.v1.UIControllerService.RatePlugin:input_type -> zhiplugin.v1.CtrlRatePluginRequest
-	1,  // 32: zhiplugin.v1.UIService.Run:output_type -> zhiplugin.v1.RunResponse
-	3,  // 33: zhiplugin.v1.UIService.Capabilities:output_type -> zhiplugin.v1.CapabilitiesResponse
-	5,  // 34: zhiplugin.v1.UIControllerService.LoadTree:output_type -> zhiplugin.v1.CtrlLoadTreeResponse
-	7,  // 35: zhiplugin.v1.UIControllerService.SetValue:output_type -> zhiplugin.v1.CtrlSetValueResponse
-	9,  // 36: zhiplugin.v1.UIControllerService.Validate:output_type -> zhiplugin.v1.CtrlValidateResponse
-	11, // 37: zhiplugin.v1.UIControllerService.SaveTree:output_type -> zhiplugin.v1.CtrlSaveTreeResponse
-	14, // 38: zhiplugin.v1.UIControllerService.ExportTemplates:output_type -> zhiplugin.v1.CtrlExportTemplatesResponse
-	16, // 39: zhiplugin.v1.UIControllerService.Export:output_type -> zhiplugin.v1.CtrlExportResponse
-	18, // 40: zhiplugin.v1.UIControllerService.Apply:output_type -> zhiplugin.v1.CtrlApplyResponse
-	21, // 41: zhiplugin.v1.UIControllerService.ListComponents:output_type -> zhiplugin.v1.CtrlListComponentsResponse
-	23, // 42: zhiplugin.v1.UIControllerService.EnableComponent:output_type -> zhiplugin.v1.CtrlEnableComponentResponse
-	25, // 43: zhiplugin.v1.UIControllerService.DisableComponent:output_type -> zhiplugin.v1.CtrlDisableComponentResponse
-	27, // 44: zhiplugin.v1.UIControllerService.WorkspaceName:output_type -> zhiplugin.v1.CtrlWorkspaceNameResponse
-	30, // 45: zhiplugin.v1.UIControllerService.SearchMarketplace:output_type -> zhiplugin.v1.CtrlSearchMarketplaceResponse
-	35, // 46: zhiplugin.v1.UIControllerService.GetMarketplaceDetail:output_type -> zhiplugin.v1.CtrlGetMarketplaceDetailResponse
-	37, // 47: zhiplugin.v1.UIControllerService.InstallPlugin:output_type -> zhiplugin.v1.CtrlInstallPluginResponse
-	39, // 48: zhiplugin.v1.UIControllerService.UninstallPlugin:output_type -> zhiplugin.v1.CtrlUninstallPluginResponse
-	42, // 49: zhiplugin.v1.UIControllerService.ListInstalledPlugins:output_type -> zhiplugin.v1.CtrlListInstalledPluginsResponse
-	45, // 50: zhiplugin.v1.UIControllerService.CheckUpdates:output_type -> zhiplugin.v1.CtrlCheckUpdatesResponse
-	47, // 51: zhiplugin.v1.UIControllerService.UpdatePlugin:output_type -> zhiplugin.v1.CtrlUpdatePluginResponse
-	49, // 52: zhiplugin.v1.UIControllerService.RatePlugin:output_type -> zhiplugin.v1.CtrlRatePluginResponse
-	32, // [32:53] is the sub-list for method output_type
-	11, // [11:32] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	50, // 11: zhiplugin.v1.CtrlStoreAuthMethodMsg.fields:type_name -> zhiplugin.v1.CtrlStoreAuthFieldMsg
+	51, // 12: zhiplugin.v1.CtrlStoreAuthMethodsResponse.methods:type_name -> zhiplugin.v1.CtrlStoreAuthMethodMsg
+	60, // 13: zhiplugin.v1.CtrlStoreLoginRequest.credentials:type_name -> zhiplugin.v1.CtrlStoreLoginRequest.CredentialsEntry
+	61, // 14: zhiplugin.v1.CtrlStoreLoginResponse.metadata:type_name -> zhiplugin.v1.CtrlStoreLoginResponse.MetadataEntry
+	62, // 15: zhiplugin.v1.CtrlStoreAuthStatusResponse.metadata:type_name -> zhiplugin.v1.CtrlStoreAuthStatusResponse.MetadataEntry
+	0,  // 16: zhiplugin.v1.UIService.Run:input_type -> zhiplugin.v1.RunRequest
+	2,  // 17: zhiplugin.v1.UIService.Capabilities:input_type -> zhiplugin.v1.CapabilitiesRequest
+	4,  // 18: zhiplugin.v1.UIControllerService.LoadTree:input_type -> zhiplugin.v1.CtrlLoadTreeRequest
+	6,  // 19: zhiplugin.v1.UIControllerService.SetValue:input_type -> zhiplugin.v1.CtrlSetValueRequest
+	8,  // 20: zhiplugin.v1.UIControllerService.Validate:input_type -> zhiplugin.v1.CtrlValidateRequest
+	10, // 21: zhiplugin.v1.UIControllerService.SaveTree:input_type -> zhiplugin.v1.CtrlSaveTreeRequest
+	12, // 22: zhiplugin.v1.UIControllerService.ExportTemplates:input_type -> zhiplugin.v1.CtrlExportTemplatesRequest
+	15, // 23: zhiplugin.v1.UIControllerService.Export:input_type -> zhiplugin.v1.CtrlExportRequest
+	17, // 24: zhiplugin.v1.UIControllerService.Apply:input_type -> zhiplugin.v1.CtrlApplyRequest
+	19, // 25: zhiplugin.v1.UIControllerService.ListComponents:input_type -> zhiplugin.v1.CtrlListComponentsRequest
+	22, // 26: zhiplugin.v1.UIControllerService.EnableComponent:input_type -> zhiplugin.v1.CtrlEnableComponentRequest
+	24, // 27: zhiplugin.v1.UIControllerService.DisableComponent:input_type -> zhiplugin.v1.CtrlDisableComponentRequest
+	26, // 28: zhiplugin.v1.UIControllerService.WorkspaceName:input_type -> zhiplugin.v1.CtrlWorkspaceNameRequest
+	28, // 29: zhiplugin.v1.UIControllerService.SearchMarketplace:input_type -> zhiplugin.v1.CtrlSearchMarketplaceRequest
+	31, // 30: zhiplugin.v1.UIControllerService.GetMarketplaceDetail:input_type -> zhiplugin.v1.CtrlGetMarketplaceDetailRequest
+	36, // 31: zhiplugin.v1.UIControllerService.InstallPlugin:input_type -> zhiplugin.v1.CtrlInstallPluginRequest
+	38, // 32: zhiplugin.v1.UIControllerService.UninstallPlugin:input_type -> zhiplugin.v1.CtrlUninstallPluginRequest
+	40, // 33: zhiplugin.v1.UIControllerService.ListInstalledPlugins:input_type -> zhiplugin.v1.CtrlListInstalledPluginsRequest
+	43, // 34: zhiplugin.v1.UIControllerService.CheckUpdates:input_type -> zhiplugin.v1.CtrlCheckUpdatesRequest
+	46, // 35: zhiplugin.v1.UIControllerService.UpdatePlugin:input_type -> zhiplugin.v1.CtrlUpdatePluginRequest
+	48, // 36: zhiplugin.v1.UIControllerService.RatePlugin:input_type -> zhiplugin.v1.CtrlRatePluginRequest
+	52, // 37: zhiplugin.v1.UIControllerService.StoreAuthMethods:input_type -> zhiplugin.v1.CtrlStoreAuthMethodsRequest
+	54, // 38: zhiplugin.v1.UIControllerService.StoreLogin:input_type -> zhiplugin.v1.CtrlStoreLoginRequest
+	56, // 39: zhiplugin.v1.UIControllerService.StoreAuthStatus:input_type -> zhiplugin.v1.CtrlStoreAuthStatusRequest
+	58, // 40: zhiplugin.v1.UIControllerService.StoreLogout:input_type -> zhiplugin.v1.CtrlStoreLogoutRequest
+	1,  // 41: zhiplugin.v1.UIService.Run:output_type -> zhiplugin.v1.RunResponse
+	3,  // 42: zhiplugin.v1.UIService.Capabilities:output_type -> zhiplugin.v1.CapabilitiesResponse
+	5,  // 43: zhiplugin.v1.UIControllerService.LoadTree:output_type -> zhiplugin.v1.CtrlLoadTreeResponse
+	7,  // 44: zhiplugin.v1.UIControllerService.SetValue:output_type -> zhiplugin.v1.CtrlSetValueResponse
+	9,  // 45: zhiplugin.v1.UIControllerService.Validate:output_type -> zhiplugin.v1.CtrlValidateResponse
+	11, // 46: zhiplugin.v1.UIControllerService.SaveTree:output_type -> zhiplugin.v1.CtrlSaveTreeResponse
+	14, // 47: zhiplugin.v1.UIControllerService.ExportTemplates:output_type -> zhiplugin.v1.CtrlExportTemplatesResponse
+	16, // 48: zhiplugin.v1.UIControllerService.Export:output_type -> zhiplugin.v1.CtrlExportResponse
+	18, // 49: zhiplugin.v1.UIControllerService.Apply:output_type -> zhiplugin.v1.CtrlApplyResponse
+	21, // 50: zhiplugin.v1.UIControllerService.ListComponents:output_type -> zhiplugin.v1.CtrlListComponentsResponse
+	23, // 51: zhiplugin.v1.UIControllerService.EnableComponent:output_type -> zhiplugin.v1.CtrlEnableComponentResponse
+	25, // 52: zhiplugin.v1.UIControllerService.DisableComponent:output_type -> zhiplugin.v1.CtrlDisableComponentResponse
+	27, // 53: zhiplugin.v1.UIControllerService.WorkspaceName:output_type -> zhiplugin.v1.CtrlWorkspaceNameResponse
+	30, // 54: zhiplugin.v1.UIControllerService.SearchMarketplace:output_type -> zhiplugin.v1.CtrlSearchMarketplaceResponse
+	35, // 55: zhiplugin.v1.UIControllerService.GetMarketplaceDetail:output_type -> zhiplugin.v1.CtrlGetMarketplaceDetailResponse
+	37, // 56: zhiplugin.v1.UIControllerService.InstallPlugin:output_type -> zhiplugin.v1.CtrlInstallPluginResponse
+	39, // 57: zhiplugin.v1.UIControllerService.UninstallPlugin:output_type -> zhiplugin.v1.CtrlUninstallPluginResponse
+	42, // 58: zhiplugin.v1.UIControllerService.ListInstalledPlugins:output_type -> zhiplugin.v1.CtrlListInstalledPluginsResponse
+	45, // 59: zhiplugin.v1.UIControllerService.CheckUpdates:output_type -> zhiplugin.v1.CtrlCheckUpdatesResponse
+	47, // 60: zhiplugin.v1.UIControllerService.UpdatePlugin:output_type -> zhiplugin.v1.CtrlUpdatePluginResponse
+	49, // 61: zhiplugin.v1.UIControllerService.RatePlugin:output_type -> zhiplugin.v1.CtrlRatePluginResponse
+	53, // 62: zhiplugin.v1.UIControllerService.StoreAuthMethods:output_type -> zhiplugin.v1.CtrlStoreAuthMethodsResponse
+	55, // 63: zhiplugin.v1.UIControllerService.StoreLogin:output_type -> zhiplugin.v1.CtrlStoreLoginResponse
+	57, // 64: zhiplugin.v1.UIControllerService.StoreAuthStatus:output_type -> zhiplugin.v1.CtrlStoreAuthStatusResponse
+	59, // 65: zhiplugin.v1.UIControllerService.StoreLogout:output_type -> zhiplugin.v1.CtrlStoreLogoutResponse
+	41, // [41:66] is the sub-list for method output_type
+	16, // [16:41] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_zhiplugin_v1_ui_proto_init() }
@@ -3186,7 +3766,7 @@ func file_zhiplugin_v1_ui_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_zhiplugin_v1_ui_proto_rawDesc), len(file_zhiplugin_v1_ui_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   50,
+			NumMessages:   63,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/zhiplugin/ui/proto/ui_grpc.pb.go
+++ b/pkg/zhiplugin/ui/proto/ui_grpc.pb.go
@@ -197,6 +197,10 @@ const (
 	UIControllerService_CheckUpdates_FullMethodName         = "/zhiplugin.v1.UIControllerService/CheckUpdates"
 	UIControllerService_UpdatePlugin_FullMethodName         = "/zhiplugin.v1.UIControllerService/UpdatePlugin"
 	UIControllerService_RatePlugin_FullMethodName           = "/zhiplugin.v1.UIControllerService/RatePlugin"
+	UIControllerService_StoreAuthMethods_FullMethodName     = "/zhiplugin.v1.UIControllerService/StoreAuthMethods"
+	UIControllerService_StoreLogin_FullMethodName           = "/zhiplugin.v1.UIControllerService/StoreLogin"
+	UIControllerService_StoreAuthStatus_FullMethodName      = "/zhiplugin.v1.UIControllerService/StoreAuthStatus"
+	UIControllerService_StoreLogout_FullMethodName          = "/zhiplugin.v1.UIControllerService/StoreLogout"
 )
 
 // UIControllerServiceClient is the client API for UIControllerService service.
@@ -244,6 +248,14 @@ type UIControllerServiceClient interface {
 	UpdatePlugin(ctx context.Context, in *CtrlUpdatePluginRequest, opts ...grpc.CallOption) (*CtrlUpdatePluginResponse, error)
 	// RatePlugin submits a rating for a marketplace plugin.
 	RatePlugin(ctx context.Context, in *CtrlRatePluginRequest, opts ...grpc.CallOption) (*CtrlRatePluginResponse, error)
+	// StoreAuthMethods returns the auth methods supported by the configured store.
+	StoreAuthMethods(ctx context.Context, in *CtrlStoreAuthMethodsRequest, opts ...grpc.CallOption) (*CtrlStoreAuthMethodsResponse, error)
+	// StoreLogin authenticates with the store using the given method and credentials.
+	StoreLogin(ctx context.Context, in *CtrlStoreLoginRequest, opts ...grpc.CallOption) (*CtrlStoreLoginResponse, error)
+	// StoreAuthStatus returns the current authentication status.
+	StoreAuthStatus(ctx context.Context, in *CtrlStoreAuthStatusRequest, opts ...grpc.CallOption) (*CtrlStoreAuthStatusResponse, error)
+	// StoreLogout clears the current authentication session.
+	StoreLogout(ctx context.Context, in *CtrlStoreLogoutRequest, opts ...grpc.CallOption) (*CtrlStoreLogoutResponse, error)
 }
 
 type uIControllerServiceClient struct {
@@ -453,6 +465,46 @@ func (c *uIControllerServiceClient) RatePlugin(ctx context.Context, in *CtrlRate
 	return out, nil
 }
 
+func (c *uIControllerServiceClient) StoreAuthMethods(ctx context.Context, in *CtrlStoreAuthMethodsRequest, opts ...grpc.CallOption) (*CtrlStoreAuthMethodsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CtrlStoreAuthMethodsResponse)
+	err := c.cc.Invoke(ctx, UIControllerService_StoreAuthMethods_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *uIControllerServiceClient) StoreLogin(ctx context.Context, in *CtrlStoreLoginRequest, opts ...grpc.CallOption) (*CtrlStoreLoginResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CtrlStoreLoginResponse)
+	err := c.cc.Invoke(ctx, UIControllerService_StoreLogin_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *uIControllerServiceClient) StoreAuthStatus(ctx context.Context, in *CtrlStoreAuthStatusRequest, opts ...grpc.CallOption) (*CtrlStoreAuthStatusResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CtrlStoreAuthStatusResponse)
+	err := c.cc.Invoke(ctx, UIControllerService_StoreAuthStatus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *uIControllerServiceClient) StoreLogout(ctx context.Context, in *CtrlStoreLogoutRequest, opts ...grpc.CallOption) (*CtrlStoreLogoutResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CtrlStoreLogoutResponse)
+	err := c.cc.Invoke(ctx, UIControllerService_StoreLogout_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // UIControllerServiceServer is the server API for UIControllerService service.
 // All implementations must embed UnimplementedUIControllerServiceServer
 // for forward compatibility.
@@ -498,6 +550,14 @@ type UIControllerServiceServer interface {
 	UpdatePlugin(context.Context, *CtrlUpdatePluginRequest) (*CtrlUpdatePluginResponse, error)
 	// RatePlugin submits a rating for a marketplace plugin.
 	RatePlugin(context.Context, *CtrlRatePluginRequest) (*CtrlRatePluginResponse, error)
+	// StoreAuthMethods returns the auth methods supported by the configured store.
+	StoreAuthMethods(context.Context, *CtrlStoreAuthMethodsRequest) (*CtrlStoreAuthMethodsResponse, error)
+	// StoreLogin authenticates with the store using the given method and credentials.
+	StoreLogin(context.Context, *CtrlStoreLoginRequest) (*CtrlStoreLoginResponse, error)
+	// StoreAuthStatus returns the current authentication status.
+	StoreAuthStatus(context.Context, *CtrlStoreAuthStatusRequest) (*CtrlStoreAuthStatusResponse, error)
+	// StoreLogout clears the current authentication session.
+	StoreLogout(context.Context, *CtrlStoreLogoutRequest) (*CtrlStoreLogoutResponse, error)
 	mustEmbedUnimplementedUIControllerServiceServer()
 }
 
@@ -564,6 +624,18 @@ func (UnimplementedUIControllerServiceServer) UpdatePlugin(context.Context, *Ctr
 }
 func (UnimplementedUIControllerServiceServer) RatePlugin(context.Context, *CtrlRatePluginRequest) (*CtrlRatePluginResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RatePlugin not implemented")
+}
+func (UnimplementedUIControllerServiceServer) StoreAuthMethods(context.Context, *CtrlStoreAuthMethodsRequest) (*CtrlStoreAuthMethodsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method StoreAuthMethods not implemented")
+}
+func (UnimplementedUIControllerServiceServer) StoreLogin(context.Context, *CtrlStoreLoginRequest) (*CtrlStoreLoginResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method StoreLogin not implemented")
+}
+func (UnimplementedUIControllerServiceServer) StoreAuthStatus(context.Context, *CtrlStoreAuthStatusRequest) (*CtrlStoreAuthStatusResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method StoreAuthStatus not implemented")
+}
+func (UnimplementedUIControllerServiceServer) StoreLogout(context.Context, *CtrlStoreLogoutRequest) (*CtrlStoreLogoutResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method StoreLogout not implemented")
 }
 func (UnimplementedUIControllerServiceServer) mustEmbedUnimplementedUIControllerServiceServer() {}
 func (UnimplementedUIControllerServiceServer) testEmbeddedByValue()                             {}
@@ -921,6 +993,78 @@ func _UIControllerService_RatePlugin_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _UIControllerService_StoreAuthMethods_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CtrlStoreAuthMethodsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UIControllerServiceServer).StoreAuthMethods(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UIControllerService_StoreAuthMethods_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UIControllerServiceServer).StoreAuthMethods(ctx, req.(*CtrlStoreAuthMethodsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UIControllerService_StoreLogin_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CtrlStoreLoginRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UIControllerServiceServer).StoreLogin(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UIControllerService_StoreLogin_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UIControllerServiceServer).StoreLogin(ctx, req.(*CtrlStoreLoginRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UIControllerService_StoreAuthStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CtrlStoreAuthStatusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UIControllerServiceServer).StoreAuthStatus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UIControllerService_StoreAuthStatus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UIControllerServiceServer).StoreAuthStatus(ctx, req.(*CtrlStoreAuthStatusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UIControllerService_StoreLogout_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CtrlStoreLogoutRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UIControllerServiceServer).StoreLogout(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UIControllerService_StoreLogout_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UIControllerServiceServer).StoreLogout(ctx, req.(*CtrlStoreLogoutRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // UIControllerService_ServiceDesc is the grpc.ServiceDesc for UIControllerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -999,6 +1143,22 @@ var UIControllerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RatePlugin",
 			Handler:    _UIControllerService_RatePlugin_Handler,
+		},
+		{
+			MethodName: "StoreAuthMethods",
+			Handler:    _UIControllerService_StoreAuthMethods_Handler,
+		},
+		{
+			MethodName: "StoreLogin",
+			Handler:    _UIControllerService_StoreLogin_Handler,
+		},
+		{
+			MethodName: "StoreAuthStatus",
+			Handler:    _UIControllerService_StoreAuthStatus_Handler,
+		},
+		{
+			MethodName: "StoreLogout",
+			Handler:    _UIControllerService_StoreLogout_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pkg/zhiplugin/ui/ui_test.go
+++ b/pkg/zhiplugin/ui/ui_test.go
@@ -280,6 +280,22 @@ func (c *testController) RatePlugin(_ context.Context, _, publisher, name string
 	return nil
 }
 
+func (c *testController) StoreAuthMethods(_ context.Context) ([]StoreAuthMethod, error) {
+	return nil, nil
+}
+
+func (c *testController) StoreLogin(_ context.Context, _ string, _ map[string]string) (*StoreSession, error) {
+	return &StoreSession{Status: StoreSessionNone}, nil
+}
+
+func (c *testController) StoreAuthStatus(_ context.Context) (*StoreSession, error) {
+	return &StoreSession{Status: StoreSessionNone}, nil
+}
+
+func (c *testController) StoreLogout(_ context.Context) error {
+	return nil
+}
+
 // --- testUIPlugin: exercises the Controller during Run --------------------
 
 type testUIPlugin struct {


### PR DESCRIPTION
## Summary

Expose store authentication operations through the UI controller layer so that both built-in and external UI plugins can initiate login flows.

**Phase 2** of the [login system implementation](plans/login/roadmap/phase2-controller-api.md).

## Changes

### New File
- **`pkg/zhiplugin/ui/auth.go`** — UI-facing auth types: `StoreAuthMethod`, `StoreAuthField`, `StoreSession`, `StoreSessionStatus` constants

### Modified Files
- **`pkg/zhiplugin/ui/plugin.go`** — Added `StoreAuthMethods`, `StoreLogin`, `StoreAuthStatus`, `StoreLogout` to the `Controller` interface
- **`internal/ui/driver.go`** — Implemented the four new methods in `UIController`, delegating to `engine.Session()`. Added error propagation: `LoadTree` and `SaveTree` now call `HandleAuthError` on failures
- **`internal/ui/adapter.go`** — Bridged the new `UIController` methods in `ControllerAdapter`
- **`api/proto/zhiplugin/v1/ui.proto`** — Added four new RPCs and messages to `UIControllerService`
- **`pkg/zhiplugin/ui/controller_client.go`** — gRPC client implementations for auth RPCs
- **`pkg/zhiplugin/ui/controller_server.go`** — gRPC server implementations for auth RPCs
- **`pkg/zhiplugin/ui/proto/`** — Regenerated via `make proto`

### Test Updates
- **`internal/ui/driver_test.go`** — Tests for `UIController` auth methods with both no-auth and auth-enabled mock stores
- **`internal/ui/adapter_test.go`** (new) — Tests for `ControllerAdapter` auth delegation
- **`pkg/zhiplugin/ui/ui_test.go`** — Updated `testController` mock
- **`examples/zhi-ui-httpapi/main_test.go`** — Updated `mockController`
- **`pkg/providers/ui/webui/webui_test.go`** — Updated `mockController`

## Acceptance Criteria
- [x] `Controller` interface includes all four auth methods
- [x] `UIController` delegates correctly to `SessionManager`
- [x] `ControllerAdapter` bridges correctly
- [x] gRPC client/server implemented for all four RPCs
- [x] Existing tests still pass (mocks updated)
- [x] `make check` passes (fmt + vet + lint + test)

## Dependencies
- Phase 1 (Core Session Manager) — #54