### PR TITLE
fix: address 7 CodeQL security findings (path traversal, zip-slip, int overflow)

### DIFF
--- a/cmd/zhi-mirror/airgap/import.go
+++ b/cmd/zhi-mirror/airgap/import.go
@@ -113,9 +113,20 @@ func extractTarball(src, dst string) error {
 			return fmt.Errorf("reading tar: %w", err)
 		}
 
+		// Reject archive entries with absolute paths or ".." components before
+		// joining, to prevent zip-slip directory traversal attacks.
+		for _, part := range strings.Split(filepath.ToSlash(header.Name), "/") {
+			if part == ".." {
+				return fmt.Errorf("invalid tar entry path: %s", header.Name)
+			}
+		}
+		if filepath.IsAbs(header.Name) {
+			return fmt.Errorf("invalid tar entry path (absolute): %s", header.Name)
+		}
+
 		target := filepath.Join(dst, header.Name)
 
-		// Prevent path traversal.
+		// Defense-in-depth: verify the joined path is still inside dst.
 		if !strings.HasPrefix(filepath.Clean(target), filepath.Clean(dst)+string(os.PathSeparator)) &&
 			filepath.Clean(target) != filepath.Clean(dst) {
 			return fmt.Errorf("invalid tar entry path: %s", header.Name)

--- a/internal/core/export.go
+++ b/internal/core/export.go
@@ -167,6 +167,9 @@ func (pt *prefixTree) List() []string {
 // If opts is non-nil, template functions like fileGroupID and fileMode will
 // capture their values into it.
 func renderTemplateFile(td *TreeData, path string, opts *exportFileOptions) (string, error) {
+	if containsPathTraversal(path) {
+		return "", fmt.Errorf("template path %q: path traversal (.. segments) is not allowed", path)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("reading template: %w", err)
@@ -320,10 +323,12 @@ func shellQuote(s string) string {
 //   - Sets file permissions (default 0644, overridable via opts.mode)
 //   - Optionally sets file group ID via opts.groupID
 func writeExportFile(outputPath string, data []byte, opts *exportFileOptions) error {
-	// Reject path traversal.
+	// Reject path traversal in the raw (un-normalized) path.
 	if containsPathTraversal(outputPath) {
 		return fmt.Errorf("export output path %q: path traversal (.. segments) is not allowed", outputPath)
 	}
+	// Normalize to a canonical path for all subsequent operations.
+	outputPath = filepath.Clean(outputPath)
 
 	// Resolve the directory, creating it if needed.
 	dir := filepath.Dir(outputPath)

--- a/pkg/sharing/client/push.go
+++ b/pkg/sharing/client/push.go
@@ -561,9 +561,20 @@ func extractTarGz(data []byte, targetDir string) error {
 			return fmt.Errorf("reading tar: %w", err)
 		}
 
+		// Reject archive entries with absolute paths or ".." components before
+		// joining, to prevent zip-slip directory traversal attacks.
+		for _, part := range strings.Split(filepath.ToSlash(header.Name), "/") {
+			if part == ".." {
+				return fmt.Errorf("invalid tar entry path: %s", header.Name)
+			}
+		}
+		if filepath.IsAbs(header.Name) {
+			return fmt.Errorf("invalid tar entry path (absolute): %s", header.Name)
+		}
+
 		target := filepath.Join(targetDir, header.Name)
 
-		// Prevent path traversal.
+		// Defense-in-depth: verify the joined path is still inside targetDir.
 		if !strings.HasPrefix(filepath.Clean(target), filepath.Clean(targetDir)+string(os.PathSeparator)) &&
 			filepath.Clean(target) != filepath.Clean(targetDir) {
 			return fmt.Errorf("invalid tar entry path: %s", header.Name)

--- a/pkg/zhiplugin/ui/controller_client.go
+++ b/pkg/zhiplugin/ui/controller_client.go
@@ -3,7 +3,9 @@ package ui
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"math"
 
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
 	pb "github.com/MrWong99/zhi/pkg/zhiplugin/ui/proto"
@@ -182,6 +184,12 @@ func (c *controllerGRPCClient) WorkspaceName(ctx context.Context) (string, error
 }
 
 func (c *controllerGRPCClient) SearchMarketplace(ctx context.Context, query MarketplaceQuery) (*MarketplaceResults, error) {
+	if query.Page < 0 || query.Page > math.MaxInt32 {
+		return nil, fmt.Errorf("page value %d out of int32 range", query.Page)
+	}
+	if query.PerPage < 0 || query.PerPage > math.MaxInt32 {
+		return nil, fmt.Errorf("perPage value %d out of int32 range", query.PerPage)
+	}
 	resp, err := c.client.SearchMarketplace(ctx, &pb.CtrlSearchMarketplaceRequest{
 		Query:    query.Query,
 		Type:     query.Type,


### PR DESCRIPTION
## Summary

Addresses all 7 CodeQL security findings reported against the codebase.

### Uncontrolled data used in path expression (`internal/core/export.go`)

- **Line 170** – `renderTemplateFile` called `os.ReadFile(path)` with no validation on `TemplatePath`. Added the same `containsPathTraversal` guard already applied to `OutputPath`.
- **Lines 330, 342, 368** – `writeExportFile` already had a `containsPathTraversal` check on the raw path, but downstream variables (`dir`, `realDir`, `realPath`) were derived from the unsanitized value. Added `filepath.Clean(outputPath)` **after** the raw-path check so all subsequent path operations use a canonical, normalised form. The traversal check intentionally runs first (on the original string) so that `..`-containing paths such as `/tmp/../../../etc/evil` are still rejected before `Clean` resolves them.

### Zip Slip (`pkg/sharing/client/push.go`, `cmd/zhi-mirror/airgap/import.go`)

Both tar extractors already had a post-`filepath.Join` containment check, but CodeQL's taint analysis does not recognise `strings.HasPrefix` as a canonical sanitiser. Added an **explicit pre-join guard** on `header.Name` that:
1. Rejects any entry whose slash-split components include `..`.
2. Rejects entries with an absolute path (`filepath.IsAbs`).

The existing post-join prefix check is retained as defense-in-depth.

### Incorrect integer conversion (`pkg/zhiplugin/ui/controller_client.go`)

`query.Page` and `query.PerPage` (type `int`, 64-bit on 64-bit targets) were converted directly to `int32` inside `SearchMarketplace`. Added bounds guards (`< 0 || > math.MaxInt32`) that return an error before the conversion for any value that would overflow.

## Test plan

- [ ] `make test` passes with no failures (verified locally – all packages green)
- [ ] `make build` produces clean binaries
- [ ] Existing path-traversal tests (`TestWriteExportFileRejectsTraversal`, `TestExportPathTraversalInConfig`) continue to pass with the new normalisation order
- [ ] Zip-slip tests in `cmd/zhi-mirror/airgap` and `pkg/sharing/client` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)