### PR TITLE
docs: add VHS demo tapes for common CLI commands

### DIFF
--- a/docs/demos/export.tape
+++ b/docs/demos/export.tape
@@ -1,0 +1,37 @@
+# VHS tape: zhi export
+#
+# Exports configuration using a built-in format (YAML).
+#
+# Prerequisites:
+#   - vhs (https://github.com/charmbracelet/vhs)
+#   - zhi binary in PATH
+#   - A zhi workspace (run `zhi init` first)
+#
+# Run with: vhs export.tape
+
+Output export.gif
+
+Require zhi
+
+Set Shell zsh
+Set FontSize 16
+Set Width 1200
+Set Height 700
+Set Padding 20
+Set TypingSpeed 60ms
+Set Theme "Catppuccin Mocha"
+Set WindowBar Colorful
+Set BorderRadius 8
+Set Framerate 30
+Set CursorBlink true
+
+# Set up a temporary workspace
+Type "cd $(mktemp -d) && zhi init > /dev/null"
+Sleep 500ms
+Enter
+Sleep 3s
+
+Type "zhi export --format yaml"
+Sleep 500ms
+Enter
+Sleep 5s

--- a/docs/demos/init.tape
+++ b/docs/demos/init.tape
@@ -1,0 +1,35 @@
+# VHS tape: zhi init
+#
+# Initializes a new zhi workspace with a config provider and store provider.
+#
+# Prerequisites:
+#   - vhs (https://github.com/charmbracelet/vhs)
+#   - zhi binary in PATH
+#
+# Run with: vhs init.tape
+
+Output init.gif
+
+Require zhi
+
+Set Shell zsh
+Set FontSize 16
+Set Width 1200
+Set Height 600
+Set Padding 20
+Set TypingSpeed 60ms
+Set Theme "Catppuccin Mocha"
+Set WindowBar Colorful
+Set BorderRadius 8
+Set Framerate 30
+Set CursorBlink true
+
+Type "cd $(mktemp -d) && pwd"
+Sleep 500ms
+Enter
+Sleep 2s
+
+Type "zhi init --config-provider structuredfile --store-provider zhi-store-json"
+Sleep 500ms
+Enter
+Sleep 5s

--- a/docs/demos/list-providers.tape
+++ b/docs/demos/list-providers.tape
@@ -1,0 +1,37 @@
+# VHS tape: zhi list providers
+#
+# Lists all available built-in and external providers.
+#
+# Prerequisites:
+#   - vhs (https://github.com/charmbracelet/vhs)
+#   - zhi binary in PATH
+#   - A zhi workspace (run `zhi init` first)
+#
+# Run with: vhs list-providers.tape
+
+Output list-providers.gif
+
+Require zhi
+
+Set Shell zsh
+Set FontSize 16
+Set Width 1200
+Set Height 600
+Set Padding 20
+Set TypingSpeed 60ms
+Set Theme "Catppuccin Mocha"
+Set WindowBar Colorful
+Set BorderRadius 8
+Set Framerate 30
+Set CursorBlink true
+
+# Set up a temporary workspace
+Type "cd $(mktemp -d) && zhi init > /dev/null"
+Sleep 500ms
+Enter
+Sleep 3s
+
+Type "zhi list providers"
+Sleep 500ms
+Enter
+Sleep 5s

--- a/docs/demos/plugin-install.tape
+++ b/docs/demos/plugin-install.tape
@@ -1,0 +1,31 @@
+# VHS tape: zhi plugin install
+#
+# Installs a plugin from an OCI registry (ghcr.io).
+#
+# Prerequisites:
+#   - vhs (https://github.com/charmbracelet/vhs)
+#   - zhi binary in PATH
+#   - Network access to ghcr.io
+#
+# Run with: vhs plugin-install.tape
+
+Output plugin-install.gif
+
+Require zhi
+
+Set Shell zsh
+Set FontSize 16
+Set Width 1400
+Set Height 500
+Set Padding 20
+Set TypingSpeed 60ms
+Set Theme "Catppuccin Mocha"
+Set WindowBar Colorful
+Set BorderRadius 8
+Set Framerate 30
+Set CursorBlink true
+
+Type "zhi plugin install oci://ghcr.io/mrwong99/zhi/zhi-store-memory:v0.0.9"
+Sleep 500ms
+Enter
+Sleep 8s

--- a/docs/demos/plugin-list.tape
+++ b/docs/demos/plugin-list.tape
@@ -1,0 +1,31 @@
+# VHS tape: zhi plugin list
+#
+# Lists all installed shared plugins with version and source info.
+#
+# Prerequisites:
+#   - vhs (https://github.com/charmbracelet/vhs)
+#   - zhi binary in PATH
+#   - At least one plugin installed (e.g. via `zhi plugin install`)
+#
+# Run with: vhs plugin-list.tape
+
+Output plugin-list.gif
+
+Require zhi
+
+Set Shell zsh
+Set FontSize 16
+Set Width 1400
+Set Height 500
+Set Padding 20
+Set TypingSpeed 60ms
+Set Theme "Catppuccin Mocha"
+Set WindowBar Colorful
+Set BorderRadius 8
+Set Framerate 30
+Set CursorBlink true
+
+Type "zhi plugin list"
+Sleep 500ms
+Enter
+Sleep 5s

--- a/docs/demos/plugin-new.tape
+++ b/docs/demos/plugin-new.tape
@@ -1,0 +1,35 @@
+# VHS tape: zhi plugin new
+#
+# Scaffolds a complete new plugin project from a template.
+#
+# Prerequisites:
+#   - vhs (https://github.com/charmbracelet/vhs)
+#   - zhi binary in PATH
+#
+# Run with: vhs plugin-new.tape
+
+Output plugin-new.gif
+
+Require zhi
+
+Set Shell zsh
+Set FontSize 16
+Set Width 1400
+Set Height 700
+Set Padding 20
+Set TypingSpeed 60ms
+Set Theme "Catppuccin Mocha"
+Set WindowBar Colorful
+Set BorderRadius 8
+Set Framerate 30
+Set CursorBlink true
+
+Type "cd $(mktemp -d)"
+Sleep 500ms
+Enter
+Sleep 1s
+
+Type "zhi plugin new --name my-store --type store --author demo --license MIT"
+Sleep 500ms
+Enter
+Sleep 6s

--- a/docs/demos/plugin-verify.tape
+++ b/docs/demos/plugin-verify.tape
@@ -1,0 +1,32 @@
+# VHS tape: zhi plugin verify
+#
+# Verifies a plugin artifact's cosign signature without installing it.
+# Useful for auditing and compliance checks.
+#
+# Prerequisites:
+#   - vhs (https://github.com/charmbracelet/vhs)
+#   - zhi binary in PATH
+#   - Network access to ghcr.io
+#
+# Run with: vhs plugin-verify.tape
+
+Output plugin-verify.gif
+
+Require zhi
+
+Set Shell zsh
+Set FontSize 16
+Set Width 1400
+Set Height 500
+Set Padding 20
+Set TypingSpeed 60ms
+Set Theme "Catppuccin Mocha"
+Set WindowBar Colorful
+Set BorderRadius 8
+Set Framerate 30
+Set CursorBlink true
+
+Type "zhi plugin verify oci://ghcr.io/mrwong99/zhi/zhi-config-pokedex:v0.0.9"
+Sleep 500ms
+Enter
+Sleep 8s

--- a/docs/demos/validate.tape
+++ b/docs/demos/validate.tape
@@ -1,0 +1,37 @@
+# VHS tape: zhi validate
+#
+# Validates the configuration tree and prints results grouped by severity.
+#
+# Prerequisites:
+#   - vhs (https://github.com/charmbracelet/vhs)
+#   - zhi binary in PATH
+#   - A zhi workspace (run `zhi init` first)
+#
+# Run with: vhs validate.tape
+
+Output validate.gif
+
+Require zhi
+
+Set Shell zsh
+Set FontSize 16
+Set Width 1200
+Set Height 500
+Set Padding 20
+Set TypingSpeed 60ms
+Set Theme "Catppuccin Mocha"
+Set WindowBar Colorful
+Set BorderRadius 8
+Set Framerate 30
+Set CursorBlink true
+
+# Set up a temporary workspace
+Type "cd $(mktemp -d) && zhi init > /dev/null"
+Sleep 500ms
+Enter
+Sleep 3s
+
+Type "zhi validate"
+Sleep 500ms
+Enter
+Sleep 5s

--- a/docs/demos/version.tape
+++ b/docs/demos/version.tape
@@ -1,0 +1,30 @@
+# VHS tape: zhi version
+#
+# Shows the zhi CLI version, commit hash, and build date.
+#
+# Prerequisites:
+#   - vhs (https://github.com/charmbracelet/vhs)
+#   - zhi binary in PATH
+#
+# Run with: vhs version.tape
+
+Output version.gif
+
+Require zhi
+
+Set Shell zsh
+Set FontSize 16
+Set Width 900
+Set Height 300
+Set Padding 20
+Set TypingSpeed 60ms
+Set Theme "Catppuccin Mocha"
+Set WindowBar Colorful
+Set BorderRadius 8
+Set Framerate 30
+Set CursorBlink true
+
+Type "zhi version"
+Sleep 500ms
+Enter
+Sleep 4s


### PR DESCRIPTION
Add 9 focused VHS tape files in docs/demos/, each recording a single
zhi CLI command for use in documentation. Unlike the existing demo.tape
which shows a long multi-step MCP workflow, these tapes capture one-shot
commands that are easy to follow:

- version.tape: zhi version
- init.tape: zhi init with provider flags
- plugin-install.tape: install from OCI (zhi-store-memory)
- plugin-list.tape: list installed plugins
- plugin-new.tape: scaffold a new plugin project
- plugin-verify.tape: verify OCI artifact signature
- validate.tape: validate workspace configuration
- export.tape: export config as YAML
- list-providers.tape: list available providers

All tapes use the same Catppuccin Mocha theme and similar console settings
as the existing demo.tape, with window sizes adjusted per expected output.
OCI references point to real published plugins at ghcr.io/mrwong99/zhi/.

https://claude.ai/code/session_01GUo52857N8WR6AUyF4D1b2