### PR TITLE
docs: add meta-plugin SDK documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,16 @@ UI plugins use bidirectional gRPC: the host calls the plugin to start the UI, an
 
 TTY-dependent UIs (like the TUI) must set `RequiresTTY: true` and be registered as built-in plugins, since external gRPC processes lack terminal access.
 
+### Meta-Plugin SDK
+
+A meta-plugin is a regular plugin binary that internally launches and composes child plugins using `pkg/zhiplugin/launch/`. The SDK provides three building blocks:
+
+- **Launch** (`pkg/zhiplugin/launch/`) -- start child plugin processes with binary validation and integrity auditing
+- **Delegate** (`{config,transform,store}/delegate.go`) -- forward all interface calls to a base plugin, override selectively
+- **Compose** (`config/compose.go`, `store/compose.go`) -- structural patterns: `MergedPlugin` (namespace config plugins by prefix) and `MirroredPlugin` (primary + backup stores)
+
+See `docs/plugin-development/meta-plugin.md` for the full guide and `examples/zhi-store-mirror/` for a working example.
+
 ### Configuration Tree Model
 
 `config.Tree` is a flat key-value store with slash-delimited paths (e.g. `database/host`, `app/tls/cert.pem`). Path segments must match `[a-z][a-z0-9._-]*[a-z0-9]`. `Tree` implements `TreeReader` (read-only) and also exposes `GetPtr` for mutable access and `Delete` for removal. `Value` holds the data (`Val any`), optional `Metadata`, and local `Validators` (closures that never cross the gRPC wire).
@@ -130,11 +140,11 @@ Each plugin type has `grpc_client.go` (host-side) and `grpc_server.go` (plugin-s
 - `internal/core/` -- engine, registry, components, export, apply, plugin discovery
 - `internal/cli/` -- CLI subcommands (Cobra)
 - `internal/ui/` -- UI abstraction layer and TUI implementation
-- `pkg/zhiplugin/` -- public plugin framework (config, transform, store, ui, labels)
+- `pkg/zhiplugin/` -- public plugin framework (config, transform, store, ui, labels, launch)
 - `pkg/providers/` -- built-in provider implementations (structuredfile config, vault store)
 - `pkg/sharing/` -- plugin distribution: manifests, lockfiles, OCI client, verification, marketplace
 - `api/proto/zhiplugin/v1/` -- protobuf service definitions
-- `examples/` -- working plugin examples (pokedex config, memory/json/vault stores, transform, HTTP API UI)
+- `examples/` -- working plugin examples (pokedex config, memory/json/vault stores, transform, HTTP API UI, store mirror meta-plugin)
 - `docs/user-guide/` -- end-user documentation
 - `docs/plugin-development/` -- plugin developer documentation
 - `docs/design/` -- design documents (e.g., metadata-labels API)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Core principles:
 
 - **Encrypted configuration at rest** -- store plugin layer supports encryption and key rotation
 - **Automatic validation** -- config plugins define validation rules, including cross-value checks
-- **Plugin-based extensibility** -- [gRPC-based plugin system](https://github.com/hashicorp/go-plugin) with four plugin types (config, transform, store, UI)
+- **Plugin-based extensibility** -- [gRPC-based plugin system](https://github.com/hashicorp/go-plugin) with four plugin types (config, transform, store, UI) and a [meta-plugin SDK](docs/plugin-development/meta-plugin.md) for composing plugins
 - **Auto-generated TUI** -- interactive terminal interface built with [Bubbletea](https://github.com/charmbracelet/bubbletea)
 - **Component model** -- group configuration into toggleable bundles with dependencies
 - **Template-based exports** -- render configuration to JSON, YAML, TOML, dotenv, or custom templates
@@ -153,6 +153,7 @@ zhi's plugin system supports four types: **config**, **transform**, **store**, a
 - [Transform Plugin API](docs/plugin-development/transform-plugin.md) -- mutate trees before display or after save
 - [Store Plugin API](docs/plugin-development/store-plugin.md) -- persist and retrieve trees
 - [UI Plugin API](docs/plugin-development/ui-plugin.md) -- provide interactive frontends
+- [Meta-Plugin SDK](docs/plugin-development/meta-plugin.md) -- launch, delegate, and compose child plugins
 - [Structured File Provider](docs/plugin-development/structuredfile-provider.md) -- built-in file-based config provider
 
 ### Examples
@@ -168,6 +169,7 @@ The [`examples/`](examples/) directory contains fully working plugins you can bu
 | [zhi-store-vault](examples/zhi-store-vault/) | Store | HashiCorp Vault KV v2 backend |
 | [zhi-ui-httpapi](examples/zhi-ui-httpapi/) | UI | HTTP/JSON API with SSE streaming |
 | [zhi-config-javabean](examples/zhi-config-javabean/) | Config | Java plugin with Bean Validation and GraalVM native-image |
+| [zhi-store-mirror](examples/zhi-store-mirror/) | Store (meta) | Meta-plugin: mirrors writes to memory + JSON file |
 
 All Go example plugins are published to the GitHub Container Registry on every release and can be installed directly:
 

--- a/docs/plugin-development/meta-plugin.md
+++ b/docs/plugin-development/meta-plugin.md
@@ -1,0 +1,362 @@
+# Meta-Plugin SDK
+
+A meta-plugin is a regular zhi plugin that internally launches and
+orchestrates one or more child plugins. From the host's perspective
+a meta-plugin looks like any other plugin -- it implements the same
+gRPC interface. Internally, it uses the SDK helpers to launch child
+processes and compose their behaviour.
+
+The meta-plugin SDK provides three building blocks:
+
+1. **Launch** -- start child plugin processes with security auditing
+2. **Delegate** -- forward calls to a base plugin, overriding only what you need
+3. **Compose** -- combine multiple plugins with structural patterns (merging, mirroring)
+
+## Package layout
+
+```
+pkg/zhiplugin/
+  launch/
+    launch.go         LaunchConfig, LaunchTransform, LaunchStore
+    options.go        Option, WithLogger, WithIsolatedEnv, WithAuditMode
+    audit.go          AuditBinary, PluginNameFromPath, binary validation
+  config/
+    delegate.go       DelegatingPlugin (config)
+    compose.go        MergedPlugin, MountedPlugin
+  transform/
+    delegate.go       DelegatingPlugin (transform)
+  store/
+    delegate.go       DelegatingPlugin (store)
+    compose.go        MirroredPlugin
+```
+
+## Launch package
+
+`pkg/zhiplugin/launch` provides functions for launching external plugin
+binaries as child processes. It extracts the launch logic from the
+internal engine so that meta-plugins can reuse the same mechanisms.
+
+### Launch functions
+
+Each function returns the typed plugin interface, a cleanup function
+that kills the child process, and an error:
+
+```go
+import "github.com/MrWong99/zhi/pkg/zhiplugin/launch"
+
+// Launch a config plugin binary.
+cfg, cleanup, err := launch.LaunchConfig("/path/to/zhi-config-foo", opts...)
+defer cleanup()
+
+// Launch a transform plugin binary.
+tfm, cleanup, err := launch.LaunchTransform("/path/to/zhi-transform-bar", opts...)
+defer cleanup()
+
+// Launch a store plugin binary.
+st, cleanup, err := launch.LaunchStore("/path/to/zhi-store-baz", opts...)
+defer cleanup()
+```
+
+The caller **must** call the cleanup function when done to kill the
+child process. Use `defer cleanup()` immediately after a successful
+launch.
+
+### Options
+
+| Option | Purpose |
+|--------|---------|
+| `WithLogger(l)` | structured logger for audit results and lifecycle events |
+| `WithIsolatedEnv(env)` | restrict child environment to handshake variables + extras |
+| `WithAuditMode(mode)` | control how integrity check failures are handled |
+
+#### WithIsolatedEnv
+
+By default, child processes inherit the parent's full environment.
+`WithIsolatedEnv` restricts the child to only `ZHI_PLUGIN`, `PATH`,
+and the user-supplied map. This prevents leaking secrets or credentials
+to children:
+
+```go
+launch.LaunchStore(bin,
+    launch.WithIsolatedEnv(map[string]string{
+        "VAULT_ADDR":  "https://vault.example.com",
+        "VAULT_TOKEN": os.Getenv("VAULT_TOKEN"),
+    }),
+)
+```
+
+#### AuditMode
+
+| Mode | Behaviour |
+|------|-----------|
+| `AuditHardFail` (default) | return an error if binary integrity check fails |
+| `AuditWarnOnly` | log a warning but continue launching |
+
+The public API defaults to `AuditHardFail`. The engine uses
+`AuditWarnOnly` for backward compatibility.
+
+### Binary security checks
+
+Before launching a plugin, the launch package:
+
+1. **Resolves symlinks** and rejects paths containing `..` components
+2. **Computes SHA-256** of the binary and logs it
+3. **Warns** if the binary is world-writable
+4. **Verifies integrity** against the stored digest from installation
+   time (for plugins installed via `zhi plugin install`)
+
+If the binary was not installed via the sharing system (e.g.,
+locally-built plugins), the integrity check is skipped.
+
+### Process isolation
+
+Child processes are launched in a separate process group
+(`Setpgid: true` on Unix) so that signals sent to the parent do not
+propagate directly to children. This ensures clean shutdown via the
+cleanup function rather than accidental signal forwarding.
+
+## Delegate pattern
+
+Each plugin type provides a `DelegatingPlugin` struct that implements
+the full interface by forwarding every call to a `Base` plugin. Embed
+this struct and override only the methods you need:
+
+### config.DelegatingPlugin
+
+```go
+import "github.com/MrWong99/zhi/pkg/zhiplugin/config"
+
+type auditingConfig struct {
+    config.DelegatingPlugin
+    log *slog.Logger
+}
+
+func (a *auditingConfig) Set(ctx context.Context, path string, v config.Value) error {
+    a.log.Info("config value changed", "path", path)
+    return a.Base.Set(ctx, path, v)
+}
+
+// List, Get, Validate are all forwarded to Base automatically.
+```
+
+### store.DelegatingPlugin
+
+```go
+import "github.com/MrWong99/zhi/pkg/zhiplugin/store"
+
+type cachingStore struct {
+    store.DelegatingPlugin
+    cache map[string]map[string]config.Value
+}
+
+func (c *cachingStore) GetValues(ctx context.Context, id string, paths []string) (map[string]config.Value, error) {
+    // Check cache first, fall back to Base.
+    // ...
+    return c.Base.GetValues(ctx, id, paths)
+}
+
+// All other store methods (Capabilities, PutValues, ListTrees, etc.)
+// are forwarded to Base automatically.
+```
+
+### transform.DelegatingPlugin
+
+```go
+import "github.com/MrWong99/zhi/pkg/zhiplugin/transform"
+
+type loggingTransform struct {
+    transform.DelegatingPlugin
+    log *slog.Logger
+}
+
+func (l *loggingTransform) BeforeDisplay(ctx context.Context, tree *config.Tree) error {
+    l.log.Info("transforming tree", "paths", len(tree.List()))
+    return l.Base.BeforeDisplay(ctx, tree)
+}
+
+// AfterSave and ValidatePolicy are forwarded to Base automatically.
+```
+
+### Creating a DelegatingPlugin
+
+Use the `NewDelegatingPlugin` constructor for each type. It panics if
+`base` is nil:
+
+```go
+base := config.NewDelegatingPlugin(somePlugin)
+// or
+base := store.NewDelegatingPlugin(somePlugin)
+// or
+base := transform.NewDelegatingPlugin(somePlugin)
+```
+
+## Compose patterns
+
+### config.MergedPlugin
+
+Combines multiple config plugins under distinct path prefixes. Each
+child's paths are namespaced by its mount point:
+
+```go
+import "github.com/MrWong99/zhi/pkg/zhiplugin/config"
+
+merged, err := config.MergedPlugin(
+    config.MountedPlugin{Impl: appA, Prefix: "app-a/"},
+    config.MountedPlugin{Impl: appB, Prefix: "app-b/"},
+)
+```
+
+**Behaviour:**
+
+| Operation | Routing |
+|-----------|---------|
+| `List` | queries all children in parallel, prefixes each path |
+| `Get` | routes to child matching the path prefix |
+| `Set` | routes to child matching the path prefix |
+| `Validate` | routes to child matching the prefix; provides a scoped `TreeReader` |
+
+**Constraints:**
+
+- At least one child is required
+- Prefixes must not overlap (neither can be a prefix of another)
+- Empty prefixes are rejected
+- Nil `Impl` values are rejected
+
+The scoped `TreeReader` passed to `Validate` strips the prefix so that
+each child sees paths relative to its own namespace.
+
+### store.MirroredPlugin
+
+Writes to all stores but reads from the primary. Mirror write errors
+are logged but do not fail the operation:
+
+```go
+import "github.com/MrWong99/zhi/pkg/zhiplugin/store"
+
+composed := store.MirroredPlugin(logger, primary, mirror1, mirror2)
+```
+
+**Behaviour:**
+
+| Operation | Routing |
+|-----------|---------|
+| Reads (`GetValues`, `ListTrees`, versioning reads) | primary only |
+| Writes (`PutValues`, `DeleteValues`, `DeleteTree`) | primary first, then mirrors in parallel |
+| `Capabilities` | intersection of all stores (most restrictive wins) |
+| Auth/Encryption/Access control | primary only |
+
+Mirror writes use `nil` for `PutOptions` (no CAS on mirrors) to avoid
+conflicts. If a mirror write fails, the error is logged but the
+operation succeeds as long as the primary succeeded.
+
+## Building a meta-plugin
+
+A meta-plugin is a standard plugin binary that uses the SDK to launch
+children and compose them. The host treats it like any other plugin.
+
+### Step 1: Find child binaries
+
+Locate sibling binaries relative to your own executable, or look them
+up on `PATH`:
+
+```go
+selfPath, _ := os.Executable()
+dir := filepath.Dir(selfPath)
+
+primaryBin := filepath.Join(dir, "zhi-store-memory")
+mirrorBin := filepath.Join(dir, "zhi-store-json")
+```
+
+### Step 2: Launch children
+
+```go
+primary, cleanupPrimary, err := launch.LaunchStore(primaryBin,
+    launch.WithLogger(logger),
+)
+if err != nil {
+    // handle error
+}
+defer cleanupPrimary()
+
+mirror, cleanupMirror, err := launch.LaunchStore(mirrorBin,
+    launch.WithLogger(logger),
+)
+if err != nil {
+    // handle error
+}
+defer cleanupMirror()
+```
+
+### Step 3: Compose
+
+```go
+composed := store.MirroredPlugin(logger, primary, mirror)
+```
+
+### Step 4: Serve to host
+
+```go
+goplugin.Serve(&goplugin.ServeConfig{
+    HandshakeConfig: zhiplugin.Handshake,
+    Plugins: map[string]goplugin.Plugin{
+        "store": &store.GRPCPlugin{Impl: composed},
+    },
+    GRPCServer: goplugin.DefaultGRPCServer,
+})
+```
+
+### Plugin manifest
+
+A meta-plugin's `zhi-plugin.yaml` uses the standard format. The `type`
+matches the interface the meta-plugin exposes to the host:
+
+```yaml
+schemaVersion: "1"
+name: mirror
+type: store
+version: 0.0.1
+zhiProtocolVersion: "1"
+description: Meta-plugin that mirrors writes to two child store plugins
+keywords:
+  - store
+  - mirror
+  - meta-plugin
+  - composition
+```
+
+### Naming convention
+
+Meta-plugin binaries follow the same naming scheme as regular plugins:
+`zhi-<type>-<name>` (e.g. `zhi-store-mirror`).
+
+## Complete example
+
+The [`examples/zhi-store-mirror/`](../../examples/zhi-store-mirror/)
+directory contains a working meta-plugin that launches `zhi-store-memory`
+as the primary and `zhi-store-json` as the mirror. Build and run it
+with:
+
+```sh
+make build-examples
+```
+
+Both child plugin binaries must be available in the same directory as
+the meta-plugin binary (or on `PATH`).
+
+## Use cases
+
+| Pattern | Use case |
+|---------|----------|
+| **MirroredPlugin** | backup/replication: fast in-memory primary with durable JSON file mirror |
+| **MergedPlugin** | multi-tenant config: each tenant's config plugin mounted under a prefix |
+| **DelegatingPlugin + Launch** | add logging, caching, or access control around an existing plugin |
+| **DelegatingPlugin alone** | override specific methods of any plugin without reimplementing the full interface |
+
+## Security considerations
+
+- Use `WithIsolatedEnv` to avoid leaking secrets to child processes
+- The default `AuditHardFail` mode rejects tampered binaries; use
+  `AuditWarnOnly` only during development
+- Child processes run in separate process groups for clean lifecycle
+  management
+- Binary paths are validated against symlink traversal attacks

--- a/docs/plugin-development/overview.md
+++ b/docs/plugin-development/overview.md
@@ -13,6 +13,8 @@ zhi has four plugin types:
 | [Store](store-plugin.md) | Persist and retrieve configuration trees | Host -> Plugin |
 | [UI](ui-plugin.md) | Provide interactive frontends | Bidirectional |
 
+Any of the above types can be implemented as a **meta-plugin** -- a plugin that internally launches and composes child plugins using the [Meta-Plugin SDK](meta-plugin.md). From the host's perspective a meta-plugin is indistinguishable from a regular plugin.
+
 ## Shared Handshake
 
 All plugins share the same handshake defined in `pkg/zhiplugin/plugin.go`:
@@ -129,6 +131,7 @@ The [`examples/`](../../examples/) directory contains working reference implemen
 | [zhi-store-memory](../../examples/zhi-store-memory/) | Store | Minimal in-memory store |
 | [zhi-ui-httpapi](../../examples/zhi-ui-httpapi/) | UI | HTTP/JSON API with SSE streaming |
 | [zhi-config-javabean](../../examples/zhi-config-javabean/) | Config | Java bean with Bean Validation, GraalVM native-image |
+| [zhi-store-mirror](../../examples/zhi-store-mirror/) | Store (meta) | Meta-plugin: mirrors writes to memory + JSON file |
 
 All Go examples are published as OCI artifacts to `ghcr.io/mrwong99/zhi/` on every release and can be installed with `zhi plugin install oci://ghcr.io/mrwong99/zhi/<plugin-name>:<tag>`. See the [Sharing and Registries guide](../user-guide/sharing-and-registries.md#official-plugin-registry) for the full list.
 
@@ -168,5 +171,6 @@ See the [Sharing and Registries guide](../user-guide/sharing-and-registries.md) 
 - [Transform Plugin API](transform-plugin.md)
 - [Store Plugin API](store-plugin.md)
 - [UI Plugin API](ui-plugin.md)
+- [Meta-Plugin SDK](meta-plugin.md)
 - [Java Plugin Development](java-plugin.md)
 - [Sharing and Registries](../user-guide/sharing-and-registries.md)


### PR DESCRIPTION
Add comprehensive documentation for the meta-plugin SDK introduced in
PR #64. The SDK enables plugin composition through launch, delegate,
and compose helpers.

- Create docs/plugin-development/meta-plugin.md with full guide
  covering launch package, delegate pattern, compose patterns
  (MergedPlugin, MirroredPlugin), security considerations, and
  step-by-step meta-plugin building instructions
- Update docs/plugin-development/overview.md with meta-plugin
  references in plugin types, examples table, and further reading
- Update CLAUDE.md with meta-plugin SDK architecture section and
  updated key directories
- Update README.md with meta-plugin SDK link and mirror example

https://claude.ai/code/session_01SuBZToSUPd3CV4FEyjLpPr