### PR TITLE
Fix CSRF secure cookie flag to respect TLS configuration

### DIFF
--- a/internal/ui/tui/apply_view.go
+++ b/internal/ui/tui/apply_view.go
@@ -227,7 +227,7 @@ func (v ApplyView) View() string {
 
 	// Header with status.
 	if v.running {
-		sb.WriteString(fmt.Sprintf("  %s Running apply command...\n\n", v.spinner.View()))
+		fmt.Fprintf(&sb, "  %s Running apply command...\n\n", v.spinner.View())
 	} else {
 		sb.WriteString("  Apply Output:\n\n")
 	}

--- a/internal/ui/tui/component_view.go
+++ b/internal/ui/tui/component_view.go
@@ -256,12 +256,12 @@ func (v ComponentView) renderInfoPanel(comp core.ComponentState) string {
 	var sb strings.Builder
 	sb.WriteString(HeaderStyle.Render(fmt.Sprintf(" Component: %s ", comp.Name)))
 	sb.WriteString("\n")
-	sb.WriteString(fmt.Sprintf("  Description:  %s\n", def.Description))
+	fmt.Fprintf(&sb, "  Description:  %s\n", def.Description)
 	status := "enabled"
 	if !comp.Enabled {
 		status = "disabled"
 	}
-	sb.WriteString(fmt.Sprintf("  Status:       %s\n", status))
+	fmt.Fprintf(&sb, "  Status:       %s\n", status)
 	sb.WriteString(fmt.Sprintf("  Mandatory:    %v\n", comp.Mandatory))
 	sb.WriteString(fmt.Sprintf("  Paths:        %s\n", strings.Join(def.Paths, ", ")))
 	if len(comp.Dependencies) > 0 {

--- a/pkg/providers/ui/webui/middleware.go
+++ b/pkg/providers/ui/webui/middleware.go
@@ -229,12 +229,13 @@ func generateNonce() string {
 // csrfMiddleware implements double-submit cookie CSRF protection.
 type csrfMiddleware struct {
 	secret []byte
+	secure bool
 }
 
-func newCSRFMiddleware() *csrfMiddleware {
+func newCSRFMiddleware(secure bool) *csrfMiddleware {
 	secret := make([]byte, 32)
 	_, _ = rand.Read(secret)
-	return &csrfMiddleware{secret: secret}
+	return &csrfMiddleware{secret: secret, secure: secure}
 }
 
 // generateToken creates an HMAC-SHA256 CSRF token.
@@ -274,7 +275,7 @@ func (c *csrfMiddleware) middleware(next http.Handler) http.Handler {
 				Path:     "/",
 				HttpOnly: true,
 				SameSite: http.SameSiteStrictMode,
-				Secure:   true,
+				Secure:   c.secure,
 			})
 		} else {
 			token = cookie.Value

--- a/pkg/providers/ui/webui/server.go
+++ b/pkg/providers/ui/webui/server.go
@@ -64,8 +64,18 @@ func (s *Server) Addr(ctx context.Context) (string, error) {
 
 // ListenAndServe starts the HTTP server and blocks until ctx is cancelled.
 func (s *Server) ListenAndServe(ctx context.Context) error {
+	// Determine TLS config first so the middleware chain can know whether
+	// the server is running over HTTPS.
+	tlsCfg := &tlsutil.Config{
+		CertFile:     s.config.TLSCert,
+		KeyFile:      s.config.TLSKey,
+		ClientCAFile: s.config.TLSClientCA,
+		MinVersion:   s.config.TLSMinVersion,
+		CipherSuites: s.config.TLSCipherSuites,
+	}
+
 	// Build the middleware chain.
-	csrf := newCSRFMiddleware()
+	csrf := newCSRFMiddleware(tlsCfg.Enabled())
 	handler := s.mux
 	var h http.Handler = handler
 
@@ -98,13 +108,6 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 	}
 
 	// Wrap with TLS if configured.
-	tlsCfg := &tlsutil.Config{
-		CertFile:     s.config.TLSCert,
-		KeyFile:      s.config.TLSKey,
-		ClientCAFile: s.config.TLSClientCA,
-		MinVersion:   s.config.TLSMinVersion,
-		CipherSuites: s.config.TLSCipherSuites,
-	}
 	if tlsCfg.Enabled() {
 		tc, err := tlsCfg.TLSConfig()
 		if err != nil {


### PR DESCRIPTION
## What does this PR do?

This PR fixes the CSRF middleware to respect the server's TLS configuration when setting the `Secure` flag on CSRF protection cookies. Previously, the `Secure` flag was hardcoded to `true`, which caused issues in non-HTTPS environments. The changes also include minor code style improvements in the TUI components.

**Key changes:**
1. Move TLS configuration initialization earlier in `ListenAndServe()` so it can be used by the middleware chain
2. Pass the TLS enabled state to `newCSRFMiddleware()` 
3. Update the CSRF cookie's `Secure` flag to match the actual TLS configuration instead of being hardcoded
4. Minor refactoring: Replace `sb.WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(&sb, ...)` for better style in TUI components

## Why is this change needed?

The hardcoded `Secure: true` flag on CSRF cookies breaks the web UI in development and non-HTTPS environments. Browsers will reject secure cookies over HTTP connections, preventing legitimate requests. By making the flag dynamic based on actual TLS configuration, the server works correctly in both HTTPS and HTTP modes.

## How was this tested?

- [ ] `make check` passes
- [ ] Manual testing in HTTP and HTTPS environments

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor / code cleanup

## Checklist

- [x] My code follows the project's code style (`gofmt`, `go vet`)
- [x] My commits are focused and have clear messages

## Additional Notes

The TUI code style changes (using `fmt.Fprintf` instead of `sb.WriteString(fmt.Sprintf(...))`) are minor improvements that follow Go best practices for writing to `io.Writer` interfaces.

https://claude.ai/code/session_018REjf5DmV2ZDrV4XUHXBRo