### PR TITLE
feat(tui): add login view for store authentication

### DIFF
--- a/internal/ui/tui/app.go
+++ b/internal/ui/tui/app.go
@@ -10,13 +10,15 @@ import (
 	"github.com/MrWong99/zhi/internal/ui"
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
 	"github.com/MrWong99/zhi/pkg/zhiplugin/store"
+	zhiui "github.com/MrWong99/zhi/pkg/zhiplugin/ui"
 )
 
 // viewType identifies which sub-view is currently active.
 type viewType int
 
 const (
-	viewTree viewType = iota
+	viewLogin viewType = iota
+	viewTree
 	viewEditor
 	viewComponent
 	viewValidation
@@ -62,6 +64,8 @@ type App struct {
 	ctx              context.Context
 	tree             *config.Tree
 	activeView       viewType
+	previousView     viewType // view to return to after re-authentication
+	loginView        loginModel
 	treeView         TreeView
 	editorView       ValueEditor
 	componentView    ComponentView
@@ -81,20 +85,28 @@ type App struct {
 
 // NewApp creates a new App and performs the initial tree load.
 func NewApp(ctx context.Context, controller *ui.UIController) (*App, error) {
-	tree, err := controller.LoadTree(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("loading initial tree: %w", err)
-	}
-
 	app := &App{
 		controller: controller,
 		ctx:        ctx,
-		tree:       tree,
 		activeView: viewTree,
 		width:      80,
 		height:     24,
 	}
 
+	// Check if authentication is required before loading the tree.
+	if needsLogin, methods := app.checkAuthRequired(ctx); needsLogin {
+		app.loginView = newLoginModel(ctx, controller, methods, "")
+		app.activeView = viewLogin
+		app.notification = NewNotification()
+		return app, nil
+	}
+
+	tree, err := controller.LoadTree(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading initial tree: %w", err)
+	}
+
+	app.tree = tree
 	app.treeView = NewTreeView(controller, tree)
 	app.editorView = NewValueEditor()
 	app.componentView = NewComponentView(controller)
@@ -106,6 +118,37 @@ func NewApp(ctx context.Context, controller *ui.UIController) (*App, error) {
 	app.notification = NewNotification()
 
 	return app, nil
+}
+
+// checkAuthRequired checks if the store requires authentication.
+// Returns true and the available methods if login is needed.
+func (a *App) checkAuthRequired(ctx context.Context) (bool, []zhiui.StoreAuthMethod) {
+	methods, err := a.controller.StoreAuthMethods(ctx)
+	if err != nil || len(methods) == 0 {
+		return false, nil
+	}
+	session, err := a.controller.StoreAuthStatus(ctx)
+	if err != nil || session == nil {
+		return false, nil
+	}
+	if session.Status != zhiui.StoreSessionUnauthenticated && session.Status != zhiui.StoreSessionExpired {
+		return false, nil
+	}
+	return true, methods
+}
+
+// showLoginView transitions to the login view with an optional message.
+func (a *App) showLoginView(message string) tea.Cmd {
+	methods, err := a.controller.StoreAuthMethods(a.ctx)
+	if err != nil || len(methods) == 0 {
+		a.statusMsg = "Authentication required but no auth methods available"
+		return nil
+	}
+	a.previousView = a.activeView
+	a.loginView = newLoginModel(a.ctx, a.controller, methods, message)
+	a.loginView.SetSize(a.width, a.contentHeight())
+	a.activeView = viewLogin
+	return a.loginView.Init()
 }
 
 // Init returns the initial command.
@@ -122,6 +165,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		a.width = msg.Width
 		a.height = msg.Height
+		a.loginView.SetSize(a.width, a.contentHeight())
 		a.treeView.SetSize(a.width, a.contentHeight())
 		a.validationView.SetSize(a.width, a.contentHeight())
 		a.applyView.SetSize(a.width, a.contentHeight())
@@ -163,6 +207,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.showHelp = false
 				return a, nil
 			}
+			if a.activeView == viewLogin {
+				// Let the login view handle Esc (e.g. back to method selection).
+				break
+			}
 			if a.activeView == viewTree {
 				if a.treeView.filtering {
 					a.treeView.ClearFilter()
@@ -180,8 +228,25 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+	case loginResultMsg:
+		if msg.err != nil {
+			// Error is displayed within the login view itself.
+			a.loginView, _ = a.loginView.UpdateLogin(msg)
+			return a, nil
+		}
+		a.loginView, _ = a.loginView.UpdateLogin(msg)
+		// Successful login: load tree and transition to tree view.
+		a.statusMsg = "Login successful"
+		return a, func() tea.Msg {
+			tree, err := a.controller.LoadTree(a.ctx)
+			return treeLoadedMsg{tree: tree, err: err}
+		}
+
 	case treeLoadedMsg:
 		if msg.err != nil {
+			if store.IsAuthRequired(msg.err) {
+				return a, a.showLoginView("Authentication required. Please log in.")
+			}
 			a.err = msg.err
 			a.statusMsg = "Error loading tree: " + msg.err.Error()
 			return a, nil
@@ -189,7 +254,20 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.tree = msg.tree
 		a.treeView = NewTreeView(a.controller, a.tree)
 		a.treeView.SetSize(a.width, a.contentHeight())
-		a.statusMsg = "Tree reloaded"
+		if a.activeView == viewLogin {
+			// Transitioning from login: initialize all views and go to tree.
+			a.editorView = NewValueEditor()
+			a.componentView = NewComponentView(a.controller)
+			a.validationView = NewValidationView()
+			a.applyView = NewApplyView()
+			a.exportView = NewExportView(a.controller)
+			a.marketplaceView = NewMarketplaceView(a.ctx, a.controller)
+			a.installedView = NewInstalledView(a.ctx, a.controller)
+			a.activeView = viewTree
+			a.statusMsg = "Login successful"
+		} else {
+			a.statusMsg = "Tree reloaded"
+		}
 		return a, nil
 
 	case statusMsg:
@@ -204,6 +282,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Route to active view.
 	switch a.activeView {
+	case viewLogin:
+		return a.updateLoginView(msg)
 	case viewTree:
 		return a.updateTreeView(msg)
 	case viewEditor:
@@ -227,6 +307,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return a, nil
 }
 
+func (a *App) updateLoginView(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	a.loginView, cmd = a.loginView.UpdateLogin(msg)
+	return a, cmd
+}
+
 func (a *App) updateTreeView(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if keyMsg, ok := msg.(tea.KeyMsg); ok && !a.treeView.filtering {
 		switch keyMsg.String() {
@@ -247,6 +333,9 @@ func (a *App) updateTreeView(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "s":
 			err := a.controller.SaveTree(a.ctx)
 			if err != nil {
+				if store.IsAuthRequired(err) {
+					return a, a.showLoginView("Session expired. Please log in again.")
+				}
 				if store.IsCASConflict(err) {
 					a.statusMsg = "Save conflict: tree was modified externally. Press r to reload."
 				} else {
@@ -260,6 +349,9 @@ func (a *App) updateTreeView(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "v":
 			results, err := a.controller.Validate(a.ctx)
 			if err != nil {
+				if store.IsAuthRequired(err) {
+					return a, a.showLoginView("Session expired. Please log in again.")
+				}
 				a.statusMsg = "Validation error: " + err.Error()
 				return a, nil
 			}
@@ -365,6 +457,9 @@ func (a *App) commitEditorValue() (tea.Model, tea.Cmd) {
 	val := a.editorView.CommitValue()
 	err := a.controller.SetValue(a.ctx, a.editorView.path, val)
 	if err != nil {
+		if store.IsAuthRequired(err) {
+			return a, a.showLoginView("Session expired. Please log in again.")
+		}
 		a.statusMsg = "Set failed: " + err.Error()
 	} else {
 		a.statusMsg = fmt.Sprintf("Updated %s", a.editorView.path)
@@ -503,6 +598,8 @@ func (a *App) renderHeader() string {
 	title := fmt.Sprintf(" zhi - %s ", a.controller.WorkspaceName())
 	viewName := ""
 	switch a.activeView {
+	case viewLogin:
+		viewName = "Login"
 	case viewTree:
 		viewName = "Tree"
 	case viewEditor:
@@ -532,6 +629,8 @@ func (a *App) renderHeader() string {
 
 func (a *App) renderContent() string {
 	switch a.activeView {
+	case viewLogin:
+		return a.loginView.View()
 	case viewTree:
 		return a.treeView.View()
 	case viewEditor:
@@ -558,6 +657,8 @@ func (a *App) renderContent() string {
 func (a *App) renderStatusBar() string {
 	var hints string
 	switch a.activeView {
+	case viewLogin:
+		hints = "Tab:next field  Enter:submit  Ctrl+C:quit"
 	case viewTree:
 		hints = "j/k:navigate  enter:edit  s:save  v:validate  a:apply  e:export  c:components  m:marketplace  p:plugins  r:reload  ?:help  q:quit"
 	case viewEditor:

--- a/internal/ui/tui/login.go
+++ b/internal/ui/tui/login.go
@@ -1,0 +1,300 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MrWong99/zhi/internal/ui"
+	zhiui "github.com/MrWong99/zhi/pkg/zhiplugin/ui"
+)
+
+// loginPhase tracks which part of the login flow is active.
+type loginPhase int
+
+const (
+	loginPhaseMethod loginPhase = iota
+	loginPhaseForm
+)
+
+// loginResultMsg is sent after a login attempt completes.
+type loginResultMsg struct {
+	session *zhiui.StoreSession
+	err     error
+}
+
+// loginModel is the Bubbletea model for the store login view.
+type loginModel struct {
+	controller *ui.UIController
+	ctx        context.Context
+	methods    []zhiui.StoreAuthMethod
+	phase      loginPhase
+	// Method selection state.
+	methodCursor int
+	// Credential form state.
+	selectedMethod zhiui.StoreAuthMethod
+	inputs         []textinput.Model
+	focusIndex     int
+	// Result state.
+	submitting bool
+	errMsg     string
+	message    string // e.g. "Session expired. Please log in again."
+	width      int
+	height     int
+}
+
+// newLoginModel creates a login model with the given auth methods.
+func newLoginModel(ctx context.Context, controller *ui.UIController, methods []zhiui.StoreAuthMethod, message string) loginModel {
+	m := loginModel{
+		controller: controller,
+		ctx:        ctx,
+		methods:    methods,
+		message:    message,
+		width:      80,
+		height:     24,
+	}
+
+	if len(methods) == 1 {
+		m.phase = loginPhaseForm
+		m.selectedMethod = methods[0]
+		m.buildInputs()
+	} else {
+		m.phase = loginPhaseMethod
+	}
+
+	return m
+}
+
+func (m *loginModel) buildInputs() {
+	m.inputs = make([]textinput.Model, len(m.selectedMethod.Fields))
+	for i, field := range m.selectedMethod.Fields {
+		ti := textinput.New()
+		ti.Placeholder = field.Description
+		ti.CharLimit = 256
+		ti.Width = 40
+		if field.Secret {
+			ti.EchoMode = textinput.EchoNone
+			ti.EchoCharacter = '•'
+		}
+		if i == 0 {
+			ti.Focus()
+		}
+		m.inputs[i] = ti
+	}
+	m.focusIndex = 0
+}
+
+// SetSize updates the dimensions available for rendering.
+func (m *loginModel) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+// Init returns the initial command for the login model.
+func (m loginModel) Init() tea.Cmd {
+	if m.phase == loginPhaseForm && len(m.inputs) > 0 {
+		return textinput.Blink
+	}
+	return nil
+}
+
+// UpdateLogin handles messages for the login view.
+func (m loginModel) UpdateLogin(msg tea.Msg) (loginModel, tea.Cmd) {
+	if m.submitting {
+		if result, ok := msg.(loginResultMsg); ok {
+			m.submitting = false
+			if result.err != nil {
+				m.errMsg = result.err.Error()
+				return m, nil
+			}
+			// Success is handled by the app model checking the result message.
+			return m, nil
+		}
+		return m, nil
+	}
+
+	switch m.phase {
+	case loginPhaseMethod:
+		return m.updateMethodSelection(msg)
+	case loginPhaseForm:
+		return m.updateCredentialForm(msg)
+	}
+	return m, nil
+}
+
+func (m loginModel) updateMethodSelection(msg tea.Msg) (loginModel, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "j", "down":
+			if m.methodCursor < len(m.methods)-1 {
+				m.methodCursor++
+			}
+		case "k", "up":
+			if m.methodCursor > 0 {
+				m.methodCursor--
+			}
+		case "enter":
+			m.selectedMethod = m.methods[m.methodCursor]
+			m.phase = loginPhaseForm
+			m.errMsg = ""
+			m.buildInputs()
+			return m, textinput.Blink
+		}
+	}
+	return m, nil
+}
+
+func (m loginModel) updateCredentialForm(msg tea.Msg) (loginModel, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "tab", "shift+tab":
+			dir := 1
+			if keyMsg.String() == "shift+tab" {
+				dir = -1
+			}
+			m.focusIndex = (m.focusIndex + dir + len(m.inputs)) % len(m.inputs)
+			cmds := make([]tea.Cmd, len(m.inputs))
+			for i := range m.inputs {
+				if i == m.focusIndex {
+					cmds[i] = m.inputs[i].Focus()
+				} else {
+					m.inputs[i].Blur()
+				}
+			}
+			return m, tea.Batch(cmds...)
+
+		case "enter":
+			return m.submitLogin()
+
+		case "esc":
+			if len(m.methods) > 1 {
+				m.phase = loginPhaseMethod
+				m.errMsg = ""
+				return m, nil
+			}
+		}
+	}
+
+	// Update the focused input.
+	if m.focusIndex < len(m.inputs) {
+		var cmd tea.Cmd
+		m.inputs[m.focusIndex], cmd = m.inputs[m.focusIndex].Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m loginModel) submitLogin() (loginModel, tea.Cmd) {
+	credentials := make(map[string]string, len(m.inputs))
+	for i, field := range m.selectedMethod.Fields {
+		credentials[field.Name] = m.inputs[i].Value()
+	}
+	method := m.selectedMethod.Type
+	m.submitting = true
+	m.errMsg = ""
+
+	ctx := m.ctx
+	ctrl := m.controller
+	return m, func() tea.Msg {
+		session, err := ctrl.StoreLogin(ctx, method, credentials)
+		return loginResultMsg{session: session, err: err}
+	}
+}
+
+// View renders the login view.
+func (m loginModel) View() string {
+	var sb strings.Builder
+
+	sb.WriteString("\n")
+	sb.WriteString(HeaderStyle.Render(" Store Login "))
+	sb.WriteString("\n\n")
+
+	if m.message != "" {
+		sb.WriteString(WarningStyle.Render(fmt.Sprintf("  %s", m.message)))
+		sb.WriteString("\n\n")
+	} else {
+		sb.WriteString(DimStyle.Render("  The store requires authentication."))
+		sb.WriteString("\n\n")
+	}
+
+	switch m.phase {
+	case loginPhaseMethod:
+		sb.WriteString(m.viewMethodSelection())
+	case loginPhaseForm:
+		sb.WriteString(m.viewCredentialForm())
+	}
+
+	if m.errMsg != "" {
+		sb.WriteString("\n")
+		sb.WriteString(ErrorStyle.Render(fmt.Sprintf("  Error: %s", m.errMsg)))
+		sb.WriteString("\n")
+	}
+
+	if m.submitting {
+		sb.WriteString("\n")
+		sb.WriteString(SpinnerStyle.Render("  Logging in..."))
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString(m.viewHints())
+
+	return sb.String()
+}
+
+func (m loginModel) viewMethodSelection() string {
+	var sb strings.Builder
+	sb.WriteString("  Select authentication method:\n\n")
+	for i, method := range m.methods {
+		cursor := "  "
+		if i == m.methodCursor {
+			cursor = "> "
+		}
+		style := ValueStyle
+		if i == m.methodCursor {
+			style = ActiveStyle
+		}
+		line := method.Type
+		if method.Description != "" {
+			line += DimStyle.Render(fmt.Sprintf(" - %s", method.Description))
+		}
+		sb.WriteString(fmt.Sprintf("  %s%s\n", cursor, style.Render(line)))
+	}
+	return sb.String()
+}
+
+func (m loginModel) viewCredentialForm() string {
+	var sb strings.Builder
+
+	if len(m.methods) > 1 {
+		sb.WriteString(DimStyle.Render(fmt.Sprintf("  Method: %s", m.selectedMethod.Type)))
+		sb.WriteString("\n\n")
+	}
+
+	for i, field := range m.selectedMethod.Fields {
+		label := field.Name
+		if field.Required {
+			label += RequiredBadgeStyle.Render(" *")
+		}
+		sb.WriteString(fmt.Sprintf("  %s:\n", label))
+		sb.WriteString(fmt.Sprintf("  %s\n\n", m.inputs[i].View()))
+	}
+	return sb.String()
+}
+
+func (m loginModel) viewHints() string {
+	switch m.phase {
+	case loginPhaseMethod:
+		return DimStyle.Render("  j/k: select  Enter: choose  Ctrl+C: quit")
+	case loginPhaseForm:
+		hints := "  Tab: next field  Enter: login  Ctrl+C: quit"
+		if len(m.methods) > 1 {
+			hints = "  Tab: next field  Enter: login  Esc: back  Ctrl+C: quit"
+		}
+		return DimStyle.Render(hints)
+	}
+	return ""
+}

--- a/internal/ui/tui/login_test.go
+++ b/internal/ui/tui/login_test.go
@@ -1,0 +1,580 @@
+package tui_test
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MrWong99/zhi/internal/core"
+	"github.com/MrWong99/zhi/internal/ui"
+	"github.com/MrWong99/zhi/internal/ui/tui"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/store"
+)
+
+// authMockStore is a mock store that requires authentication.
+type authMockStore struct {
+	trees       map[string]map[string]config.Value
+	methods     []store.AuthMethod
+	loginFunc   func(method string, creds map[string]string) (*store.Credential, error)
+	loggedIn    bool
+	authEnabled bool
+}
+
+func newAuthMockStore() *authMockStore {
+	return &authMockStore{
+		trees:       make(map[string]map[string]config.Value),
+		authEnabled: true,
+		methods: []store.AuthMethod{
+			{
+				Type:        "userpass",
+				Description: "Username and password",
+				Fields: []store.AuthField{
+					{Name: "username", Description: "Your username", Required: true},
+					{Name: "password", Description: "Your password", Required: true, Secret: true},
+				},
+			},
+		},
+		loginFunc: func(_ string, creds map[string]string) (*store.Credential, error) {
+			if creds["username"] == "admin" && creds["password"] == "secret" {
+				return &store.Credential{
+					Token:     "tok-123",
+					ExpiresAt: time.Now().Add(time.Hour).Format(time.RFC3339),
+				}, nil
+			}
+			return nil, fmt.Errorf("invalid credentials")
+		},
+	}
+}
+
+func (m *authMockStore) Capabilities(_ context.Context) (*store.Capabilities, error) {
+	return &store.Capabilities{
+		Versioning: store.VersioningNone,
+		Encryption: store.EncryptionNone,
+		Auth:       m.authEnabled,
+	}, nil
+}
+
+func (m *authMockStore) AuthMethods(_ context.Context) ([]store.AuthMethod, error) {
+	if !m.authEnabled {
+		return nil, nil
+	}
+	return m.methods, nil
+}
+
+func (m *authMockStore) Login(_ context.Context, method string, creds map[string]string) (*store.Credential, error) {
+	cred, err := m.loginFunc(method, creds)
+	if err == nil {
+		m.loggedIn = true
+	}
+	return cred, err
+}
+
+func (m *authMockStore) ListTrees(_ context.Context) ([]string, error) {
+	var ids []string
+	for id := range m.trees {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func (m *authMockStore) DeleteTree(_ context.Context, id string) error {
+	delete(m.trees, id)
+	return nil
+}
+
+func (m *authMockStore) GetValues(_ context.Context, id string, paths []string) (map[string]config.Value, error) {
+	vals, ok := m.trees[id]
+	if !ok {
+		return nil, nil
+	}
+	result := make(map[string]config.Value)
+	for _, p := range paths {
+		if v, exists := vals[p]; exists {
+			result[p] = v
+		}
+	}
+	return result, nil
+}
+
+func (m *authMockStore) PutValues(_ context.Context, id string, values map[string]config.Value, _ *store.PutOptions) error {
+	if m.trees[id] == nil {
+		m.trees[id] = make(map[string]config.Value)
+	}
+	maps.Copy(m.trees[id], values)
+	return nil
+}
+
+func (m *authMockStore) DeleteValues(_ context.Context, id string, paths []string) error {
+	vals := m.trees[id]
+	if vals == nil {
+		return nil
+	}
+	for _, p := range paths {
+		delete(vals, p)
+	}
+	return nil
+}
+
+func (m *authMockStore) ListTreeVersions(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+func (m *authMockStore) GetTreeVersion(_ context.Context, _, _ string, _ []string) (map[string]config.Value, error) {
+	return nil, nil
+}
+func (m *authMockStore) RollbackTree(_ context.Context, _, _ string) error      { return nil }
+func (m *authMockStore) DeleteTreeVersion(_ context.Context, _, _ string) error { return nil }
+func (m *authMockStore) ListValueVersions(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}
+func (m *authMockStore) GetValueVersion(_ context.Context, _, _, _ string) (config.Value, bool, error) {
+	return config.Value{}, false, nil
+}
+func (m *authMockStore) RollbackValue(_ context.Context, _, _, _ string) error      { return nil }
+func (m *authMockStore) DeleteValueVersion(_ context.Context, _, _, _ string) error { return nil }
+func (m *authMockStore) InitEncryption(_ context.Context, _ []byte) error           { return nil }
+func (m *authMockStore) RotateEncryption(_ context.Context, _, _ []byte) error      { return nil }
+func (m *authMockStore) GrantAccess(_ context.Context, _ string, _ string, _ []store.Permission) error {
+	return nil
+}
+func (m *authMockStore) RevokeAccess(_ context.Context, _ string, _ string, _ []string) error {
+	return nil
+}
+func (m *authMockStore) ListAccess(_ context.Context, _ string) (map[string][]store.Permission, error) {
+	return nil, nil
+}
+
+func setupAuthTestController(t *testing.T, ms *authMockStore) *ui.UIController {
+	t.Helper()
+
+	reg := core.NewRegistry()
+	mc := newMockConfig()
+
+	if err := reg.RegisterConfig("mock", func(string, map[string]any) (config.Plugin, error) {
+		return mc, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.RegisterStore("mock-auth", func(string, map[string]any) (store.Plugin, error) {
+		return ms, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := &core.WorkspaceConfig{
+		Version: "1",
+		Config:  core.ProviderRef{Provider: "mock"},
+		Store:   core.ProviderRef{Provider: "mock-auth"},
+		Dir:     t.TempDir(),
+	}
+
+	eng, err := core.NewEngine(reg, ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ui.NewUIController(eng)
+}
+
+func TestApp_StartsWithLoginWhenAuthRequired(t *testing.T) {
+	ms := newAuthMockStore()
+	ctrl := setupAuthTestController(t, ms)
+	ctx := context.Background()
+
+	app, err := tui.NewApp(ctx, ctrl)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	view := app.View()
+	if !strings.Contains(view, "Login") {
+		t.Error("expected Login in header when auth is required")
+	}
+	if !strings.Contains(view, "requires authentication") {
+		t.Error("expected authentication message in login view")
+	}
+}
+
+func TestApp_SkipsLoginWhenNoAuth(t *testing.T) {
+	ms := newAuthMockStore()
+	ms.authEnabled = false
+	ctrl := setupAuthTestController(t, ms)
+	ctx := context.Background()
+
+	app, err := tui.NewApp(ctx, ctrl)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	view := app.View()
+	if strings.Contains(view, "Store Login") {
+		t.Error("expected no login view when auth is not required")
+	}
+	if !strings.Contains(view, "Tree") {
+		t.Error("expected Tree view header when auth is not required")
+	}
+}
+
+func TestApp_LoginViewRendersFields(t *testing.T) {
+	ms := newAuthMockStore()
+	ctrl := setupAuthTestController(t, ms)
+	ctx := context.Background()
+
+	app, err := tui.NewApp(ctx, ctrl)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = model.(*tui.App)
+
+	view := app.View()
+	if !strings.Contains(view, "username") {
+		t.Error("expected username field in login view")
+	}
+	if !strings.Contains(view, "password") {
+		t.Error("expected password field in login view")
+	}
+}
+
+func TestApp_LoginViewMethodSelection(t *testing.T) {
+	ms := newAuthMockStore()
+	ms.methods = []store.AuthMethod{
+		{
+			Type:        "userpass",
+			Description: "Username and password",
+			Fields: []store.AuthField{
+				{Name: "username", Required: true},
+				{Name: "password", Required: true, Secret: true},
+			},
+		},
+		{
+			Type:        "token",
+			Description: "API token",
+			Fields: []store.AuthField{
+				{Name: "token", Required: true, Secret: true},
+			},
+		},
+	}
+	ctrl := setupAuthTestController(t, ms)
+	ctx := context.Background()
+
+	app, err := tui.NewApp(ctx, ctrl)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = model.(*tui.App)
+
+	view := app.View()
+	// Should show method selection, not credential form.
+	if !strings.Contains(view, "Select authentication method") {
+		t.Error("expected method selection when multiple methods available")
+	}
+	if !strings.Contains(view, "userpass") {
+		t.Error("expected userpass method in selection")
+	}
+	if !strings.Contains(view, "token") {
+		t.Error("expected token method in selection")
+	}
+
+	// Navigate down and select the token method.
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	app = model.(*tui.App)
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	app = model.(*tui.App)
+
+	view = app.View()
+	if !strings.Contains(view, "token") {
+		t.Error("expected token field after selecting token method")
+	}
+	// Should no longer show method selection.
+	if strings.Contains(view, "Select authentication method") {
+		t.Error("expected credential form, not method selection")
+	}
+}
+
+func TestApp_LoginViewEscBackToMethodSelection(t *testing.T) {
+	ms := newAuthMockStore()
+	ms.methods = []store.AuthMethod{
+		{Type: "userpass", Fields: []store.AuthField{{Name: "username"}}},
+		{Type: "token", Fields: []store.AuthField{{Name: "token"}}},
+	}
+	ctrl := setupAuthTestController(t, ms)
+	ctx := context.Background()
+
+	app, err := tui.NewApp(ctx, ctrl)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = model.(*tui.App)
+
+	// Select the first method.
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	app = model.(*tui.App)
+
+	// Should be in credential form.
+	view := app.View()
+	if !strings.Contains(view, "username") {
+		t.Error("expected credential form")
+	}
+
+	// Press Esc to go back to method selection.
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	app = model.(*tui.App)
+
+	view = app.View()
+	if !strings.Contains(view, "Select authentication method") {
+		t.Error("expected method selection after Esc")
+	}
+}
+
+func TestApp_LoginSuccess(t *testing.T) {
+	ms := newAuthMockStore()
+	ctrl := setupAuthTestController(t, ms)
+	ctx := context.Background()
+
+	app, err := tui.NewApp(ctx, ctrl)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = model.(*tui.App)
+
+	// Type username in the first field.
+	for _, r := range "admin" {
+		model, _ = app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		app = model.(*tui.App)
+	}
+
+	// Tab to password field.
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyTab})
+	app = model.(*tui.App)
+
+	// Type password.
+	for _, r := range "secret" {
+		model, _ = app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		app = model.(*tui.App)
+	}
+
+	// Submit.
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected command from login submit")
+	}
+
+	// Execute the command to simulate the login call.
+	msg := cmd()
+
+	// Process the login result.
+	model, cmd = app.Update(msg)
+	app = model.(*tui.App)
+
+	if cmd == nil {
+		t.Fatal("expected tree load command after successful login")
+	}
+
+	// Execute tree load.
+	msg = cmd()
+	model, _ = app.Update(msg)
+	app = model.(*tui.App)
+
+	// Should now be in tree view.
+	view := app.View()
+	if !strings.Contains(view, "Tree") {
+		t.Error("expected Tree view after successful login")
+	}
+	if strings.Contains(view, "Store Login") {
+		t.Error("should not be showing login view after success")
+	}
+}
+
+func TestApp_LoginFailure(t *testing.T) {
+	ms := newAuthMockStore()
+	ctrl := setupAuthTestController(t, ms)
+	ctx := context.Background()
+
+	app, err := tui.NewApp(ctx, ctrl)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = model.(*tui.App)
+
+	// Type wrong credentials.
+	for _, r := range "wronguser" {
+		model, _ = app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		app = model.(*tui.App)
+	}
+
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyTab})
+	app = model.(*tui.App)
+
+	for _, r := range "wrongpass" {
+		model, _ = app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		app = model.(*tui.App)
+	}
+
+	// Submit.
+	_, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected command from login submit")
+	}
+
+	// Execute the login call.
+	msg := cmd()
+
+	// Process the login result.
+	model, _ = app.Update(msg)
+	app = model.(*tui.App)
+
+	// Should still be on login view with error.
+	view := app.View()
+	if !strings.Contains(view, "Login") {
+		t.Error("expected to remain on login view after failure")
+	}
+	if !strings.Contains(view, "invalid credentials") {
+		t.Error("expected error message after failed login")
+	}
+}
+
+func TestApp_LoginSecretFieldsMasked(t *testing.T) {
+	ms := newAuthMockStore()
+	ctrl := setupAuthTestController(t, ms)
+	ctx := context.Background()
+
+	app, err := tui.NewApp(ctx, ctrl)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = model.(*tui.App)
+
+	// Tab to password field.
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyTab})
+	app = model.(*tui.App)
+
+	// Type a password.
+	for _, r := range "secret" {
+		model, _ = app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		app = model.(*tui.App)
+	}
+
+	// The view should not contain the plaintext password.
+	view := app.View()
+	if strings.Contains(view, "secret") {
+		t.Error("expected password to be masked, but found plaintext in view")
+	}
+}
+
+func TestApp_LoginShowsCustomMessage(t *testing.T) {
+	ms := newAuthMockStore()
+	ctrl := setupAuthTestController(t, ms)
+	ctx := context.Background()
+
+	app, err := tui.NewApp(ctx, ctrl)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = model.(*tui.App)
+
+	// Should be on login view. Default message is shown.
+	view := app.View()
+	if !strings.Contains(view, "requires authentication") {
+		t.Error("expected default authentication message")
+	}
+}
+
+func TestApp_LoginTabNavigation(t *testing.T) {
+	ms := newAuthMockStore()
+	ms.methods = []store.AuthMethod{
+		{
+			Type: "userpass",
+			Fields: []store.AuthField{
+				{Name: "username", Required: true},
+				{Name: "password", Required: true, Secret: true},
+				{Name: "otp", Description: "One-time password"},
+			},
+		},
+	}
+	ctrl := setupAuthTestController(t, ms)
+	ctx := context.Background()
+
+	app, err := tui.NewApp(ctx, ctrl)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = model.(*tui.App)
+
+	// Tab through all fields.
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyTab})
+	app = model.(*tui.App)
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyTab})
+	app = model.(*tui.App)
+
+	// Should render without panicking.
+	view := app.View()
+	if view == "" {
+		t.Error("expected non-empty view after tabbing")
+	}
+
+	// Shift+Tab should go back.
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	app = model.(*tui.App)
+
+	view = app.View()
+	if view == "" {
+		t.Error("expected non-empty view after shift-tab")
+	}
+}
+
+func TestApp_LoginRequiredFieldsMarked(t *testing.T) {
+	ms := newAuthMockStore()
+	ms.methods = []store.AuthMethod{
+		{
+			Type: "userpass",
+			Fields: []store.AuthField{
+				{Name: "username", Required: true},
+				{Name: "password", Required: true, Secret: true},
+				{Name: "domain", Required: false},
+			},
+		},
+	}
+	ctrl := setupAuthTestController(t, ms)
+	ctx := context.Background()
+
+	app, err := tui.NewApp(ctx, ctrl)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = model.(*tui.App)
+
+	view := app.View()
+	// Required fields should have a marker.
+	if !strings.Contains(view, "username") {
+		t.Error("expected username field")
+	}
+	if !strings.Contains(view, "password") {
+		t.Error("expected password field")
+	}
+	if !strings.Contains(view, "domain") {
+		t.Error("expected domain field")
+	}
+}


### PR DESCRIPTION
## Summary

Add a login view to the TUI so users can authenticate with the store plugin from the terminal. This implements **Phase 4** of the login roadmap.

## Changes

### New Files

- **`internal/ui/tui/login.go`** -- `loginModel` Bubbletea model with:
  - Method selection list when multiple auth methods are available
  - Dynamic credential form generated from `StoreAuthMethod.Fields`
  - Password masking for secret fields (`textinput.EchoNone`)
  - Submit handling that calls `StoreLogin()` via the controller
  - Error display with retry capability

- **`internal/ui/tui/login_test.go`** -- Comprehensive tests covering:
  - Login view renders correct fields for auth methods
  - Successful login transitions to tree view
  - Failed login shows error and stays on login view
  - Method selection works with multiple methods
  - Secret fields are masked
  - App starts with login view when auth is required
  - App skips login when auth is not required
  - Tab/Shift+Tab field navigation
  - Esc returns to method selection

### Modified Files

- **`internal/ui/tui/app.go`**:
  - Added `viewLogin` state to `viewType` enum
  - Added `loginView` and `previousView` fields to `App` struct
  - On startup, checks `StoreAuthMethods()` / `StoreAuthStatus()` and shows login if needed
  - Intercepts `store.ErrAuthRequired` from save, validate, set value, and tree load to trigger re-authentication
  - Login view integrated into render header, content, and status bar
  - Global Esc handler defers to login view for method selection navigation

## Acceptance Criteria

- [x] Login view shows before tree view when auth is required
- [x] Method selector appears when multiple auth methods exist
- [x] Credential fields are generated dynamically from auth method definitions
- [x] Secret fields are masked in the terminal
- [x] Successful login transitions to tree view
- [x] Failed login shows error with retry
- [x] Mid-session expiry shows login view with expiry message
- [x] `make check` passes

## Dependencies

- Phase 2 (Controller API Extensions) -- complete
- Phase 3 (WebUI Login) -- complete