### PR TITLE
Potential fix for code scanning alert no. 1: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ tools: ## Install required development tools
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 	go install github.com/goreleaser/goreleaser/v2@latest
-	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOPATH)/bin v2.9.0
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOPATH)/bin v2.10.1
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Release

--- a/internal/core/export.go
+++ b/internal/core/export.go
@@ -303,7 +303,7 @@ func toDotenv(v any) (string, error) {
 	var sb strings.Builder
 	for _, k := range keys {
 		envKey := strings.ToUpper(strings.ReplaceAll(k, "/", "_"))
-		sb.WriteString(fmt.Sprintf("%s=%v\n", envKey, m[k]))
+		fmt.Fprintf(&sb, "%s=%v\n", envKey, m[k])
 	}
 	return strings.TrimSpace(sb.String()), nil
 }

--- a/internal/ui/tui/apply_view.go
+++ b/internal/ui/tui/apply_view.go
@@ -227,7 +227,7 @@ func (v ApplyView) View() string {
 
 	// Header with status.
 	if v.running {
-		sb.WriteString(fmt.Sprintf("  %s Running apply command...\n\n", v.spinner.View()))
+		fmt.Fprintf(&sb, "  %s Running apply command...\n\n", v.spinner.View())
 	} else {
 		sb.WriteString("  Apply Output:\n\n")
 	}

--- a/internal/ui/tui/component_view.go
+++ b/internal/ui/tui/component_view.go
@@ -256,21 +256,21 @@ func (v ComponentView) renderInfoPanel(comp core.ComponentState) string {
 	var sb strings.Builder
 	sb.WriteString(HeaderStyle.Render(fmt.Sprintf(" Component: %s ", comp.Name)))
 	sb.WriteString("\n")
-	sb.WriteString(fmt.Sprintf("  Description:  %s\n", def.Description))
+	fmt.Fprintf(&sb, "  Description:  %s\n", def.Description)
 	status := "enabled"
 	if !comp.Enabled {
 		status = "disabled"
 	}
-	sb.WriteString(fmt.Sprintf("  Status:       %s\n", status))
-	sb.WriteString(fmt.Sprintf("  Mandatory:    %v\n", comp.Mandatory))
-	sb.WriteString(fmt.Sprintf("  Paths:        %s\n", strings.Join(def.Paths, ", ")))
+	fmt.Fprintf(&sb, "  Status:       %s\n", status)
+	fmt.Fprintf(&sb, "  Mandatory:    %v\n", comp.Mandatory)
+	fmt.Fprintf(&sb, "  Paths:        %s\n", strings.Join(def.Paths, ", "))
 	if len(comp.Dependencies) > 0 {
-		sb.WriteString(fmt.Sprintf("  Dependencies: %s\n", strings.Join(comp.Dependencies, ", ")))
+		fmt.Fprintf(&sb, "  Dependencies: %s\n", strings.Join(comp.Dependencies, ", "))
 	} else {
 		sb.WriteString("  Dependencies: -\n")
 	}
 	if len(dependents) > 0 {
-		sb.WriteString(fmt.Sprintf("  Dependents:   %s\n", strings.Join(dependents, ", ")))
+		fmt.Fprintf(&sb, "  Dependents:   %s\n", strings.Join(dependents, ", "))
 	} else {
 		sb.WriteString("  Dependents:   -\n")
 	}

--- a/internal/ui/tui/login.go
+++ b/internal/ui/tui/login.go
@@ -261,7 +261,7 @@ func (m loginModel) viewMethodSelection() string {
 		if method.Description != "" {
 			line += DimStyle.Render(fmt.Sprintf(" - %s", method.Description))
 		}
-		sb.WriteString(fmt.Sprintf("  %s%s\n", cursor, style.Render(line)))
+		fmt.Fprintf(&sb, "  %s%s\n", cursor, style.Render(line))
 	}
 	return sb.String()
 }
@@ -279,8 +279,8 @@ func (m loginModel) viewCredentialForm() string {
 		if field.Required {
 			label += RequiredBadgeStyle.Render(" *")
 		}
-		sb.WriteString(fmt.Sprintf("  %s:\n", label))
-		sb.WriteString(fmt.Sprintf("  %s\n\n", m.inputs[i].View()))
+		fmt.Fprintf(&sb, "  %s:\n", label)
+		fmt.Fprintf(&sb, "  %s\n\n", m.inputs[i].View())
 	}
 	return sb.String()
 }

--- a/internal/ui/tui/marketplace.go
+++ b/internal/ui/tui/marketplace.go
@@ -237,8 +237,7 @@ func (v MarketplaceView) View() string {
 	if v.typeFilter != "" {
 		typeLabel = v.typeFilter
 	}
-	sb.WriteString(fmt.Sprintf("  Filter: [%s]  Sort: [%s]  (t:type o:sort)", typeLabel, v.sortBy))
-	sb.WriteString("\n\n")
+	fmt.Fprintf(&sb, "  Filter: [%s]  Sort: [%s]  (t:type o:sort)\n\n", typeLabel, v.sortBy)
 
 	// Messages.
 	if v.errMsg != "" {

--- a/internal/ui/tui/notification.go
+++ b/internal/ui/tui/notification.go
@@ -78,11 +78,9 @@ func (n Notification) View() string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("  %d plugin update(s) available:", len(n.updates)))
-	sb.WriteString("\n")
+	fmt.Fprintf(&sb, "  %d plugin update(s) available:\n", len(n.updates))
 	for _, u := range n.updates {
-		sb.WriteString(fmt.Sprintf("    %s: %s -> %s", u.Name, u.CurrentVersion, u.LatestVersion))
-		sb.WriteString("\n")
+		fmt.Fprintf(&sb, "    %s: %s -> %s\n", u.Name, u.CurrentVersion, u.LatestVersion)
 	}
 	sb.WriteString("  [d]ismiss")
 	sb.WriteString("\n")

--- a/internal/ui/tui/value_editor.go
+++ b/internal/ui/tui/value_editor.go
@@ -225,7 +225,7 @@ func (e ValueEditor) View() string {
 
 	if e.componentName != "" {
 		badge := ComponentBadgeStyle.Render("[" + e.componentName + "]")
-		sb.WriteString(fmt.Sprintf("  Component: %s\n", badge))
+		fmt.Fprintf(&sb, "  Component: %s\n", badge)
 		if e.disabled {
 			sb.WriteString(WarningStyle.Render("  Warning: This path belongs to disabled component '" + e.componentName + "'. It will not be included in exports."))
 			sb.WriteString("\n")
@@ -273,11 +273,11 @@ func (e ValueEditor) View() string {
 			if i == e.enumCursor {
 				style = ActiveStyle
 			}
-			sb.WriteString(fmt.Sprintf("  %s%s\n", marker, style.Render(opt)))
+			fmt.Fprintf(&sb, "  %s%s\n", marker, style.Render(opt))
 		}
 	} else {
 		sb.WriteString("  Value:\n")
-		sb.WriteString(fmt.Sprintf("  %s\n", e.input.View()))
+		fmt.Fprintf(&sb, "  %s\n", e.input.View())
 	}
 	sb.WriteString("\n")
 

--- a/pkg/providers/ui/webui/middleware.go
+++ b/pkg/providers/ui/webui/middleware.go
@@ -229,12 +229,13 @@ func generateNonce() string {
 // csrfMiddleware implements double-submit cookie CSRF protection.
 type csrfMiddleware struct {
 	secret []byte
+	secure bool
 }
 
-func newCSRFMiddleware() *csrfMiddleware {
+func newCSRFMiddleware(secure bool) *csrfMiddleware {
 	secret := make([]byte, 32)
 	_, _ = rand.Read(secret)
-	return &csrfMiddleware{secret: secret}
+	return &csrfMiddleware{secret: secret, secure: secure}
 }
 
 // generateToken creates an HMAC-SHA256 CSRF token.
@@ -274,7 +275,7 @@ func (c *csrfMiddleware) middleware(next http.Handler) http.Handler {
 				Path:     "/",
 				HttpOnly: true,
 				SameSite: http.SameSiteStrictMode,
-				Secure:   true,
+				Secure:   c.secure,
 			})
 		} else {
 			token = cookie.Value

--- a/pkg/providers/ui/webui/server.go
+++ b/pkg/providers/ui/webui/server.go
@@ -64,8 +64,18 @@ func (s *Server) Addr(ctx context.Context) (string, error) {
 
 // ListenAndServe starts the HTTP server and blocks until ctx is cancelled.
 func (s *Server) ListenAndServe(ctx context.Context) error {
+	// Determine TLS config first so the middleware chain can know whether
+	// the server is running over HTTPS.
+	tlsCfg := &tlsutil.Config{
+		CertFile:     s.config.TLSCert,
+		KeyFile:      s.config.TLSKey,
+		ClientCAFile: s.config.TLSClientCA,
+		MinVersion:   s.config.TLSMinVersion,
+		CipherSuites: s.config.TLSCipherSuites,
+	}
+
 	// Build the middleware chain.
-	csrf := newCSRFMiddleware()
+	csrf := newCSRFMiddleware(tlsCfg.Enabled())
 	handler := s.mux
 	var h http.Handler = handler
 
@@ -98,13 +108,6 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 	}
 
 	// Wrap with TLS if configured.
-	tlsCfg := &tlsutil.Config{
-		CertFile:     s.config.TLSCert,
-		KeyFile:      s.config.TLSKey,
-		ClientCAFile: s.config.TLSClientCA,
-		MinVersion:   s.config.TLSMinVersion,
-		CipherSuites: s.config.TLSCipherSuites,
-	}
 	if tlsCfg.Enabled() {
 		tc, err := tlsCfg.TLSConfig()
 		if err != nil {

--- a/pkg/providers/ui/webui/webui_test.go
+++ b/pkg/providers/ui/webui/webui_test.go
@@ -555,7 +555,7 @@ func TestValueType(t *testing.T) {
 // ---------- middleware tests ----------
 
 func TestCSRFValidation(t *testing.T) {
-	csrf := newCSRFMiddleware()
+	csrf := newCSRFMiddleware(true)
 	token := csrf.generateToken()
 
 	if !csrf.validateToken(token) {


### PR DESCRIPTION
Potential fix for [https://github.com/MrWong99/zhi/security/code-scanning/1](https://github.com/MrWong99/zhi/security/code-scanning/1)

In general, to fix this kind of issue you must explicitly set the `Secure` field of the `http.Cookie` struct to `true` when creating cookies that should only be transmitted over HTTPS. This ensures browsers will not send the cookie over insecure HTTP connections.

In this file, the `_csrf` cookie is created inside `csrfMiddleware.middleware` with `HttpOnly` and `SameSite` configured but no `Secure` attribute. The best, minimal‑impact fix is to add `Secure: true,` to that cookie literal. This change preserves the existing behavior (name, value, path, HttpOnly, SameSite) and only constrains transport to HTTPS, which is the intended security posture for a CSRF protection cookie.

Concretely:
- Edit `pkg/providers/ui/webui/middleware.go`.
- In the `csrfMiddleware.middleware` function, locate the `http.SetCookie(w, &http.Cookie{ ... })` call that sets the `_csrf` cookie (around line 271).
- Add `Secure:   true,` to the struct literal.

No new imports or helper methods are required; `Secure` is a standard field on `http.Cookie`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
