### PR TITLE
fix: use graceful Shutdown in authcallback to prevent EOF race condition

Replace server.Close() with server.Shutdown() in the CallbackServer.Close()
method. server.Close() immediately kills all active connections, which could
cause the HTTP client to receive an EOF before the response was fully
delivered. server.Shutdown() waits for in-flight requests to complete,
ensuring the success response reaches the client before the server stops.

This fixes the flaky TestCallbackServer_SuccessfulCallback failure on macOS.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

### DIFF
--- a/internal/core/authcallback/server.go
+++ b/internal/core/authcallback/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 )
 
 // CallbackResult holds the query parameters received from the IdP callback.
@@ -71,9 +72,12 @@ func (s *CallbackServer) Wait(ctx context.Context) (CallbackResult, error) {
 }
 
 // Close shuts down the callback server. Safe to call multiple times.
+// Uses graceful shutdown to allow in-flight responses to be fully sent.
 func (s *CallbackServer) Close() {
 	s.closeOnce.Do(func() {
-		s.server.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.server.Shutdown(ctx)
 	})
 }
 


### PR DESCRIPTION
## What does this PR do?

<!--
A clear description of the change. Link any related issues with
"Closes #123" or "Relates to #456".
-->

## Why is this change needed?

<!--
Explain the motivation. What problem does it solve? What feature
does it add? A Trainer always knows *why* they're heading to the
next Gym.
-->

## How was this tested?

<!--
Describe the tests you ran or added. Did you run `make check`?
Any manual verification steps?
-->

- [ ] `make check` passes
- [ ] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [ ] My code follows the project's code style (`gofmt`, `go vet`)
- [ ] I have added/updated tests for my changes
- [ ] I have updated documentation if needed
- [ ] If I changed `.proto` files, I ran `make proto` and committed the generated code
- [ ] My commits are focused and have clear messages

## Additional Notes

<!--
Anything else reviewers should know? Screenshots of TUI changes,
performance considerations, migration steps, or just a fun Pokemon
fact to brighten our day -- all welcome.
-->
