### PR TITLE
refactor: optimize Go code with stdlib helpers and reduce duplication

### DIFF
--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -175,7 +176,7 @@ func runListPaths(cmd *cobra.Command, _ []string) error {
 	}
 
 	paths := tree.List()
-	sortStrings(paths)
+	sort.Strings(paths)
 
 	if listJSON {
 		data, err := json.MarshalIndent(paths, "", "  ")
@@ -285,13 +286,4 @@ func runListComponents(cmd *cobra.Command, _ []string) error {
 	}
 	fprintTable(w, headers, rows)
 	return nil
-}
-
-// sortStrings sorts a string slice in place.
-func sortStrings(s []string) {
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0 && s[j] < s[j-1]; j-- {
-			s[j], s[j-1] = s[j-1], s[j]
-		}
-	}
 }

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -119,19 +119,17 @@ func runWorkspaceInstall(cmd *cobra.Command, args []string) error {
 // checkExternalTool checks if an external tool is available on PATH.
 func checkExternalTool(w interface{ Write([]byte) (int, error) }, tool manifest.ToolRequirement) {
 	_, err := exec.LookPath(tool.Name)
+	symbol := "+"
+	status := "found"
 	if err != nil {
-		msg := fmt.Sprintf("  ! %s not found", tool.Name)
-		if tool.Version != "" {
-			msg += fmt.Sprintf(" (%s required)", tool.Version)
-		}
-		fmt.Fprintln(w, msg)
-	} else {
-		msg := fmt.Sprintf("  + %s found", tool.Name)
-		if tool.Version != "" {
-			msg += fmt.Sprintf(" (%s required)", tool.Version)
-		}
-		fmt.Fprintln(w, msg)
+		symbol = "!"
+		status = "not found"
 	}
+	msg := fmt.Sprintf("  %s %s %s", symbol, tool.Name, status)
+	if tool.Version != "" {
+		msg += fmt.Sprintf(" (%s required)", tool.Version)
+	}
+	fmt.Fprintln(w, msg)
 }
 
 // --- workspace publish ---

--- a/internal/core/component.go
+++ b/internal/core/component.go
@@ -85,7 +85,9 @@ func (cm *ComponentManager) detectCycles() error {
 	inDegree := make(map[string]int, len(cm.definitions))
 	dependents := make(map[string][]string, len(cm.definitions))
 	for _, d := range cm.definitions {
-		inDegree[d.Name] += 0 // ensure entry exists
+		if _, exists := inDegree[d.Name]; !exists {
+			inDegree[d.Name] = 0
+		}
 		for _, dep := range d.Dependencies {
 			dependents[dep] = append(dependents[dep], d.Name)
 			inDegree[d.Name]++
@@ -204,13 +206,11 @@ func (cm *ComponentManager) IsEnabled(name string) bool {
 func (cm *ComponentManager) ListComponents() []ComponentState {
 	out := make([]ComponentState, len(cm.definitions))
 	for i, d := range cm.definitions {
-		deps := make([]string, len(d.Dependencies))
-		copy(deps, d.Dependencies)
 		out[i] = ComponentState{
 			Name:         d.Name,
 			Enabled:      cm.state[d.Name],
 			Mandatory:    d.Mandatory,
-			Dependencies: deps,
+			Dependencies: slices.Clone(d.Dependencies),
 		}
 	}
 	return out
@@ -299,9 +299,7 @@ func (cm *ComponentManager) SaveState() map[string]bool {
 
 // Definitions returns a copy of all component definitions.
 func (cm *ComponentManager) Definitions() []ComponentDef {
-	out := make([]ComponentDef, len(cm.definitions))
-	copy(out, cm.definitions)
-	return out
+	return slices.Clone(cm.definitions)
 }
 
 // Definition returns the definition of a component by name.

--- a/internal/core/export.go
+++ b/internal/core/export.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -93,7 +94,7 @@ func Export(_ context.Context, tree *TreeData, cfg ExportRunConfig) (*ExportResu
 
 // ExportAll runs all exports defined in the workspace configuration.
 func ExportAll(ctx context.Context, tree *TreeData, configs []ExportRunConfig) ([]*ExportResult, error) {
-	var results []*ExportResult
+	results := make([]*ExportResult, 0, len(configs))
 	for _, cfg := range configs {
 		r, err := Export(ctx, tree, cfg)
 		if err != nil {
@@ -297,11 +298,7 @@ func toDotenv(v any) (string, error) {
 	}
 
 	// Sort keys for deterministic output.
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(m))
 
 	var sb strings.Builder
 	for _, k := range keys {

--- a/internal/core/registry.go
+++ b/internal/core/registry.go
@@ -4,6 +4,7 @@ package core
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"sync"
@@ -151,90 +152,53 @@ func (r *Registry) UIProvider(workspace, name string, options map[string]any) (z
 // ListConfig returns the sorted names of all registered config providers
 // (built-in and external).
 func (r *Registry) ListConfig() []string {
-	names := sortedKeys(r.config)
-	for _, p := range r.externalPlugins {
-		if p.Type == PluginTypeConfig && !contains(names, p.Name) {
-			names = append(names, p.Name)
-		}
-	}
-	sort.Strings(names)
-	return names
+	return listNames(r, r.config, PluginTypeConfig)
 }
 
 // ListTransform returns the sorted names of all registered transform
 // providers (built-in and external).
 func (r *Registry) ListTransform() []string {
-	names := sortedKeys(r.transform)
-	for _, p := range r.externalPlugins {
-		if p.Type == PluginTypeTransform && !contains(names, p.Name) {
-			names = append(names, p.Name)
-		}
-	}
-	sort.Strings(names)
-	return names
+	return listNames(r, r.transform, PluginTypeTransform)
 }
 
 // ListStore returns the sorted names of all registered store providers
 // (built-in and external).
 func (r *Registry) ListStore() []string {
-	names := sortedKeys(r.store)
-	for _, p := range r.externalPlugins {
-		if p.Type == PluginTypeStore && !contains(names, p.Name) {
-			names = append(names, p.Name)
-		}
-	}
-	sort.Strings(names)
-	return names
-}
-
-// ListConfigProviders returns detailed provider info including source.
-func (r *Registry) ListConfigProviders() []ProviderInfo {
-	var infos []ProviderInfo
-	for _, name := range sortedKeys(r.config) {
-		infos = append(infos, ProviderInfo{Name: name, Source: "built-in"})
-	}
-	for _, p := range r.externalPlugins {
-		if p.Type == PluginTypeConfig && !r.isBuiltinConfig(p.Name) {
-			infos = append(infos, ProviderInfo{Name: p.Name, Source: p.Path})
-		}
-	}
-	return infos
-}
-
-// ListTransformProviders returns detailed provider info including source.
-func (r *Registry) ListTransformProviders() []ProviderInfo {
-	var infos []ProviderInfo
-	for _, name := range sortedKeys(r.transform) {
-		infos = append(infos, ProviderInfo{Name: name, Source: "built-in"})
-	}
-	for _, p := range r.externalPlugins {
-		if p.Type == PluginTypeTransform && !r.isBuiltinTransform(p.Name) {
-			infos = append(infos, ProviderInfo{Name: p.Name, Source: p.Path})
-		}
-	}
-	return infos
-}
-
-// ListStoreProviders returns detailed provider info including source.
-func (r *Registry) ListStoreProviders() []ProviderInfo {
-	var infos []ProviderInfo
-	for _, name := range sortedKeys(r.store) {
-		infos = append(infos, ProviderInfo{Name: name, Source: "built-in"})
-	}
-	for _, p := range r.externalPlugins {
-		if p.Type == PluginTypeStore && !r.isBuiltinStore(p.Name) {
-			infos = append(infos, ProviderInfo{Name: p.Name, Source: p.Path})
-		}
-	}
-	return infos
+	return listNames(r, r.store, PluginTypeStore)
 }
 
 // ListUI returns the sorted names of all registered UI providers
 // (built-in and external).
 func (r *Registry) ListUI() []string {
-	names := sortedKeys(r.ui)
+	return listNames(r, r.ui, PluginTypeUI)
+}
+
+// ListConfigProviders returns detailed provider info including source.
+func (r *Registry) ListConfigProviders() []ProviderInfo {
+	return listProviderInfos(r, r.config, PluginTypeConfig)
+}
+
+// ListTransformProviders returns detailed provider info including source.
+func (r *Registry) ListTransformProviders() []ProviderInfo {
+	return listProviderInfos(r, r.transform, PluginTypeTransform)
+}
+
+// ListStoreProviders returns detailed provider info including source.
+func (r *Registry) ListStoreProviders() []ProviderInfo {
+	return listProviderInfos(r, r.store, PluginTypeStore)
+}
+
+// ListUIProviders returns detailed provider info including source.
+func (r *Registry) ListUIProviders() []ProviderInfo {
+	return listProviderInfos(r, r.ui, PluginTypeUI)
+}
+
+// listNames returns the sorted names of all built-in and external providers
+// of the given type.
+func listNames[V any](r *Registry, builtins map[string]V, pt PluginType) []string {
+	names := sortedKeys(builtins)
 	for _, p := range r.externalPlugins {
-		if p.Type == PluginTypeUI && !contains(names, p.Name) {
+		if p.Type == pt && !slices.Contains(names, p.Name) {
 			names = append(names, p.Name)
 		}
 	}
@@ -242,14 +206,15 @@ func (r *Registry) ListUI() []string {
 	return names
 }
 
-// ListUIProviders returns detailed provider info including source.
-func (r *Registry) ListUIProviders() []ProviderInfo {
+// listProviderInfos returns detailed info for all built-in and external
+// providers of the given type.
+func listProviderInfos[V any](r *Registry, builtins map[string]V, pt PluginType) []ProviderInfo {
 	var infos []ProviderInfo
-	for _, name := range sortedKeys(r.ui) {
+	for _, name := range sortedKeys(builtins) {
 		infos = append(infos, ProviderInfo{Name: name, Source: "built-in"})
 	}
 	for _, p := range r.externalPlugins {
-		if p.Type == PluginTypeUI && !r.isBuiltinUI(p.Name) {
+		if p.Type == pt && !isBuiltin(builtins, p.Name) {
 			infos = append(infos, ProviderInfo{Name: p.Name, Source: p.Path})
 		}
 	}
@@ -400,35 +365,14 @@ func (r *Registry) findExternal(name string, pt PluginType) (PluginInfo, bool) {
 	return PluginInfo{}, false
 }
 
-func (r *Registry) isBuiltinConfig(name string) bool {
-	_, ok := r.config[name]
-	return ok
-}
-
-func (r *Registry) isBuiltinTransform(name string) bool {
-	_, ok := r.transform[name]
-	return ok
-}
-
-func (r *Registry) isBuiltinStore(name string) bool {
-	_, ok := r.store[name]
-	return ok
-}
-
-func (r *Registry) isBuiltinUI(name string) bool {
-	_, ok := r.ui[name]
+// isBuiltin reports whether the given name is registered as a built-in
+// provider in the provided factory map.
+func isBuiltin[V any](m map[string]V, name string) bool {
+	_, ok := m[name]
 	return ok
 }
 
 func sortedKeys[V any](m map[string]V) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(m))
 	return keys
-}
-
-func contains(slice []string, s string) bool {
-	return slices.Contains(slice, s)
 }

--- a/internal/core/workspace.go
+++ b/internal/core/workspace.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -86,11 +87,7 @@ func (ac *ApplyConfig) ResolveTarget(name string) (ApplyTargetConfig, error) {
 	if len(ac.Targets) > 0 {
 		t, ok := ac.Targets[name]
 		if !ok {
-			available := make([]string, 0, len(ac.Targets))
-			for k := range ac.Targets {
-				available = append(available, k)
-			}
-			return ApplyTargetConfig{}, fmt.Errorf("unknown apply target %q (available: %v)", name, available)
+			return ApplyTargetConfig{}, fmt.Errorf("unknown apply target %q (available: %v)", name, slices.Sorted(maps.Keys(ac.Targets)))
 		}
 		return t, nil
 	}

--- a/pkg/zhiplugin/config/grpc_client.go
+++ b/pkg/zhiplugin/config/grpc_client.go
@@ -37,16 +37,9 @@ func (c *GRPCClient) Get(ctx context.Context, path string) (Value, bool, error) 
 }
 
 func (c *GRPCClient) Set(ctx context.Context, path string, v Value) error {
-	valJSON, err := json.Marshal(v.Val)
+	valJSON, metaJSON, err := ValueToProto(v)
 	if err != nil {
 		return err
-	}
-	var metaJSON []byte
-	if v.Metadata != nil {
-		metaJSON, err = json.Marshal(v.Metadata)
-		if err != nil {
-			return err
-		}
 	}
 	_, err = c.client.Set(ctx, &pb.SetRequest{
 		Path:         path,
@@ -78,13 +71,9 @@ func TreeToProto(tree TreeReader) []*pb.TreeEntry {
 		if !ok {
 			continue
 		}
-		valJSON, err := json.Marshal(v.Val)
+		valJSON, metaJSON, err := ValueToProto(v)
 		if err != nil {
 			continue
-		}
-		var metaJSON []byte
-		if v.Metadata != nil {
-			metaJSON, _ = json.Marshal(v.Metadata)
 		}
 		entries = append(entries, &pb.TreeEntry{
 			Path:         p,
@@ -112,6 +101,22 @@ func resultsFromProto(msgs []*pb.ValidationResultMsg) ([]ValidationResult, error
 		results = append(results, r)
 	}
 	return results, nil
+}
+
+// ValueToProto serialises a Value into JSON-encoded value and metadata bytes
+// for wire transfer.
+func ValueToProto(v Value) (valJSON, metaJSON []byte, err error) {
+	valJSON, err = json.Marshal(v.Val)
+	if err != nil {
+		return nil, nil, err
+	}
+	if v.Metadata != nil {
+		metaJSON, err = json.Marshal(v.Metadata)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return valJSON, metaJSON, nil
 }
 
 // ValueFromProto reconstructs a Value from JSON-encoded bytes received over

--- a/pkg/zhiplugin/config/grpc_server.go
+++ b/pkg/zhiplugin/config/grpc_server.go
@@ -30,16 +30,9 @@ func (s *GRPCServer) Get(ctx context.Context, req *pb.GetRequest) (*pb.GetRespon
 	if !ok {
 		return &pb.GetResponse{Found: false}, nil
 	}
-	valJSON, err := json.Marshal(v.Val)
+	valJSON, metaJSON, err := ValueToProto(v)
 	if err != nil {
 		return nil, err
-	}
-	var metaJSON []byte
-	if v.Metadata != nil {
-		metaJSON, err = json.Marshal(v.Metadata)
-		if err != nil {
-			return nil, err
-		}
 	}
 	return &pb.GetResponse{
 		Found:        true,

--- a/pkg/zhiplugin/labels/registry.go
+++ b/pkg/zhiplugin/labels/registry.go
@@ -2,6 +2,8 @@ package labels
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -105,9 +107,7 @@ func (r *Registry) ListByNamespace(namespace string) []*Label {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	labels := r.byNS[namespace]
-	result := make([]*Label, len(labels))
-	copy(result, labels)
+	result := slices.Clone(r.byNS[namespace])
 
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].Name < result[j].Name
@@ -120,14 +120,7 @@ func (r *Registry) ListByNamespace(namespace string) []*Label {
 func (r *Registry) Namespaces() []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-
-	result := make([]string, 0, len(r.byNS))
-	for ns := range r.byNS {
-		result = append(result, ns)
-	}
-
-	sort.Strings(result)
-	return result
+	return slices.Sorted(maps.Keys(r.byNS))
 }
 
 // Validate checks if a metadata value is valid for the given label.

--- a/pkg/zhiplugin/store/grpc_client.go
+++ b/pkg/zhiplugin/store/grpc_client.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
 	configpb "github.com/MrWong99/zhi/pkg/zhiplugin/config/proto"
@@ -295,13 +294,9 @@ func (c *GRPCClient) ListAccess(ctx context.Context, id string) (map[string][]Pe
 func valuesToProto(values map[string]config.Value) []*configpb.TreeEntry {
 	entries := make([]*configpb.TreeEntry, 0, len(values))
 	for path, v := range values {
-		valJSON, err := json.Marshal(v.Val)
+		valJSON, metaJSON, err := config.ValueToProto(v)
 		if err != nil {
 			continue
-		}
-		var metaJSON []byte
-		if v.Metadata != nil {
-			metaJSON, _ = json.Marshal(v.Metadata)
 		}
 		entries = append(entries, &configpb.TreeEntry{
 			Path:         path,

--- a/pkg/zhiplugin/store/grpc_server.go
+++ b/pkg/zhiplugin/store/grpc_server.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
 	configpb "github.com/MrWong99/zhi/pkg/zhiplugin/config/proto"
@@ -196,16 +195,9 @@ func (s *GRPCServer) GetValueVersion(ctx context.Context, req *pb.GetValueVersio
 	if !found {
 		return &pb.GetValueVersionResponse{Found: false}, nil
 	}
-	valJSON, err := json.Marshal(v.Val)
+	valJSON, metaJSON, err := config.ValueToProto(v)
 	if err != nil {
 		return nil, err
-	}
-	var metaJSON []byte
-	if v.Metadata != nil {
-		metaJSON, err = json.Marshal(v.Metadata)
-		if err != nil {
-			return nil, err
-		}
 	}
 	return &pb.GetValueVersionResponse{
 		Found:        true,

--- a/pkg/zhiplugin/ui/controller_client.go
+++ b/pkg/zhiplugin/ui/controller_client.go
@@ -27,16 +27,9 @@ func (c *controllerGRPCClient) LoadTree(ctx context.Context) (*config.Tree, erro
 }
 
 func (c *controllerGRPCClient) SetValue(ctx context.Context, path string, value config.Value) error {
-	valJSON, err := json.Marshal(value.Val)
+	valJSON, metaJSON, err := config.ValueToProto(value)
 	if err != nil {
 		return err
-	}
-	var metaJSON []byte
-	if value.Metadata != nil {
-		metaJSON, err = json.Marshal(value.Metadata)
-		if err != nil {
-			return err
-		}
 	}
 	_, err = c.client.SetValue(ctx, &pb.CtrlSetValueRequest{
 		Path:         path,

--- a/pkg/zhiplugin/ui/controller_server.go
+++ b/pkg/zhiplugin/ui/controller_server.go
@@ -6,6 +6,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
 	cfgpb "github.com/MrWong99/zhi/pkg/zhiplugin/config/proto"
 	pb "github.com/MrWong99/zhi/pkg/zhiplugin/ui/proto"
 )
@@ -28,7 +29,7 @@ func (s *controllerGRPCServer) LoadTree(ctx context.Context, _ *pb.CtrlLoadTreeR
 }
 
 func (s *controllerGRPCServer) SetValue(ctx context.Context, req *pb.CtrlSetValueRequest) (*pb.CtrlSetValueResponse, error) {
-	v, err := valueFromProto(req.GetValueJson(), req.GetMetadataJson())
+	v, err := config.ValueFromProto(req.GetValueJson(), req.GetMetadataJson())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zhiplugin/ui/proto_helpers.go
+++ b/pkg/zhiplugin/ui/proto_helpers.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
@@ -9,60 +8,14 @@ import (
 	pb "github.com/MrWong99/zhi/pkg/zhiplugin/ui/proto"
 )
 
-// treeToProto serialises a config.TreeReader into proto TreeEntry messages.
+// treeToProto delegates to config.TreeToProto.
 func treeToProto(tree config.TreeReader) []*cfgpb.TreeEntry {
-	paths := tree.List()
-	entries := make([]*cfgpb.TreeEntry, 0, len(paths))
-	for _, p := range paths {
-		v, ok := tree.Get(p)
-		if !ok {
-			continue
-		}
-		valJSON, err := json.Marshal(v.Val)
-		if err != nil {
-			continue
-		}
-		var metaJSON []byte
-		if v.Metadata != nil {
-			metaJSON, _ = json.Marshal(v.Metadata)
-		}
-		entries = append(entries, &cfgpb.TreeEntry{
-			Path:         p,
-			ValueJson:    valJSON,
-			MetadataJson: metaJSON,
-		})
-	}
-	return entries
+	return config.TreeToProto(tree)
 }
 
-// treeFromProto reconstructs a config.Tree from proto TreeEntry messages.
+// treeFromProto delegates to config.TreeFromProto.
 func treeFromProto(entries []*cfgpb.TreeEntry) *config.Tree {
-	t := config.NewTree()
-	for _, e := range entries {
-		v, err := valueFromProto(e.GetValueJson(), e.GetMetadataJson())
-		if err != nil {
-			continue
-		}
-		// Paths were validated at Set time; re-validation is acceptable.
-		_ = t.Set(e.GetPath(), &v)
-	}
-	return t
-}
-
-// valueFromProto reconstructs a config.Value from JSON-encoded bytes.
-func valueFromProto(valJSON, metaJSON []byte) (config.Value, error) {
-	var v config.Value
-	if len(valJSON) > 0 {
-		if err := json.Unmarshal(valJSON, &v.Val); err != nil {
-			return config.Value{}, err
-		}
-	}
-	if len(metaJSON) > 0 {
-		if err := json.Unmarshal(metaJSON, &v.Metadata); err != nil {
-			return config.Value{}, err
-		}
-	}
-	return v, nil
+	return config.TreeFromProto(entries)
 }
 
 // marketplaceEntryFromProto converts a proto marketplace entry to the Go type.


### PR DESCRIPTION
- Replace custom O(n²) insertion sort with stdlib sort.Strings
- Remove redundant contains() wrapper, use slices.Contains directly
- Consolidate 4 isBuiltinX methods into single generic isBuiltin function
- Extract listNames and listProviderInfos generic helpers to deduplicate
  8 nearly identical Registry methods
- Use slices.Clone instead of manual make+copy for slice duplication
- Use slices.Sorted(maps.Keys()) instead of manual map-to-slice loops
- Add config.ValueToProto helper to centralize Value marshaling (was
  duplicated 6 times across config, store, and UI gRPC layers)
- Replace duplicated UI proto helpers (treeToProto, treeFromProto,
  valueFromProto) with delegates to config package equivalents
- Simplify checkExternalTool by extracting shared logic from branches
- Pre-allocate ExportAll results slice with known capacity
- Replace idiomatic no-op (inDegree[name] += 0) with explicit init check

Net reduction: 87 insertions, 236 deletions across 14 files.

https://claude.ai/code/session_01VqnAF8D1dBN1H5Vp51rhkm