### PR TITLE
docs: add detailed WebAssembly plugin support design plan

### DIFF
--- a/docs/plans/wasm/01-runtime-evaluation.md
+++ b/docs/plans/wasm/01-runtime-evaluation.md
@@ -1,0 +1,271 @@
+# 01 — WASM Runtime Evaluation
+
+This document evaluates the available WebAssembly runtimes for embedding in
+zhi's Go host process. The runtime is the core dependency: it loads `.wasm`
+modules, executes them, and mediates all host↔plugin communication.
+
+## Candidates
+
+Four options were evaluated:
+
+1. **wazero** — Pure Go WASM runtime (tetratelabs/wazero)
+2. **wasmtime-go** — Go bindings to Wasmtime via CGO (bytecodealliance/wasmtime-go)
+3. **Extism** — High-level plugin framework built on wazero (extism/go-sdk)
+4. **knqyf263/go-plugin** — Protobuf-based Go plugin system over wazero
+
+---
+
+## 1. wazero
+
+**Repository:** https://github.com/tetratelabs/wazero
+**License:** Apache-2.0
+**Latest release:** v1.9.0 (December 2025)
+
+### Overview
+
+wazero is a WebAssembly Core Specification 1.0 and 2.0 compliant runtime
+written entirely in Go with zero external dependencies. It does not use CGO.
+
+### Strengths
+
+- **Zero dependencies** — No C compiler, no shared libraries, no libc. This
+  directly aligns with zhi's `CGO_ENABLED=0` cross-compilation policy.
+- **Two execution modes** — An interpreter (works on all Go targets) and an
+  AOT compiler (generates native code for amd64/arm64). The compiler is used
+  by default when available.
+- **Broad OS/arch support** — Linux, macOS, Windows, FreeBSD, NetBSD,
+  OpenBSD, DragonFly BSD, illumos, Solaris. Matches zhi's cross-compilation
+  matrix (linux/darwin × amd64/arm64) and then some.
+- **Stable API** — SemVer-committed since v1.0 (March 2023). No breaking
+  changes without a major version bump.
+- **Small binary footprint** — Adds ~5.5 MB to the host binary.
+- **WASI Preview 1** — Bundled `wasi_snapshot_preview1` implementation with
+  configurable filesystem (`FSConfig`), clocks, args, env, and stdio.
+- **Host functions** — Rich `HostModuleBuilder` API for exporting Go
+  functions to WASM modules. Functions can use Go closures with full access
+  to host state.
+- **Concurrency-safe** — Thread-safe module instantiation. `CompiledModule`
+  can be reused across goroutines.
+- **Active ecosystem** — Imported by 589+ Go packages. Used by Trivy,
+  Dapr, Mosn, and others in production.
+
+### Limitations
+
+- **No WASI Preview 2 / Component Model** — wazero targets
+  `wasi_snapshot_preview1` only. There is no current plan for P2 support.
+  This means no WIT-based typed interfaces or component composition at the
+  WASI level.
+- **Filesystem sandbox escape** — The current WASI filesystem implementation
+  does not fully prevent directory traversal via relative paths (e.g.,
+  `../../`). This is documented and tracked. For zhi, this is mitigated by
+  not granting filesystem access by default.
+- **No network sockets** — `sock_recv`/`sock_send` from WASI P1 are not
+  implemented. Network access must be provided through custom host functions.
+- **Performance** — Slower than Wasmtime for CPU-bound workloads (no
+  Cranelift/LLVM backend). Adequate for I/O-bound plugin workloads like
+  config/transform/store operations.
+- **Single-threaded WASM execution** — WASM is inherently single-threaded.
+  A host function call from the WASM module blocks the module's execution
+  until the host returns.
+
+### Verdict for zhi
+
+**Strong fit.** wazero's zero-dependency, pure-Go nature is a direct match
+for zhi's build philosophy. The lack of WASI P2 is not a blocker because
+zhi's plugin ABI will be defined via custom host functions anyway — not
+through WASI system interfaces.
+
+---
+
+## 2. wasmtime-go
+
+**Repository:** https://github.com/bytecodealliance/wasmtime-go
+**License:** Apache-2.0
+
+### Overview
+
+Go bindings to the Wasmtime runtime (written in Rust), exposed via a C API
+and consumed through CGO.
+
+### Strengths
+
+- **Best-in-class performance** — Cranelift AOT compiler produces
+  near-native execution speed. Matters for CPU-bound workloads.
+- **WASI Preview 2 + Component Model** — Leading implementation of the
+  latest WASI standards. Supports WIT interfaces and component composition.
+- **Industry backing** — Maintained by the Bytecode Alliance (Fastly,
+  Mozilla, Intel, etc.).
+- **Full WASI coverage** — Sockets, filesystem, clocks, random — all
+  specified WASI P1 functions implemented plus P2 additions.
+
+### Limitations
+
+- **Requires CGO** — This is the fundamental disqualifier for zhi. The
+  project builds with `CGO_ENABLED=0` across all targets. Introducing CGO
+  would break cross-compilation, increase binary size by ~38 MB, require
+  a C toolchain in CI, and add platform-specific shared library concerns.
+- **Complex build chain** — Cross-compiling for linux/darwin × amd64/arm64
+  with CGO requires per-target C toolchains (gcc-aarch64-linux-gnu, etc.).
+- **Larger binaries** — ~38 MB footprint (full Wasmtime engine).
+- **Less Go-idiomatic API** — The Go API wraps C types, leading to
+  less natural error handling and memory management patterns.
+
+### Verdict for zhi
+
+**Disqualified.** The CGO requirement is a hard conflict with zhi's static
+linking policy. If this constraint were relaxed in the future, wasmtime-go
+would be worth revisiting for its P2 support and performance.
+
+---
+
+## 3. Extism
+
+**Repository:** https://github.com/extism/go-sdk
+**License:** BSD-3-Clause
+**Latest release:** v1.7.0 (March 2025)
+
+### Overview
+
+Extism is a high-level WebAssembly plugin framework that provides a
+standardized ABI for host↔plugin communication. The Go SDK is built on
+wazero (since v1.0, the Go SDK was rewritten from C bindings to pure
+wazero).
+
+### Strengths
+
+- **Pure Go (wazero underneath)** — No CGO. Inherits wazero's
+  cross-compilation story.
+- **Batteries-included plugin ABI** — Provides memory management (alloc/free),
+  input/output buffers, persistent module-scope variables, host function
+  linking, and host-controlled HTTP without WASI.
+- **Multi-language PDKs** — Plugin Development Kits exist for Go, Rust,
+  C, JavaScript, Python, Ruby, and more. Plugin authors write in their
+  preferred language.
+- **CompiledPlugin for concurrency** — Thread-safe compiled module that can
+  produce instances per-call.
+- **Runtime limiters** — Built-in execution timeouts and fuel-based
+  instruction counting.
+- **Production adoption** — Used by Navidrome (2026), Zed IDE, and others.
+
+### Limitations
+
+- **Opinionated ABI** — Extism defines its own calling convention
+  (input→function→output via shared memory). This is convenient but adds
+  a layer between zhi's interfaces and the WASM module. Mapping zhi's
+  multi-method plugin interfaces (e.g., store.Plugin with 20+ methods) onto
+  Extism's single-function-call model requires multiplexing.
+- **Additional dependency** — Adds Extism as a dependency on top of wazero.
+  Given zhi already has a well-defined plugin ABI (proto-based), the added
+  abstraction may not justify the extra dependency.
+- **Less control** — Extism manages the WASM module lifecycle. For advanced
+  scenarios (multiple instances, custom memory layouts, fine-grained
+  capability control), direct wazero gives more flexibility.
+- **Host function limitations** — While Extism supports host functions,
+  they must conform to Extism's memory model. Complex bidirectional protocols
+  (like the UI Controller callback) would be awkward.
+
+### Verdict for zhi
+
+**Viable but unnecessary.** Extism is excellent for projects that want a
+turnkey plugin system. zhi already has a well-structured plugin architecture
+with defined interfaces, gRPC proto definitions, and a registry system.
+Using wazero directly gives us more control over the ABI and avoids adding
+a framework dependency for functionality we can implement ourselves.
+
+Extism could be reconsidered if multi-language PDK support becomes a high
+priority — their PDKs are polished and well-maintained.
+
+---
+
+## 4. knqyf263/go-plugin
+
+**Repository:** https://github.com/knqyf263/go-plugin
+**License:** Apache-2.0
+**Latest release:** v0.8.0 (March 2025)
+
+### Overview
+
+A Go plugin system built on wazero that auto-generates host and plugin SDKs
+from Protocol Buffers definitions. Inspired by hashicorp/go-plugin but
+communicates via in-memory WASM function calls instead of gRPC.
+
+### Strengths
+
+- **Proto-based code generation** — This is directly relevant to zhi, which
+  already defines its plugin interfaces in `.proto` files. In theory,
+  go-plugin could generate the WASM host/plugin stubs from zhi's existing
+  proto definitions.
+- **Familiar model** — The generated code produces Go interfaces on both
+  sides, similar to hashicorp/go-plugin's dispensing model.
+- **Pure Go (wazero underneath)** — No CGO.
+- **Host functions via proto** — Define host-provided services as proto
+  services with a `// go:plugin type=host` annotation.
+
+### Limitations
+
+- **Immature** — v0.8.0, pre-1.0. API may change. Significantly less
+  adoption than wazero or Extism.
+- **Code generation coupling** — Requires a custom `protoc-gen-go-plugin`
+  generator. This adds build toolchain complexity and creates a dependency
+  on the project's specific code generation approach.
+- **Opaque runtime control** — Like Extism, it wraps wazero and manages
+  module lifecycle. Less flexibility for custom sandboxing and capability
+  grants.
+- **Proto compatibility** — Uses a customized protobuf-go and vtprotobuf
+  fork. Unclear how well this interacts with zhi's existing proto
+  generation pipeline (`make proto`).
+- **Limited documentation** — Fewer examples and less community support
+  than wazero or Extism.
+
+### Verdict for zhi
+
+**Interesting but too immature and opaque.** The proto-based approach is
+appealing given zhi's existing proto definitions, but the pre-1.0 status,
+custom code generation, and limited flexibility make it risky. If the
+project matures and stabilizes, it could be a compelling option for
+auto-generating the WASM ABI from zhi's protos.
+
+---
+
+## Recommendation
+
+### Primary: wazero (direct)
+
+Use **wazero directly** as the WASM runtime, without an intermediate
+framework.
+
+**Rationale:**
+
+| Criterion | wazero | wasmtime-go | Extism | go-plugin |
+|-----------|--------|-------------|--------|-----------|
+| No CGO required | Yes | **No** | Yes | Yes |
+| API stability | Stable (v1.0+) | Stable | Stable | Pre-1.0 |
+| Binary size impact | ~5.5 MB | ~38 MB | ~5.5 MB | ~5.5 MB |
+| Control over ABI | **Full** | Full | Limited | Limited |
+| Control over sandbox | **Full** | Full | Limited | Limited |
+| Cross-compilation | Trivial | Complex | Trivial | Trivial |
+| WASI P2 support | No | **Yes** | No | No |
+| Go ecosystem fit | **Native** | CGO wrapper | Framework | Framework |
+
+wazero provides the right level of abstraction: low enough to define a
+custom ABI that maps cleanly to zhi's plugin interfaces, and high enough
+to avoid raw WASM instruction manipulation. The lack of WASI P2 is
+irrelevant because zhi's host functions define the plugin contract, not
+WASI system interfaces.
+
+### Future consideration: Extism
+
+If demand grows for plugins written in Rust, C, JavaScript, or other
+languages, Extism's multi-language PDKs become attractive. At that point,
+Extism could be adopted as an *optional alternative runtime* alongside
+direct wazero, since both use wazero under the hood and can coexist.
+
+### WASI P2/P3 outlook
+
+WASI Preview 2 (component model) stabilized in late 2024 but wazero has
+no plans to implement it. WASI 0.3 (async) is expected around mid-2026,
+and Go's `GOOS=wasip3` proposal would make goroutine-based plugins viable.
+This is worth monitoring but does not block the initial implementation.
+When wazero or the Go ecosystem adds P2/P3 support, the ABI can be
+evolved to take advantage of typed interfaces (WIT) while maintaining
+backward compatibility with the P1-based ABI.

--- a/docs/plans/wasm/02-architecture.md
+++ b/docs/plans/wasm/02-architecture.md
@@ -1,0 +1,357 @@
+# 02 — Architecture
+
+This document describes how WASM plugins integrate into zhi's existing
+plugin architecture. The design goal is minimal disruption: the engine,
+registry, workspace configuration, and CLI should treat WASM plugins as
+just another plugin format, not a separate subsystem.
+
+## Current Architecture (Recap)
+
+```
+┌─────────────────────────────────────────────┐
+│                   Engine                     │
+│  ┌─────────┐ ┌───────────┐ ┌─────────┐     │
+│  │ Config  │ │ Transform │ │  Store  │     │
+│  │ Plugin  │ │  Plugin   │ │ Plugin  │     │
+│  └────┬────┘ └─────┬─────┘ └────┬────┘     │
+│       │             │            │           │
+│  ┌────┴─────────────┴────────────┴────┐     │
+│  │            Registry                │     │
+│  │  built-in factories + externals    │     │
+│  └────┬───────────────────────────────┘     │
+│       │                                      │
+│  ┌────┴────────────────────┐                │
+│  │    Launch (go-plugin)   │                │
+│  │  binary → subprocess    │                │
+│  │  → gRPC over stdio     │                │
+│  └─────────────────────────┘                │
+└─────────────────────────────────────────────┘
+```
+
+External plugins are native binaries launched as subprocesses via
+hashicorp/go-plugin. Communication is gRPC over stdio.
+
+## Proposed Architecture (with WASM)
+
+```
+┌───────────────────────────────────────────────────┐
+│                      Engine                        │
+│  ┌─────────┐ ┌───────────┐ ┌─────────┐ ┌────┐   │
+│  │ Config  │ │ Transform │ │  Store  │ │ UI │   │
+│  │ Plugin  │ │  Plugin   │ │ Plugin  │ │Plug│   │
+│  └────┬────┘ └─────┬─────┘ └────┬────┘ └──┬─┘   │
+│       │             │            │          │      │
+│  ┌────┴─────────────┴────────────┴──────────┴──┐  │
+│  │                 Registry                     │  │
+│  │  built-in factories + externals + wasm       │  │
+│  └──┬──────────────────────────────────┬───────┘  │
+│     │                                  │          │
+│  ┌──┴────────────────┐  ┌──────────────┴───────┐  │
+│  │ Launch (go-plugin)│  │  WASMLoader (wazero) │  │
+│  │ binary→subprocess │  │  .wasm → in-process  │  │
+│  │ → gRPC over stdio │  │  → host fn calls     │  │
+│  └───────────────────┘  └──────────────────────┘  │
+└───────────────────────────────────────────────────┘
+```
+
+The key addition is a **WASMLoader** that sits alongside the existing
+Launch mechanism. WASM plugins are loaded **in-process** (no subprocess,
+no gRPC) via wazero, with host functions providing the bridge between the
+WASM module and zhi's Go interfaces.
+
+## Discovery
+
+### File naming
+
+WASM plugins follow the same naming conventions as native plugins, with
+a `.wasm` extension:
+
+**Flat naming:**
+```
+~/.zhi/plugins/zhi-config-pokedex.wasm    → config plugin "pokedex"
+~/.zhi/plugins/zhi-transform-encrypt.wasm → transform plugin "encrypt"
+~/.zhi/plugins/zhi-store-memory.wasm      → store plugin "memory"
+~/.zhi/plugins/zhi-ui-http.wasm           → UI plugin "http"
+```
+
+**Subdirectory layout:**
+```
+~/.zhi/plugins/config/pokedex.wasm
+~/.zhi/plugins/transform/encrypt.wasm
+~/.zhi/plugins/store/memory.wasm
+~/.zhi/plugins/ui/http.wasm
+```
+
+### Changes to `discovery.go`
+
+The existing `Discover()` function checks `isExecutable()` for native
+binaries. For WASM, we add a parallel check for `.wasm` files:
+
+```go
+// PluginInfo gains a Format field.
+type PluginInfo struct {
+    Name   string
+    Type   PluginType
+    Path   string
+    Format PluginFormat  // new
+}
+
+type PluginFormat int
+
+const (
+    PluginFormatNative PluginFormat = iota
+    PluginFormatWASM
+)
+```
+
+Discovery logic for flat naming becomes:
+
+```go
+func parseFlatName(name string) (PluginType, string, PluginFormat, bool) {
+    // Strip .wasm suffix if present.
+    format := PluginFormatNative
+    base := name
+    if strings.HasSuffix(name, ".wasm") {
+        format = PluginFormatWASM
+        base = strings.TrimSuffix(name, ".wasm")
+    }
+    // ... existing prefix parsing on `base` ...
+    return pluginType, pluginName, format, true
+}
+```
+
+Native and WASM plugins with the same type+name are a conflict. If both
+`zhi-config-pokedex` and `zhi-config-pokedex.wasm` exist, the native
+binary takes precedence (matching the existing "flat before subdirectory"
+precedence rule). A warning is logged.
+
+### Changes to `registry.go`
+
+The `launchExternal*` methods dispatch based on `PluginInfo.Format`:
+
+```go
+func (r *Registry) launchExternalConfig(name string) (config.Plugin, error) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+
+    if p, ok := r.cachedConfig[name]; ok {
+        return p, nil
+    }
+
+    info, ok := r.findExternal(name, PluginTypeConfig)
+    if !ok {
+        return nil, fmt.Errorf("unknown config provider: %q", name)
+    }
+
+    var p config.Plugin
+    var cleanup func()
+    var err error
+
+    switch info.Format {
+    case PluginFormatNative:
+        p, cleanup, err = LaunchConfig(info.Path)
+    case PluginFormatWASM:
+        p, cleanup, err = LoadWASMConfig(info.Path)
+    }
+    // ... cache and return ...
+}
+```
+
+## WASMLoader
+
+The new `pkg/zhiplugin/wasmloader/` package provides the WASM equivalent
+of `pkg/zhiplugin/launch/`:
+
+```go
+package wasmloader
+
+// LoadConfig loads a .wasm file and returns a config.Plugin backed by WASM.
+func LoadConfig(wasmPath string, opts ...Option) (config.Plugin, func(), error)
+
+// LoadTransform loads a .wasm file and returns a transform.Plugin backed by WASM.
+func LoadTransform(wasmPath string, opts ...Option) (transform.Plugin, func(), error)
+
+// LoadStore loads a .wasm file and returns a store.Plugin backed by WASM.
+func LoadStore(wasmPath string, opts ...Option) (store.Plugin, func(), error)
+
+// LoadUI loads a .wasm file and returns a ui.Plugin backed by WASM.
+func LoadUI(wasmPath string, opts ...Option) (ui.Plugin, func(), error)
+```
+
+Each function:
+
+1. Reads and compiles the `.wasm` file via `wazero.NewRuntime()` +
+   `runtime.CompileModule()`.
+2. Instantiates the host module with the host functions for that plugin
+   type (see [03-host-functions-abi.md](03-host-functions-abi.md)).
+3. Optionally instantiates `wasi_snapshot_preview1` if the WASM module
+   imports WASI functions (for plugins built with `GOOS=wasip1`).
+4. Instantiates the WASM module.
+5. Returns an adapter that implements the Go plugin interface by calling
+   the module's exported functions.
+
+The `cleanup` function closes the wazero runtime and releases resources.
+
+### Module lifecycle
+
+```
+ Load .wasm file
+       │
+       ▼
+ wazero.CompileModule()      ← validates + AOT compiles
+       │
+       ▼
+ Instantiate host module     ← register host functions
+       │
+       ▼
+ Instantiate wasi (optional) ← if module imports wasi_snapshot_preview1
+       │
+       ▼
+ Instantiate plugin module   ← links imports, runs _start or _initialize
+       │
+       ▼
+ Return adapter + cleanup
+```
+
+### Compiled module caching
+
+wazero's `CompiledModule` is reusable and thread-safe. If the same `.wasm`
+file is loaded multiple times (e.g., multiple workspaces using the same
+plugin), the compiled module can be cached and only instantiation (which is
+cheap) is repeated.
+
+```go
+type moduleCache struct {
+    mu       sync.Mutex
+    compiled map[string]wazero.CompiledModule // keyed by file hash
+}
+```
+
+## Workspace Configuration
+
+WASM plugins are referenced in `zhi.yaml` identically to native plugins.
+The format is transparent to workspace authors:
+
+```yaml
+config:
+  provider: pokedex
+  # The registry resolves "pokedex" to either a native binary
+  # or a .wasm file — the user doesn't need to know which.
+
+transforms:
+  - provider: encrypt
+```
+
+### Explicit WASM capabilities
+
+When a WASM plugin needs filesystem or network access beyond the default
+sandbox, the workspace configuration grants capabilities:
+
+```yaml
+config:
+  provider: my-file-reader
+  options:
+    directory: ./configs
+  wasm:
+    capabilities:
+      fs:
+        - path: ./configs
+          mode: read
+```
+
+See [04-security-model.md](04-security-model.md) for the full capability
+model.
+
+## Package Structure
+
+New packages:
+
+```
+pkg/zhiplugin/wasmloader/
+├── loader.go          # LoadConfig, LoadTransform, LoadStore, LoadUI
+├── options.go         # WithLogger, WithCapabilities, etc.
+├── runtime.go         # wazero runtime management, module cache
+├── host_config.go     # Host functions for config plugins
+├── host_transform.go  # Host functions for transform plugins
+├── host_store.go      # Host functions for store plugins
+├── host_ui.go         # Host functions for UI plugins
+├── adapter_config.go  # config.Plugin adapter (calls WASM exports)
+├── adapter_transform.go
+├── adapter_store.go
+├── adapter_ui.go
+├── memory.go          # Shared memory helpers (alloc/free, JSON serde)
+└── loader_test.go
+```
+
+## OCI Distribution
+
+WASM `.wasm` files are single-platform artifacts — no cross-compilation
+needed. The existing OCI distribution pipeline
+(`zhi plugin publish` / `zhi plugin install`) gains WASM support:
+
+```yaml
+# zhi-plugin.yaml for a WASM plugin
+name: pokedex
+type: config
+format: wasm
+binaries:
+  - os: any
+    arch: any
+    path: bin/zhi-config-pokedex.wasm
+```
+
+The `os: any, arch: any` platform signals that this is a universal
+artifact. `zhi plugin install` detects the `.wasm` extension and places it
+in the appropriate plugin directory with the correct naming.
+
+See also the existing `pkg/sharing/` code for manifest and OCI client
+details.
+
+## Interaction with Meta-Plugin SDK
+
+Meta-plugins (plugins that compose child plugins via
+`pkg/zhiplugin/launch/`) currently only launch native binaries. The
+meta-plugin SDK would gain WASM-aware variants:
+
+```go
+// In pkg/zhiplugin/launch/
+func LaunchOrLoadConfig(path string, opts ...Option) (config.Plugin, func(), error) {
+    if strings.HasSuffix(path, ".wasm") {
+        return wasmloader.LoadConfig(path, toWASMOpts(opts)...)
+    }
+    return LaunchConfig(path, opts...)
+}
+```
+
+This allows meta-plugins to compose both native and WASM child plugins
+transparently.
+
+## Error Handling
+
+WASM module panics are caught by the wazero runtime and surfaced as Go
+errors — they never crash the host process. This is a significant safety
+improvement over native plugins, where a segfault in the subprocess
+terminates the gRPC connection but doesn't affect the host.
+
+Error categories:
+
+| Error | Source | Handling |
+|-------|--------|----------|
+| Module compilation failure | Invalid `.wasm` file | Return error from Load* |
+| Missing required export | Plugin doesn't export expected function | Return error from Load* |
+| WASM trap (panic, OOB, etc.) | Plugin runtime error | Caught by wazero, returned as Go error |
+| Host function error | Error in host-provided function | Returned to WASM via error protocol |
+| Timeout | Plugin exceeds execution limit | wazero fuel/deadline cancellation |
+| OOM | Plugin exceeds memory limit | wazero memory limit enforcement |
+
+## Backward Compatibility
+
+This design is **fully backward-compatible**:
+
+- Existing native gRPC plugins work unchanged.
+- No changes to the handshake protocol or gRPC transport.
+- No changes to the `zhi-plugin.yaml` manifest format (only new optional
+  fields).
+- Workspace `zhi.yaml` files that reference native plugins work unchanged.
+- The `PluginInfo.Format` field defaults to `PluginFormatNative` if
+  unset, preserving existing behavior.

--- a/docs/plans/wasm/03-host-functions-abi.md
+++ b/docs/plans/wasm/03-host-functions-abi.md
@@ -1,0 +1,525 @@
+# 03 — Host Functions ABI
+
+This document specifies the Application Binary Interface (ABI) between the
+zhi host process and WASM plugin modules. The ABI defines:
+
+1. How the host calls into the WASM module (exported functions)
+2. How the WASM module calls back to the host (imported host functions)
+3. How complex data (strings, JSON, errors) is passed across the boundary
+
+## Design Principles
+
+1. **JSON on the wire** — All structured data crosses the WASM boundary as
+   JSON-encoded bytes, matching the existing gRPC layer's use of
+   JSON-encoded values. This keeps the ABI language-agnostic.
+
+2. **One export per method** — Each method in the Go plugin interface maps
+   to one WASM export. This avoids multiplexing complexity and makes the
+   ABI self-documenting.
+
+3. **Error protocol** — Functions return a status code. On error, the error
+   message is written to a shared buffer readable by the host.
+
+4. **Host-managed memory** — The host allocates memory in the WASM module
+   for passing data in. The WASM module exports `malloc` and `free`
+   functions for this purpose (standard with `GOOS=wasip1` and TinyGo).
+
+## Memory Protocol
+
+WASM linear memory is a flat byte array. Passing complex data (strings,
+JSON objects) requires a shared convention for allocation and deallocation.
+
+### Required module exports
+
+Every WASM plugin must export:
+
+```
+malloc(size: i32) -> ptr: i32
+free(ptr: i32, size: i32)
+```
+
+These are automatically provided by Go's `wasip1` target and TinyGo. For
+Rust plugins, `#[no_mangle]` wrappers around the allocator are needed.
+
+### Data passing convention
+
+**Host → Plugin (input):**
+1. Host serializes input to JSON bytes.
+2. Host calls `malloc(len)` in the WASM module to get a pointer.
+3. Host writes JSON bytes into WASM memory at that pointer.
+4. Host calls the exported function with `(ptr, len)` parameters.
+5. Plugin reads from its own memory, deserializes JSON.
+
+**Plugin → Host (output):**
+1. Plugin serializes output to JSON bytes.
+2. Plugin writes to a preallocated output buffer or calls a host-provided
+   `host_set_output(ptr, len)` function.
+3. Host reads the bytes from WASM memory after the function returns.
+
+**Error reporting:**
+1. Each exported function returns an `i32` status: `0` = success, `1` = error.
+2. On error, the plugin calls `host_set_error(ptr, len)` with a UTF-8
+   error message before returning.
+
+### Shared buffer pattern
+
+To avoid complex multi-return conventions, the ABI uses a "shared output"
+pattern:
+
+```
+host module "zhi":
+    host_set_output(ptr: i32, len: i32)     // plugin writes result here
+    host_set_error(ptr: i32, len: i32)      // plugin writes error here
+```
+
+The host reads the last-set output/error after the exported function
+returns. This is a common pattern in WASM plugin systems (used by Extism,
+knqyf263/go-plugin, and others).
+
+---
+
+## Config Plugin ABI
+
+The `config.Plugin` interface has 4 methods:
+
+### Exports (plugin provides)
+
+```
+zhi_config_list()                           -> i32 (status)
+zhi_config_get(path_ptr: i32, path_len: i32) -> i32 (status)
+zhi_config_set(req_ptr: i32, req_len: i32)   -> i32 (status)
+zhi_config_validate(req_ptr: i32, req_len: i32) -> i32 (status)
+```
+
+### Imports (host provides)
+
+```
+module "zhi":
+    host_set_output(ptr: i32, len: i32)
+    host_set_error(ptr: i32, len: i32)
+    host_log(level: i32, ptr: i32, len: i32)  // optional: structured logging
+```
+
+### Data formats
+
+**`zhi_config_list`:**
+- Input: none
+- Output (via `host_set_output`): `["path/one", "path/two", ...]`
+
+**`zhi_config_get`:**
+- Input: path as raw UTF-8 string (not JSON)
+- Output: `{"found": true, "value": <json>, "metadata": <json>}` or
+  `{"found": false}`
+
+**`zhi_config_set`:**
+- Input:
+  ```json
+  {
+    "path": "database/host",
+    "value": "localhost",
+    "metadata": {"source": "user"}
+  }
+  ```
+- Output: none (status 0 = success)
+
+**`zhi_config_validate`:**
+- Input:
+  ```json
+  {
+    "path": "database/host",
+    "tree": {
+      "database/host": {"value": "localhost", "metadata": {}},
+      "database/port": {"value": 5432, "metadata": {}}
+    }
+  }
+  ```
+  The `tree` field is a flat map providing the full `TreeReader` view.
+- Output:
+  ```json
+  [
+    {"path": "database/host", "severity": "blocking", "message": "host required"}
+  ]
+  ```
+
+### Host-side adapter
+
+The host creates a Go struct that implements `config.Plugin` by calling
+the WASM exports:
+
+```go
+type wasmConfigAdapter struct {
+    module wazero.Module
+    // ... wazero function references
+}
+
+func (a *wasmConfigAdapter) List(ctx context.Context) ([]string, error) {
+    status := a.callExport(ctx, "zhi_config_list", nil)
+    if status != 0 {
+        return nil, a.lastError()
+    }
+    var paths []string
+    json.Unmarshal(a.lastOutput(), &paths)
+    return paths, nil
+}
+
+func (a *wasmConfigAdapter) Get(ctx context.Context, path string) (Value, bool, error) {
+    status := a.callExport(ctx, "zhi_config_get", []byte(path))
+    // ... deserialize output
+}
+```
+
+---
+
+## Transform Plugin ABI
+
+The `transform.Plugin` interface has 3 methods:
+
+### Exports (plugin provides)
+
+```
+zhi_transform_before_display(tree_ptr: i32, tree_len: i32) -> i32
+zhi_transform_after_save(tree_ptr: i32, tree_len: i32)     -> i32
+zhi_transform_validate_policy()                              -> i32
+```
+
+### Data formats
+
+**`zhi_transform_before_display` / `zhi_transform_after_save`:**
+- Input: The full tree as a JSON object:
+  ```json
+  {
+    "database/host": {"value": "localhost", "metadata": {}},
+    "database/port": {"value": 5432, "metadata": {}}
+  }
+  ```
+- Output: The mutated tree in the same format. The host replaces the
+  tree contents with the returned value.
+
+Transform plugins receive and return the full tree because they need
+mutable access. This is consistent with the gRPC layer, which also
+serializes the entire tree.
+
+**`zhi_transform_validate_policy`:**
+- Input: none
+- Output: `{"policy": "before"}` | `{"policy": "after"}` | `{"policy": "both"}`
+
+---
+
+## Store Plugin ABI
+
+The `store.Plugin` interface has 23 methods. Each maps to a WASM export:
+
+### Exports (plugin provides)
+
+```
+// Capabilities
+zhi_store_capabilities()                                    -> i32
+
+// Authentication
+zhi_store_auth_methods()                                    -> i32
+zhi_store_login(req_ptr: i32, req_len: i32)                -> i32
+zhi_store_login_interactive(req_ptr: i32, req_len: i32)    -> i32
+zhi_store_login_interactive_cb(req_ptr: i32, req_len: i32) -> i32
+
+// Tree management
+zhi_store_list_trees()                                      -> i32
+zhi_store_delete_tree(req_ptr: i32, req_len: i32)          -> i32
+
+// Value operations
+zhi_store_get_values(req_ptr: i32, req_len: i32)           -> i32
+zhi_store_put_values(req_ptr: i32, req_len: i32)           -> i32
+zhi_store_delete_values(req_ptr: i32, req_len: i32)        -> i32
+
+// Tree-level versioning
+zhi_store_list_tree_versions(req_ptr: i32, req_len: i32)   -> i32
+zhi_store_get_tree_version(req_ptr: i32, req_len: i32)     -> i32
+zhi_store_rollback_tree(req_ptr: i32, req_len: i32)        -> i32
+zhi_store_delete_tree_version(req_ptr: i32, req_len: i32)  -> i32
+
+// Value-level versioning
+zhi_store_list_value_versions(req_ptr: i32, req_len: i32)  -> i32
+zhi_store_get_value_version(req_ptr: i32, req_len: i32)    -> i32
+zhi_store_rollback_value(req_ptr: i32, req_len: i32)       -> i32
+zhi_store_delete_value_version(req_ptr: i32, req_len: i32) -> i32
+
+// Encryption
+zhi_store_init_encryption(req_ptr: i32, req_len: i32)      -> i32
+zhi_store_rotate_encryption(req_ptr: i32, req_len: i32)    -> i32
+
+// Access control
+zhi_store_grant_access(req_ptr: i32, req_len: i32)         -> i32
+zhi_store_revoke_access(req_ptr: i32, req_len: i32)        -> i32
+zhi_store_list_access(req_ptr: i32, req_len: i32)          -> i32
+```
+
+### Host functions for store plugins
+
+Store plugins need to interact with external systems (filesystems,
+network services like Vault). Since WASM has no direct access, the host
+provides capability-gated functions:
+
+```
+module "zhi_store":
+    // Filesystem (if fs capability granted)
+    host_fs_read(path_ptr: i32, path_len: i32)  -> i32
+    host_fs_write(req_ptr: i32, req_len: i32)   -> i32
+    host_fs_list(path_ptr: i32, path_len: i32)  -> i32
+    host_fs_delete(path_ptr: i32, path_len: i32) -> i32
+    host_fs_mkdir(path_ptr: i32, path_len: i32)  -> i32
+    host_fs_stat(path_ptr: i32, path_len: i32)   -> i32
+
+    // HTTP (if network capability granted)
+    host_http_request(req_ptr: i32, req_len: i32) -> i32
+```
+
+**Filesystem host functions** are scoped to allowed directories (see
+[04-security-model.md](04-security-model.md)). Paths outside granted
+directories return an error.
+
+**HTTP host function** input:
+```json
+{
+  "method": "GET",
+  "url": "https://vault.example.com/v1/secret/data/myapp",
+  "headers": {"X-Vault-Token": "s.xxxxx"},
+  "body": null
+}
+```
+Output:
+```json
+{
+  "status": 200,
+  "headers": {"Content-Type": "application/json"},
+  "body": "{...}"
+}
+```
+
+HTTP requests are subject to URL allowlisting from the capability config.
+
+### Example: in-memory store (no capabilities needed)
+
+A simple in-memory store plugin needs no filesystem or network access.
+It stores all data in WASM linear memory. This is the simplest store
+plugin case and requires zero host function calls beyond the standard ABI.
+
+### Example: file-based store (filesystem capability)
+
+A JSON-file store plugin needs `host_fs_read` and `host_fs_write` to
+persist data. The workspace grants:
+
+```yaml
+store:
+  provider: json-file
+  wasm:
+    capabilities:
+      fs:
+        - path: ./data
+          mode: readwrite
+```
+
+### Example: Vault store (network capability)
+
+A Vault-backed store needs `host_http_request` to talk to the Vault API.
+The workspace grants:
+
+```yaml
+store:
+  provider: vault
+  wasm:
+    capabilities:
+      net:
+        - host: vault.example.com
+          port: 8200
+          scheme: https
+```
+
+---
+
+## UI Plugin ABI
+
+UI plugins are the most complex because they use bidirectional
+communication: the host calls `Run()` on the plugin, and the plugin calls
+back into the host via the `Controller` interface.
+
+### Exports (plugin provides)
+
+```
+zhi_ui_run()             -> i32
+zhi_ui_capabilities()    -> i32
+```
+
+### Imports (host provides — Controller)
+
+The `Controller` interface is exposed as host functions that the plugin
+can call during `zhi_ui_run()`:
+
+```
+module "zhi_ui":
+    // Core
+    host_ctrl_load_tree()                                    -> i32
+    host_ctrl_set_value(req_ptr: i32, req_len: i32)         -> i32
+    host_ctrl_validate()                                     -> i32
+    host_ctrl_save_tree()                                    -> i32
+
+    // Export/Apply
+    host_ctrl_export_templates()                              -> i32
+    host_ctrl_export(req_ptr: i32, req_len: i32)             -> i32
+    host_ctrl_apply(req_ptr: i32, req_len: i32)              -> i32
+
+    // Components
+    host_ctrl_list_components()                               -> i32
+    host_ctrl_enable_component(name_ptr: i32, name_len: i32) -> i32
+    host_ctrl_disable_component(name_ptr: i32, name_len: i32)-> i32
+    host_ctrl_workspace_name()                                -> i32
+
+    // Marketplace
+    host_ctrl_search_marketplace(req_ptr: i32, req_len: i32) -> i32
+    host_ctrl_marketplace_detail(req_ptr: i32, req_len: i32) -> i32
+    host_ctrl_install_plugin(ref_ptr: i32, ref_len: i32)     -> i32
+    host_ctrl_uninstall_plugin(req_ptr: i32, req_len: i32)   -> i32
+    host_ctrl_list_installed()                                 -> i32
+    host_ctrl_check_updates()                                  -> i32
+    host_ctrl_update_plugin(req_ptr: i32, req_len: i32)       -> i32
+    host_ctrl_rate_plugin(req_ptr: i32, req_len: i32)         -> i32
+
+    // Store auth
+    host_ctrl_store_auth_methods()                             -> i32
+    host_ctrl_store_login(req_ptr: i32, req_len: i32)         -> i32
+    host_ctrl_store_login_interactive(req_ptr: i32, req_len: i32)    -> i32
+    host_ctrl_store_login_interactive_cb(req_ptr: i32, req_len: i32) -> i32
+    host_ctrl_store_auth_status()                              -> i32
+    host_ctrl_store_logout()                                   -> i32
+```
+
+All host functions use the same output/error convention: the result is
+read via `host_set_output` after the function returns status `0`.
+
+### Apply streaming
+
+The `Apply` method in the Go Controller interface takes a callback for
+streaming events. In the WASM ABI, streaming is modeled differently:
+
+**Option A: Polled iteration**
+```
+host_ctrl_apply_start(req_ptr: i32, req_len: i32) -> i32  // start apply
+host_ctrl_apply_next()                              -> i32  // get next event
+host_ctrl_apply_result()                            -> i32  // get final result
+```
+
+The plugin calls `apply_start`, then loops calling `apply_next` until it
+returns a status indicating completion, then calls `apply_result`.
+
+**Option B: Callback host function**
+
+The plugin exports `zhi_ui_apply_event(event_ptr: i32, event_len: i32)`
+which the host calls for each event during apply execution.
+
+Option A is simpler and avoids re-entrant calls into the WASM module.
+**Recommended: Option A.**
+
+### TTY limitation
+
+WASM plugins have no terminal access. `Capabilities()` for WASM UI
+plugins always reports `RequiresTTY: false`. This means WASM UI plugins
+are limited to:
+
+- HTTP-based UIs (like `zhi-ui-http`)
+- Headless/API UIs
+- Any UI that doesn't need direct terminal I/O
+
+If a WASM UI plugin needs to listen on a network port (for HTTP), the
+host provides:
+
+```
+module "zhi_ui":
+    host_http_listen(req_ptr: i32, req_len: i32) -> i32
+    host_http_accept() -> i32
+    host_http_respond(req_ptr: i32, req_len: i32) -> i32
+```
+
+This is a stretch goal and not required for the initial implementation.
+
+---
+
+## ABI Versioning
+
+The host module name includes a version suffix:
+
+```
+module "zhi_v1":
+    host_set_output(...)
+    host_set_error(...)
+    host_log(...)
+```
+
+WASM plugins import from `zhi_v1`. Future incompatible ABI changes
+increment to `zhi_v2`, etc. The host can serve multiple ABI versions
+simultaneously to maintain backward compatibility.
+
+The plugin module must also export a version function:
+
+```
+zhi_abi_version() -> i32
+```
+
+Returns `1` for the initial ABI. The host checks this before calling any
+other export and rejects modules with unsupported ABI versions.
+
+---
+
+## Summary: Export/Import Table
+
+### Config Plugin
+
+| Direction | Function | Purpose |
+|-----------|----------|---------|
+| Export | `zhi_abi_version` | ABI version check |
+| Export | `malloc` | Memory allocation |
+| Export | `free` | Memory deallocation |
+| Export | `zhi_config_list` | List paths |
+| Export | `zhi_config_get` | Get value |
+| Export | `zhi_config_set` | Set value |
+| Export | `zhi_config_validate` | Validate value |
+| Import | `zhi_v1.host_set_output` | Return results |
+| Import | `zhi_v1.host_set_error` | Return errors |
+| Import | `zhi_v1.host_log` | Logging |
+
+### Transform Plugin
+
+| Direction | Function | Purpose |
+|-----------|----------|---------|
+| Export | `zhi_abi_version` | ABI version check |
+| Export | `malloc` | Memory allocation |
+| Export | `free` | Memory deallocation |
+| Export | `zhi_transform_before_display` | Transform tree for display |
+| Export | `zhi_transform_after_save` | Transform tree after save |
+| Export | `zhi_transform_validate_policy` | Report validation policy |
+| Import | `zhi_v1.host_set_output` | Return results |
+| Import | `zhi_v1.host_set_error` | Return errors |
+| Import | `zhi_v1.host_log` | Logging |
+
+### Store Plugin
+
+| Direction | Function | Purpose |
+|-----------|----------|---------|
+| Export | `zhi_abi_version` | ABI version check |
+| Export | `malloc` / `free` | Memory management |
+| Export | `zhi_store_*` (23 functions) | Store operations |
+| Import | `zhi_v1.host_set_output` | Return results |
+| Import | `zhi_v1.host_set_error` | Return errors |
+| Import | `zhi_v1.host_log` | Logging |
+| Import | `zhi_v1.host_fs_*` (6 functions) | Filesystem (gated) |
+| Import | `zhi_v1.host_http_request` | HTTP client (gated) |
+
+### UI Plugin
+
+| Direction | Function | Purpose |
+|-----------|----------|---------|
+| Export | `zhi_abi_version` | ABI version check |
+| Export | `malloc` / `free` | Memory management |
+| Export | `zhi_ui_run` | Start UI |
+| Export | `zhi_ui_capabilities` | Report capabilities |
+| Import | `zhi_v1.host_set_output` | Return results |
+| Import | `zhi_v1.host_set_error` | Return errors |
+| Import | `zhi_v1.host_log` | Logging |
+| Import | `zhi_v1.host_ctrl_*` (25 functions) | Controller callbacks |

--- a/docs/plans/wasm/04-security-model.md
+++ b/docs/plans/wasm/04-security-model.md
@@ -1,0 +1,308 @@
+# 04 — Security Model
+
+WASM plugins are designed to be a **more secure alternative** to native
+gRPC plugins. This document defines the capability-based sandboxing model
+that enforces the principle of least privilege.
+
+## Threat Model
+
+### Native plugins (current)
+
+A native gRPC plugin is a subprocess with the same OS-level privileges as
+the user running zhi. It can:
+
+- Read/write any file the user can access
+- Open network connections to any host
+- Read environment variables (including secrets)
+- Execute other programs
+- Access hardware devices
+
+The only isolation is process separation (no shared memory with the host).
+Binary auditing (`launch/audit.go`) provides integrity checks but does not
+restrict runtime behavior.
+
+### WASM plugins (proposed)
+
+A WASM plugin runs **in-process** inside the wazero sandbox. By default,
+it can do **nothing** beyond pure computation:
+
+- No filesystem access
+- No network access
+- No environment variables
+- No process spawning
+- No system clock (unless explicitly granted)
+- No access to host memory outside its own linear memory
+
+Every capability must be explicitly granted by the host.
+
+## Capability Model
+
+Capabilities are declared in two places:
+
+1. **`zhi-plugin.yaml`** — The plugin manifest declares what capabilities
+   the plugin *requires*. This is informational and used for display/audit.
+2. **`zhi.yaml`** — The workspace configuration *grants* capabilities to
+   specific plugins. Only granted capabilities are enforced.
+
+### Capability types
+
+```yaml
+wasm:
+  capabilities:
+    # Filesystem access
+    fs:
+      - path: ./data
+        mode: read           # read | readwrite
+      - path: /etc/ssl/certs
+        mode: read
+
+    # Network access
+    net:
+      - host: vault.example.com
+        port: 8200
+        scheme: https
+      - host: "*.internal.company.com"
+        port: 443
+        scheme: https
+
+    # Environment variables
+    env:
+      - VAULT_ADDR
+      - VAULT_TOKEN
+
+    # System clock
+    clock: true
+
+    # Random number generation
+    random: true
+
+    # Stdin/stdout (for debugging)
+    stdio: false
+
+    # Execution limits
+    limits:
+      memory_mb: 64          # max WASM linear memory (default: 32 MB)
+      fuel: 1000000000       # max instructions (0 = unlimited)
+      timeout_seconds: 30    # max wall-clock time per call (0 = unlimited)
+```
+
+### Default capabilities
+
+Plugins receive these capabilities by default (no explicit grant needed):
+
+| Capability | Default | Rationale |
+|------------|---------|-----------|
+| `clock` | `true` | Many operations need timestamps |
+| `random` | `true` | Needed for UUIDs, nonces, etc. |
+| `stdio` | `false` | Disabled by default for security |
+| `fs` | `[]` (none) | Must be explicitly granted |
+| `net` | `[]` (none) | Must be explicitly granted |
+| `env` | `[]` (none) | Must be explicitly granted |
+| `limits.memory_mb` | `32` | Prevents runaway memory use |
+| `limits.fuel` | `0` (unlimited) | Can be set for untrusted plugins |
+| `limits.timeout_seconds` | `30` | Per-method-call timeout |
+
+### Capability enforcement
+
+Each capability maps to a concrete wazero configuration:
+
+**Filesystem:**
+```go
+// If fs capabilities granted, configure WASI with scoped directories.
+fsConfig := wazero.NewFSConfig()
+for _, grant := range caps.FS {
+    absPath := filepath.Join(workspaceDir, grant.Path)
+    switch grant.Mode {
+    case "read":
+        fsConfig = fsConfig.WithReadOnlyDirMount(absPath, grant.Path)
+    case "readwrite":
+        fsConfig = fsConfig.WithDirMount(absPath, grant.Path)
+    }
+}
+moduleConfig = moduleConfig.WithFSConfig(fsConfig)
+```
+
+Additionally, custom `host_fs_*` functions enforce path validation:
+
+```go
+func hostFSRead(ctx context.Context, mod api.Module, pathPtr, pathLen uint32) uint32 {
+    path := readString(mod, pathPtr, pathLen)
+
+    // Resolve to absolute, check against allowed directories.
+    absPath, err := securepath.Resolve(path, allowedDirs)
+    if err != nil {
+        setError(mod, fmt.Sprintf("fs access denied: %s", path))
+        return 1
+    }
+
+    data, err := os.ReadFile(absPath)
+    // ... write to output buffer ...
+}
+```
+
+**Network:**
+```go
+func hostHTTPRequest(ctx context.Context, mod api.Module, reqPtr, reqLen uint32) uint32 {
+    var req httpRequest
+    json.Unmarshal(readBytes(mod, reqPtr, reqLen), &req)
+
+    // Validate URL against allowed hosts.
+    if !isAllowedURL(req.URL, allowedHosts) {
+        setError(mod, fmt.Sprintf("network access denied: %s", req.URL))
+        return 1
+    }
+
+    // Execute request with timeout from context.
+    resp, err := httpClient.Do(req.toHTTP().WithContext(ctx))
+    // ... write response to output buffer ...
+}
+```
+
+**Environment:**
+```go
+// Only pass allowed env vars to the WASM module.
+for _, name := range caps.Env {
+    if val, ok := os.LookupEnv(name); ok {
+        moduleConfig = moduleConfig.WithEnv(name, val)
+    }
+}
+```
+
+**Memory limits:**
+```go
+// wazero enforces memory limits at the runtime level.
+moduleConfig = moduleConfig.WithMemoryLimitPages(caps.Limits.MemoryMB * 16)
+// 1 WASM page = 64 KiB, so 32 MB = 512 pages
+```
+
+**Fuel (instruction counting):**
+```go
+// Fuel limits the number of instructions executed.
+if caps.Limits.Fuel > 0 {
+    // wazero doesn't have built-in fuel metering.
+    // Use context deadline + periodic yield points instead.
+}
+```
+
+Note: wazero does not natively support Wasmtime-style fuel metering.
+Execution limits are enforced primarily via Go context deadlines
+(wall-clock timeouts). If fine-grained instruction counting is needed in
+the future, a metering transform pass on the WASM module can be applied
+at load time using a tool like `wasm-metering`.
+
+**Timeouts:**
+```go
+// Each method call gets a context with deadline.
+ctx, cancel := context.WithTimeout(ctx, time.Duration(caps.Limits.TimeoutSeconds)*time.Second)
+defer cancel()
+```
+
+## Comparison: Native vs WASM Security
+
+| Aspect | Native Plugin | WASM Plugin |
+|--------|---------------|-------------|
+| Execution isolation | Separate process | In-process sandbox |
+| Memory isolation | OS process boundary | WASM linear memory boundary |
+| Filesystem access | Full (user-level) | None by default; scoped grants |
+| Network access | Full | None by default; host-allowlisted |
+| Environment variables | Inherited (or isolated) | None by default; explicit list |
+| Process spawning | Possible | Impossible |
+| System calls | All | Only via host functions |
+| Crash behavior | Subprocess dies; host unaffected | wazero catches trap; host unaffected |
+| Binary integrity | Audit at launch time | Inherent (WASM is validated at load) |
+| Code review | Requires decompiling native code | WASM text format (`.wat`) is readable |
+
+## Plugin Manifest Capabilities
+
+The `zhi-plugin.yaml` manifest declares required capabilities:
+
+```yaml
+# zhi-plugin.yaml
+name: vault-store
+type: store
+format: wasm
+requires:
+  capabilities:
+    net:
+      - description: "Vault API access"
+        host: "*.vault.example.com"
+        port: 8200
+    env:
+      - VAULT_ADDR
+      - VAULT_TOKEN
+    clock: true
+```
+
+### Install-time verification
+
+When `zhi plugin install` installs a WASM plugin, it displays the
+required capabilities and asks for confirmation:
+
+```
+Installing vault-store (WASM plugin)...
+
+This plugin requires the following capabilities:
+  Network: *.vault.example.com:8200
+  Environment: VAULT_ADDR, VAULT_TOKEN
+  Clock: yes
+
+These capabilities must be granted in your workspace zhi.yaml.
+Continue? [y/N]
+```
+
+### Runtime capability mismatch
+
+If a WASM plugin calls a host function for a capability that wasn't
+granted, the host function returns an error immediately. The plugin
+receives an error string; it does not crash or panic. This allows plugins
+to degrade gracefully.
+
+```go
+// Example: plugin calls host_fs_read but no fs capability was granted.
+// Result: error "filesystem access not granted for this plugin"
+```
+
+## Audit Trail
+
+WASM plugin capability usage is logged:
+
+```
+INFO  wasm plugin "vault-store" loaded
+INFO  capabilities granted: net=[vault.example.com:8200], env=[VAULT_ADDR, VAULT_TOKEN]
+DEBUG wasm plugin "vault-store" called host_http_request -> vault.example.com:8200/v1/sys/health
+DEBUG wasm plugin "vault-store" called host_http_request -> vault.example.com:8200/v1/secret/data/myapp
+```
+
+For sensitive operations, the log can record:
+- Which host functions were called and how often
+- Which URLs were accessed
+- Which filesystem paths were read/written
+- Execution time per call
+
+This gives administrators visibility into what WASM plugins actually do
+at runtime, which is superior to native plugins where syscall tracing
+requires external tools like `strace`.
+
+## Future: Code Signing and Verification
+
+WASM modules are deterministic bytecode. This enables:
+
+1. **Content-addressable integrity** — The SHA-256 hash of a `.wasm` file
+   uniquely identifies its behavior. No need for binary auditing heuristics.
+
+2. **Reproducible builds** — Given the same source and toolchain, the
+   `.wasm` output is bitwise identical. This allows third-party verification.
+
+3. **Cosign integration** — WASM artifacts published to OCI registries can
+   be signed with Sigstore/cosign, using the same keyless signing already
+   in the plugin release pipeline.
+
+4. **Allowlisted hashes** — A workspace could pin to specific `.wasm`
+   hashes in `zhi.lock`:
+   ```yaml
+   plugins:
+     - name: vault-store
+       type: store
+       format: wasm
+       digest: sha256:abc123...
+   ```

--- a/docs/plans/wasm/05-plugin-development.md
+++ b/docs/plans/wasm/05-plugin-development.md
@@ -1,0 +1,410 @@
+# 05 — Plugin Development
+
+This document covers how plugin authors build WASM plugins for zhi:
+supported languages, build toolchains, the Plugin Development Kit (PDK),
+and the developer workflow.
+
+## Supported Languages
+
+Any language that compiles to WebAssembly with WASI support can produce
+a zhi plugin. The ABI is language-agnostic (JSON over shared memory).
+However, the quality of the developer experience varies by language:
+
+### Tier 1: Go (primary target)
+
+Go is the natural first choice since zhi itself is Go and most existing
+plugins are Go.
+
+**Toolchains:**
+
+| Toolchain | Binary Size | Stdlib | Reflection | Build Command |
+|-----------|-------------|--------|------------|---------------|
+| Go gc (`GOOS=wasip1`) | ~2.5 MB | Full | Full | `GOOS=wasip1 GOARCH=wasm go build` |
+| TinyGo | ~160 KB–500 KB | Partial | Partial | `tinygo build -target=wasip1` |
+
+**Go gc (standard toolchain) — Recommended for most plugins:**
+- Full standard library support including `encoding/json`, `reflect`, etc.
+- `//go:wasmexport` directive (Go 1.24+) for exporting functions.
+- Reactor mode via `-buildmode=c-shared` for long-lived modules.
+- Larger binary but complete language compatibility.
+
+**TinyGo — Recommended when binary size matters:**
+- Dramatically smaller binaries (5–15× smaller).
+- WASI P2 support (ahead of standard Go).
+- Limited `reflect` support — `encoding/json` may panic at runtime.
+- Not all stdlib packages compile.
+- `recover()` does not work on WASM target.
+
+**Recommendation:** Start with standard Go toolchain for maximum
+compatibility. The PDK should work with both, and plugin authors can
+choose based on their needs.
+
+### Tier 2: Rust
+
+Rust has excellent WASM support and produces small, fast binaries.
+
+- Compile with `--target wasm32-wasip1`.
+- Full control over memory layout.
+- No garbage collector overhead.
+- Requires implementing the ABI manually (JSON serialization, export
+  functions, memory management).
+- Binary sizes typically 100 KB–2 MB.
+
+A Rust PDK crate (`zhi-plugin-sdk`) could be provided in the future
+but is out of scope for the initial implementation.
+
+### Tier 3: C/C++, Zig, AssemblyScript
+
+These languages compile to WASM and could produce zhi plugins, but
+no first-party PDK would be provided initially. The ABI documentation
+and examples should be sufficient for authors using these languages.
+
+## Go Plugin Development Kit (PDK)
+
+The PDK is a Go library that plugin authors import. It handles:
+
+1. ABI boilerplate (memory protocol, JSON serialization, error reporting)
+2. Type-safe interfaces matching zhi's plugin contracts
+3. Build helpers and scaffolding
+
+### Package structure
+
+```
+pkg/zhiplugin/wasmpdk/
+├── pdk.go              # Core ABI helpers (set_output, set_error, memory)
+├── config.go           # Config plugin registration
+├── transform.go        # Transform plugin registration
+├── store.go            # Store plugin registration
+├── ui.go               # UI plugin registration
+├── hostcall.go         # Wrappers for calling host functions (fs, http)
+└── types.go            # Shared types (Value, Tree, ValidationResult, etc.)
+```
+
+### Config plugin example
+
+A complete WASM config plugin in Go using the PDK:
+
+```go
+package main
+
+import (
+    "github.com/MrWong99/zhi/pkg/zhiplugin/wasmpdk"
+)
+
+// MyConfig implements the config plugin interface.
+type MyConfig struct {
+    data map[string]wasmpdk.Value
+}
+
+func (c *MyConfig) List() ([]string, error) {
+    paths := make([]string, 0, len(c.data))
+    for k := range c.data {
+        paths = append(paths, k)
+    }
+    return paths, nil
+}
+
+func (c *MyConfig) Get(path string) (wasmpdk.Value, bool, error) {
+    v, ok := c.data[path]
+    return v, ok, nil
+}
+
+func (c *MyConfig) Set(path string, v wasmpdk.Value) error {
+    c.data[path] = v
+    return nil
+}
+
+func (c *MyConfig) Validate(path string, tree wasmpdk.TreeReader) ([]wasmpdk.ValidationResult, error) {
+    // Custom validation logic
+    return nil, nil
+}
+
+func main() {
+    wasmpdk.RegisterConfig(&MyConfig{
+        data: map[string]wasmpdk.Value{
+            "app/name":    {Val: "my-app"},
+            "app/version": {Val: "1.0.0"},
+        },
+    })
+    // wasmpdk.Run() blocks and handles ABI dispatch.
+    wasmpdk.Run()
+}
+```
+
+Build:
+```bash
+GOOS=wasip1 GOARCH=wasm go build -o zhi-config-myconfig.wasm .
+```
+
+### Transform plugin example
+
+```go
+package main
+
+import (
+    "strings"
+
+    "github.com/MrWong99/zhi/pkg/zhiplugin/wasmpdk"
+)
+
+type UpperCaseTransform struct{}
+
+func (t *UpperCaseTransform) BeforeDisplay(tree *wasmpdk.Tree) error {
+    for _, path := range tree.List() {
+        v, ok := tree.Get(path)
+        if !ok {
+            continue
+        }
+        if s, ok := v.Val.(string); ok {
+            v.Val = strings.ToUpper(s)
+            tree.Set(path, v)
+        }
+    }
+    return nil
+}
+
+func (t *UpperCaseTransform) AfterSave(tree *wasmpdk.Tree) error {
+    return nil // no-op
+}
+
+func (t *UpperCaseTransform) ValidatePolicy() (wasmpdk.ValidatePolicy, error) {
+    return wasmpdk.ValidateBeforeTransform, nil
+}
+
+func main() {
+    wasmpdk.RegisterTransform(&UpperCaseTransform{})
+    wasmpdk.Run()
+}
+```
+
+### Store plugin example (with host functions)
+
+```go
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "path"
+
+    "github.com/MrWong99/zhi/pkg/zhiplugin/wasmpdk"
+)
+
+type FileStore struct{}
+
+func (s *FileStore) Capabilities() (*wasmpdk.Capabilities, error) {
+    return &wasmpdk.Capabilities{
+        Versioning: wasmpdk.VersioningNone,
+        Encryption: wasmpdk.EncryptionNone,
+    }, nil
+}
+
+func (s *FileStore) GetValues(id string, paths []string) (map[string]wasmpdk.Value, error) {
+    // Read from host filesystem via host function.
+    filePath := path.Join("data", id+".json")
+    data, err := wasmpdk.HostFS.Read(filePath)
+    if err != nil {
+        return nil, fmt.Errorf("reading tree %s: %w", id, err)
+    }
+
+    var all map[string]wasmpdk.Value
+    if err := json.Unmarshal(data, &all); err != nil {
+        return nil, err
+    }
+
+    result := make(map[string]wasmpdk.Value)
+    for _, p := range paths {
+        if v, ok := all[p]; ok {
+            result[p] = v
+        }
+    }
+    return result, nil
+}
+
+// ... other store methods ...
+
+func main() {
+    wasmpdk.RegisterStore(&FileStore{})
+    wasmpdk.Run()
+}
+```
+
+### PDK internals
+
+The PDK generates the WASM exports via `//go:wasmexport`:
+
+```go
+// In wasmpdk/config.go
+
+var registeredConfig ConfigPlugin
+
+func RegisterConfig(p ConfigPlugin) {
+    registeredConfig = p
+}
+
+//go:wasmexport zhi_config_list
+func zhiConfigList() int32 {
+    paths, err := registeredConfig.List()
+    if err != nil {
+        setError(err.Error())
+        return 1
+    }
+    data, _ := json.Marshal(paths)
+    setOutput(data)
+    return 0
+}
+
+//go:wasmexport zhi_config_get
+func zhiConfigGet(pathPtr, pathLen int32) int32 {
+    path := readStringFromMemory(pathPtr, pathLen)
+    val, found, err := registeredConfig.Get(path)
+    if err != nil {
+        setError(err.Error())
+        return 1
+    }
+    resp := getResponse{Found: found, Value: val.Val, Metadata: val.Metadata}
+    data, _ := json.Marshal(resp)
+    setOutput(data)
+    return 0
+}
+
+//go:wasmexport zhi_abi_version
+func zhiABIVersion() int32 {
+    return 1
+}
+```
+
+Host function calls are wrapped with `//go:wasmimport`:
+
+```go
+// In wasmpdk/hostcall.go
+
+//go:wasmimport zhi_v1 host_set_output
+func hostSetOutput(ptr, len int32)
+
+//go:wasmimport zhi_v1 host_set_error
+func hostSetError(ptr, len int32)
+
+//go:wasmimport zhi_v1 host_fs_read
+func hostFSRead(pathPtr, pathLen int32) int32
+
+//go:wasmimport zhi_v1 host_http_request
+func hostHTTPRequest(reqPtr, reqLen int32) int32
+```
+
+## Build Process
+
+### Standard Go build
+
+```bash
+# Config plugin
+GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared \
+    -o bin/zhi-config-myplugin.wasm ./cmd/zhi-config-myplugin/
+
+# Transform plugin
+GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared \
+    -o bin/zhi-transform-mytransform.wasm ./cmd/zhi-transform-mytransform/
+```
+
+The `-buildmode=c-shared` flag produces a WASI reactor (long-lived module
+with `_initialize` instead of `_start`), which is appropriate for plugins
+that handle multiple calls.
+
+### TinyGo build
+
+```bash
+tinygo build -target=wasip1 -o bin/zhi-config-myplugin.wasm \
+    ./cmd/zhi-config-myplugin/
+```
+
+### Makefile integration
+
+The project Makefile gains WASM build targets:
+
+```makefile
+build-wasm-examples:
+    GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared \
+        -o bin/examples/zhi-config-pokedex.wasm ./examples/zhi-config-pokedex-wasm/
+    # ... more examples ...
+
+build-all: build build-examples build-wasm-examples
+```
+
+### Cross-platform note
+
+Unlike native binaries, WASM plugins do not need cross-compilation.
+A single `go build` invocation produces a `.wasm` file that runs on
+all platforms via wazero. This is a significant improvement for the
+plugin distribution story.
+
+## Testing WASM Plugins
+
+### Unit testing
+
+WASM plugins are regular Go packages. Unit tests run with the standard
+Go test runner (not compiled to WASM):
+
+```bash
+go test ./cmd/zhi-config-myplugin/...
+```
+
+The PDK interfaces (`ConfigPlugin`, `TransformPlugin`, etc.) are pure Go
+interfaces testable without WASM.
+
+### Integration testing
+
+To test the full WASM lifecycle (compile → load → call), an integration
+test helper loads the `.wasm` file via the wasmloader:
+
+```go
+func TestMyConfigWASM(t *testing.T) {
+    p, cleanup, err := wasmloader.LoadConfig("bin/zhi-config-myplugin.wasm")
+    require.NoError(t, err)
+    defer cleanup()
+
+    paths, err := p.List(context.Background())
+    require.NoError(t, err)
+    assert.Contains(t, paths, "app/name")
+}
+```
+
+### CLI testing
+
+```bash
+# Install locally and test with a workspace
+cp bin/zhi-config-myplugin.wasm ~/.zhi/plugins/
+zhi validate  # uses the WASM plugin through normal workspace config
+```
+
+## Plugin Scaffolding
+
+The `zhi plugin new` scaffolding command (from TODOS.md) would support
+a `--format wasm` flag:
+
+```bash
+zhi plugin new --type config --name my-plugin --format wasm
+```
+
+Generates:
+- `main.go` with PDK imports and interface stubs
+- `go.mod` with the wasmpdk dependency
+- `Makefile` with `GOOS=wasip1 GOARCH=wasm` build target
+- `zhi-plugin.yaml` with `format: wasm` and capability stubs
+- `.github/workflows/build.yml` for WASM builds + OCI publish
+
+## Size Optimization
+
+WASM binary sizes for Go plugins:
+
+| Plugin | Go gc | TinyGo | Native (linux/amd64) |
+|--------|-------|--------|---------------------|
+| Minimal config | ~2.5 MB | ~200 KB | ~8 MB |
+| Config + JSON | ~3 MB | ~400 KB | ~9 MB |
+| Store + HTTP | ~4 MB | N/A* | ~12 MB |
+
+*TinyGo may not support all packages needed for complex store plugins.
+
+Optimization techniques:
+- `go build -ldflags="-s -w"` strips debug info (~20% reduction)
+- TinyGo with `-no-debug` for minimal builds
+- wazero compiles and caches modules, so load time is amortized

--- a/docs/plans/wasm/06-implementation-phases.md
+++ b/docs/plans/wasm/06-implementation-phases.md
@@ -1,0 +1,329 @@
+# 06 — Implementation Phases
+
+This document breaks the WASM plugin support into concrete, shippable
+phases. Each phase delivers usable functionality and can be released
+independently.
+
+## Phase 1: Foundation — Config Plugins
+
+**Goal:** Ship the minimum viable WASM plugin support with config plugins
+as the proving ground.
+
+### Deliverables
+
+1. **wazero dependency**
+   - Add `github.com/tetratelabs/wazero` to `go.mod`.
+   - Verify CI builds pass with `CGO_ENABLED=0` across all targets.
+   - Confirm binary size increase is acceptable (~5.5 MB).
+
+2. **Core WASM runtime (`pkg/zhiplugin/wasmloader/`)**
+   - `runtime.go` — wazero runtime creation, compiled module cache.
+   - `memory.go` — Shared memory protocol: `malloc`/`free` wrappers,
+     `host_set_output`/`host_set_error` host functions, string/JSON
+     read/write helpers.
+   - `options.go` — `Option` type: `WithLogger`, `WithCapabilities`,
+     `WithTimeout`.
+   - `loader.go` — `LoadConfig()` function: compile module, instantiate
+     host functions, instantiate WASI (if needed), instantiate module,
+     return adapter.
+
+3. **Config adapter (`pkg/zhiplugin/wasmloader/adapter_config.go`)**
+   - Struct implementing `config.Plugin` by calling WASM exports
+     (`zhi_config_list`, `zhi_config_get`, `zhi_config_set`,
+     `zhi_config_validate`).
+   - JSON serialization/deserialization matching the gRPC layer's
+     `convert.go` patterns.
+
+4. **Config host functions (`pkg/zhiplugin/wasmloader/host_config.go`)**
+   - `zhi_v1` host module with `host_set_output`, `host_set_error`,
+     `host_log`.
+   - ABI version check (`zhi_abi_version` export).
+
+5. **Discovery changes (`internal/core/discovery.go`)**
+   - `PluginFormat` type and `PluginInfo.Format` field.
+   - `.wasm` file detection in `discoverFlat()` and
+     `discoverSubdirectory()`.
+   - Native-over-WASM precedence with warning log.
+
+6. **Registry changes (`internal/core/registry.go`)**
+   - `launchExternalConfig` dispatches to `LoadWASMConfig` for WASM
+     format.
+   - `ProviderInfo.Source` shows "wasm" for WASM plugins.
+
+7. **Go PDK — config (`pkg/zhiplugin/wasmpdk/`)**
+   - `pdk.go` — Core ABI: `setOutput`, `setError`, `readString`, `Run`.
+   - `config.go` — `ConfigPlugin` interface, `RegisterConfig`, WASM
+     exports via `//go:wasmexport`.
+   - `types.go` — `Value`, `TreeReader`, `ValidationResult`.
+
+8. **Example: WASM config plugin**
+   - Port the existing `examples/zhi-config-pokedex/` to WASM as
+     `examples/zhi-config-pokedex-wasm/`.
+   - Identical functionality, built with `GOOS=wasip1 GOARCH=wasm`.
+   - Test that it works interchangeably with the native version.
+
+9. **Tests**
+   - Unit tests for the wasmloader package.
+   - Unit tests for the PDK package (standard Go tests, not WASM).
+   - Integration test: compile WASM example → load via wasmloader →
+     exercise all 4 config methods.
+   - Discovery test: mixed native + WASM plugins in a directory.
+
+10. **Documentation**
+    - Update `docs/plugin-development/` with a WASM plugin guide.
+    - Update `docs/user-guide/workspace-configuration.md` with WASM
+      capability syntax.
+
+### What ships
+
+Users can write config plugins in Go, compile to `.wasm`, drop into
+`~/.zhi/plugins/`, and use them in workspaces. The engine treats them
+identically to native config plugins.
+
+---
+
+## Phase 2: Transform Plugins
+
+**Goal:** Extend WASM support to transform plugins.
+
+### Deliverables
+
+1. **Transform adapter (`pkg/zhiplugin/wasmloader/adapter_transform.go`)**
+   - Implements `transform.Plugin` by calling `zhi_transform_before_display`,
+     `zhi_transform_after_save`, `zhi_transform_validate_policy`.
+   - Handles full-tree JSON serialization (input) and deserialization
+     (output) for the mutable tree pattern.
+
+2. **Transform PDK (`pkg/zhiplugin/wasmpdk/transform.go`)**
+   - `TransformPlugin` interface, `RegisterTransform`.
+   - `Tree` type with `List()`, `Get()`, `Set()`, `Delete()` for
+     in-WASM tree manipulation.
+
+3. **`LoadTransform` in wasmloader**
+   - Registry integration (`launchExternalTransform` dispatch).
+
+4. **Example: WASM transform plugin**
+   - Simple example (e.g., base64 encode/decode, case transform).
+
+5. **Tests**
+   - Integration test: compile → load → before_display → verify tree
+     mutation → after_save → verify.
+
+### What ships
+
+Users can write transform plugins in Go/WASM. Combined with Phase 1,
+config + transform covers the "data pipeline" portion of zhi without
+any process spawning.
+
+---
+
+## Phase 3: Security and Capabilities
+
+**Goal:** Implement the capability-based security model.
+
+### Deliverables
+
+1. **Capability configuration**
+   - Parse `wasm.capabilities` from `zhi.yaml` workspace config.
+   - `Capabilities` struct in wasmloader options.
+   - Default capabilities (clock, random: yes; fs, net, env: no).
+
+2. **Filesystem host functions**
+   - `host_fs_read`, `host_fs_write`, `host_fs_list`, `host_fs_delete`,
+     `host_fs_mkdir`, `host_fs_stat`.
+   - Path validation: resolve against allowed directories, reject
+     traversal.
+   - `FSConfig` integration with wazero's WASI module.
+
+3. **HTTP host function**
+   - `host_http_request` with URL allowlisting.
+   - Timeout propagation from Go context.
+
+4. **Environment variable scoping**
+   - Only granted env vars passed to module config.
+
+5. **Memory limits**
+   - `WithMemoryLimitPages` on module config.
+
+6. **Execution timeouts**
+   - Context deadline propagation for each method call.
+
+7. **PDK host call wrappers**
+   - `wasmpdk.HostFS.Read()`, `.Write()`, etc.
+   - `wasmpdk.HostHTTP.Do()`.
+
+8. **Audit logging**
+   - Log capability usage at DEBUG level.
+   - Log denied capability access at WARN level.
+
+9. **Tests**
+   - Test: plugin with no capabilities cannot call fs/net host functions.
+   - Test: plugin with scoped fs access can only read allowed paths.
+   - Test: plugin with net access can only reach allowed hosts.
+   - Test: memory limit enforcement.
+   - Test: timeout enforcement.
+
+### What ships
+
+WASM plugins run in a fully sandboxed environment. Administrators can
+grant precise capabilities. Denied access is logged and does not crash
+the plugin.
+
+---
+
+## Phase 4: Store Plugins
+
+**Goal:** Enable WASM store plugins using the host functions from Phase 3.
+
+### Deliverables
+
+1. **Store adapter (`pkg/zhiplugin/wasmloader/adapter_store.go`)**
+   - Implements all 23 methods of `store.Plugin`.
+   - Each method maps to a `zhi_store_*` WASM export.
+
+2. **Store PDK (`pkg/zhiplugin/wasmpdk/store.go`)**
+   - `StorePlugin` interface (mirrors `store.Plugin`).
+   - `RegisterStore`, WASM exports for all 23 methods.
+   - Types: `Capabilities`, `AuthMethod`, `Credential`, `PutOptions`,
+     `Permission`, etc.
+
+3. **`LoadStore` in wasmloader**
+   - Registry integration.
+
+4. **Example: WASM in-memory store**
+   - Port `examples/zhi-store-memory/` to WASM.
+   - Pure in-memory, no host function calls needed.
+
+5. **Example: WASM file-based store**
+   - New example that uses `host_fs_*` functions to persist JSON files.
+   - Demonstrates capability grants in `zhi.yaml`.
+
+6. **Tests**
+   - Full store interface integration test.
+   - Capability-gated filesystem access test.
+
+### What ships
+
+Users can write store plugins in WASM. In-memory stores work with zero
+capabilities. File-based stores work with scoped filesystem grants.
+Network-backed stores (e.g., Vault) work with HTTP grants.
+
+---
+
+## Phase 5: UI Plugins (Stretch Goal)
+
+**Goal:** Enable WASM UI plugins for non-TTY UIs (HTTP-based).
+
+### Deliverables
+
+1. **Controller host functions**
+   - All 25 `host_ctrl_*` host functions from the ABI spec.
+   - Each calls through to the `UIController` on the host side.
+
+2. **UI adapter (`pkg/zhiplugin/wasmloader/adapter_ui.go`)**
+   - Implements `ui.Plugin` by calling `zhi_ui_run` and
+     `zhi_ui_capabilities`.
+   - `Capabilities` always returns `RequiresTTY: false`.
+
+3. **Apply streaming (Option A: polled iteration)**
+   - `host_ctrl_apply_start`, `host_ctrl_apply_next`,
+     `host_ctrl_apply_result` host functions.
+
+4. **UI PDK (`pkg/zhiplugin/wasmpdk/ui.go`)**
+   - `UIPlugin` interface, `RegisterUI`.
+   - `Controller` wrapper with methods for all host functions.
+
+5. **HTTP listener host functions (optional)**
+   - `host_http_listen`, `host_http_accept`, `host_http_respond`.
+   - Enables WASM plugins to serve HTTP UIs.
+
+6. **Example: WASM HTTP UI**
+   - Port or adapt `examples/zhi-ui-http/` to WASM.
+
+7. **Tests**
+   - Integration test exercising the Controller callback chain.
+
+### What ships
+
+HTTP-based UI plugins can be written as WASM modules. TTY-based UIs
+remain native-only. This completes WASM support for all four plugin
+types.
+
+---
+
+## Phase 6: Distribution and Tooling
+
+**Goal:** Polish the developer and user experience.
+
+### Deliverables
+
+1. **OCI distribution**
+   - `zhi-plugin.yaml` supports `format: wasm` with `os: any, arch: any`.
+   - `zhi plugin publish` handles WASM artifacts.
+   - `zhi plugin install` detects `.wasm` and places correctly.
+
+2. **Plugin scaffolding**
+   - `zhi plugin new --format wasm` generates WASM plugin project.
+
+3. **CLI display**
+   - `zhi plugin list` shows format column (native/wasm).
+   - `zhi plugin info` shows capabilities for WASM plugins.
+
+4. **CI pipeline updates**
+   - `release-plugins.yml` builds WASM examples alongside native.
+   - WASM artifacts published as `os: any` OCI manifests.
+
+5. **Makefile targets**
+   - `make build-wasm-examples`
+   - `make test-wasm` (runs WASM integration tests)
+
+---
+
+## Dependency Summary
+
+| Phase | Depends On | New Dependencies |
+|-------|------------|------------------|
+| 1 | — | `github.com/tetratelabs/wazero` |
+| 2 | Phase 1 | None |
+| 3 | Phase 1 | None |
+| 4 | Phase 1, 3 | None |
+| 5 | Phase 1, 3, 4 | None |
+| 6 | Phase 1–5 | None |
+
+The only new external dependency is wazero, added in Phase 1.
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| wazero API changes | Low (v1.0+ stable) | Medium | Pin version, update incrementally |
+| Go `wasip1` limitations | Medium | Medium | Test early; fall back to TinyGo for edge cases |
+| Performance unacceptable for store ops | Low | Medium | Profile early; native plugins remain available |
+| ABI design needs revision after Phase 1 | Medium | Low | Version the ABI (`zhi_v1`); Phase 1 is the proving ground |
+| `//go:wasmexport` doesn't support needed signatures | Low | High | Test with Go 1.24+ early; use raw WASM exports as fallback |
+| wazero filesystem sandbox escape | Known | Low | Don't rely on WASI fs; use custom host functions with path validation |
+| Binary size concerns with Go gc WASM | Medium | Low | TinyGo option available; WASM is still smaller than native |
+
+---
+
+## Success Criteria
+
+**Phase 1 is successful if:**
+- A WASM config plugin passes all the same integration tests as its
+  native equivalent.
+- CI builds pass on all platforms (linux/darwin × amd64/arm64) with
+  the wazero dependency.
+- The WASM plugin is discoverable and usable without any workspace
+  configuration changes.
+
+**The full feature is successful if:**
+- All four plugin types (config, transform, store, UI) can be
+  implemented as WASM plugins.
+- WASM plugins are demonstrably more secure than native plugins
+  (capability enforcement, no arbitrary syscalls).
+- Plugin authors can build and distribute WASM plugins using the PDK
+  and OCI pipeline.
+- Performance is acceptable for typical plugin workloads (config
+  load/save, transform, store get/put).

--- a/docs/plans/wasm/README.md
+++ b/docs/plans/wasm/README.md
@@ -1,0 +1,87 @@
+# WebAssembly Plugin Support — Design Plan
+
+This directory contains the detailed design plan for adding WebAssembly (WASM)
+plugin support to zhi. WASM plugins provide a **secure, sandboxed, portable**
+alternative to the current native-binary gRPC plugin model.
+
+## Goals
+
+1. **Security by default** — WASM plugins run in a memory-safe sandbox with
+   explicit capability grants. Unlike native plugins (which can execute
+   arbitrary syscalls), a WASM plugin can only access resources the host
+   explicitly provides.
+
+2. **Portability** — A single `.wasm` binary runs on any OS/architecture
+   without cross-compilation. Plugin authors build once; users install
+   anywhere.
+
+3. **Compatibility** — WASM plugins implement the same `config.Plugin`,
+   `transform.Plugin`, `store.Plugin`, and `ui.Plugin` interfaces as native
+   plugins. The engine and workspace configuration treat them identically.
+
+4. **Incremental adoption** — WASM is a new plugin *format*, not a
+   replacement. Native gRPC plugins continue to work unchanged. The two
+   models coexist, and plugin authors choose whichever suits them.
+
+## Non-Goals
+
+- Replacing hashicorp/go-plugin or the gRPC transport for native plugins.
+- Supporting browser-based WASM execution (js/wasm target).
+- Achieving performance parity with native plugins for CPU-heavy workloads.
+- Requiring WASM for any existing plugin.
+
+## Minimum Viable Scope
+
+The bare minimum is full support for **config** and **transform** WASM
+plugins. These plugin types have simple, stateless interfaces that map
+cleanly to WASM function imports/exports.
+
+**Store** plugins are stretch-goal for the initial release. They require
+filesystem and/or network access that must be mediated through host
+functions, but the design accounts for them from the start.
+
+**UI** plugins are the most ambitious target. WASM UI plugins would need the
+bidirectional Controller callback, which is achievable via host functions but
+adds complexity. TTY-based UIs remain impossible in WASM (no terminal
+access), but HTTP-based UIs (like the existing `zhi-ui-http` example) are a
+realistic target.
+
+## Document Index
+
+| Document | Description |
+|----------|-------------|
+| [01-runtime-evaluation.md](01-runtime-evaluation.md) | Evaluation of WASM runtimes: wazero, wasmtime-go, Extism, knqyf263/go-plugin |
+| [02-architecture.md](02-architecture.md) | How WASM plugins integrate into zhi's existing plugin architecture |
+| [03-host-functions-abi.md](03-host-functions-abi.md) | Host function ABI design for each plugin type |
+| [04-security-model.md](04-security-model.md) | Capability-based sandboxing and permission model |
+| [05-plugin-development.md](05-plugin-development.md) | Plugin Development Kit: supported languages, build toolchains, SDK |
+| [06-implementation-phases.md](06-implementation-phases.md) | Phased implementation plan with milestones |
+
+## Key Design Decisions (Summary)
+
+These are elaborated in the individual documents but summarized here for
+quick reference:
+
+1. **Runtime: wazero** — Pure Go, zero CGO, zero dependencies. Aligns with
+   zhi's `CGO_ENABLED=0` static-linking policy and cross-compilation story.
+   See [01-runtime-evaluation.md](01-runtime-evaluation.md).
+
+2. **Communication: host functions, not gRPC** — WASM plugins communicate
+   via imported/exported functions with JSON-serialized payloads, not over
+   gRPC. This eliminates the subprocess + network overhead entirely. See
+   [03-host-functions-abi.md](03-host-functions-abi.md).
+
+3. **Discovery: `.wasm` file extension** — WASM plugins are discovered
+   alongside native plugins using the same naming conventions but with a
+   `.wasm` suffix (e.g., `zhi-config-pokedex.wasm`). See
+   [02-architecture.md](02-architecture.md).
+
+4. **Security: opt-in capabilities** — WASM plugins get no filesystem,
+   network, or environment access by default. Capabilities are granted
+   explicitly in `zhi.yaml` or `zhi-plugin.yaml`. See
+   [04-security-model.md](04-security-model.md).
+
+5. **SDK: Go-first, multi-language possible** — The initial Plugin
+   Development Kit targets Go (`GOOS=wasip1`). The ABI is language-agnostic,
+   so Rust, C, and other languages can produce compatible `.wasm` files. See
+   [05-plugin-development.md](05-plugin-development.md).


### PR DESCRIPTION
Comprehensive design plan for adding WASM plugin support to zhi using
wazero as the pure-Go runtime. Covers runtime evaluation, architecture
integration, host function ABI for all plugin types, capability-based
security model, Go PDK design, and phased implementation plan.

https://claude.ai/code/session_01Dm4g1J6i8ipgD4MEzYBhkJ