### PR TITLE
docs: improve documentation clarity, add emojis, fix stale references

### DIFF
--- a/.claude/skills/config-plugin/SKILL.md
+++ b/.claude/skills/config-plugin/SKILL.md
@@ -46,8 +46,8 @@ package main
 
 import (
     goplugin "github.com/hashicorp/go-plugin"
-    "github.com/itsluketwist/zhi/pkg/zhiplugin"
-    "github.com/itsluketwist/zhi/pkg/zhiplugin/config"
+    "github.com/MrWong99/zhi/pkg/zhiplugin"
+    "github.com/MrWong99/zhi/pkg/zhiplugin/config"
 )
 
 func main() {

--- a/.claude/skills/store-plugin/SKILL.md
+++ b/.claude/skills/store-plugin/SKILL.md
@@ -45,8 +45,8 @@ package main
 
 import (
     goplugin "github.com/hashicorp/go-plugin"
-    "github.com/itsluketwist/zhi/pkg/zhiplugin"
-    "github.com/itsluketwist/zhi/pkg/zhiplugin/store"
+    "github.com/MrWong99/zhi/pkg/zhiplugin"
+    "github.com/MrWong99/zhi/pkg/zhiplugin/store"
 )
 
 func main() {

--- a/.claude/skills/transform-plugin/SKILL.md
+++ b/.claude/skills/transform-plugin/SKILL.md
@@ -50,9 +50,9 @@ package main
 
 import (
     goplugin "github.com/hashicorp/go-plugin"
-    "github.com/itsluketwist/zhi/pkg/zhiplugin"
-    "github.com/itsluketwist/zhi/pkg/zhiplugin/config"
-    "github.com/itsluketwist/zhi/pkg/zhiplugin/transform"
+    "github.com/MrWong99/zhi/pkg/zhiplugin"
+    "github.com/MrWong99/zhi/pkg/zhiplugin/config"
+    "github.com/MrWong99/zhi/pkg/zhiplugin/transform"
 )
 
 func main() {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Each plugin type has `grpc_client.go` (host-side) and `grpc_server.go` (plugin-s
 - `pkg/providers/` -- built-in provider implementations (structuredfile config, vault store)
 - `pkg/sharing/` -- plugin distribution: manifests, lockfiles, OCI client, verification, marketplace
 - `api/proto/zhiplugin/v1/` -- protobuf service definitions
-- `examples/` -- working plugin examples (pokedex config, memory/json/vault stores, transform, HTTP API UI, store mirror meta-plugin)
+- `examples/` -- working plugin examples (pokedex config, memory/json/vault stores, transform, HTTP API UI, MCP SSE UI, Web UI, store mirror meta-plugin, Java bean config)
 - `docs/user-guide/` -- end-user documentation
 - `docs/plugin-development/` -- plugin developer documentation
 - `docs/design/` -- design documents (e.g., metadata-labels API)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,15 +10,12 @@ to set up a local development environment, run common tasks, and submit changes.
 | Tool | Purpose | Install |
 |------|---------|---------|
 | **Go 1.26+** | Build & test | [go.dev/dl](https://go.dev/dl/) |
-| **protoc** | Compile `.proto` files | [protobuf releases](https://github.com/protocolbuffers/protobuf/releases) |
-| **protoc-gen-go** | Go code generation for protobuf | `go install google.golang.org/protobuf/cmd/protoc-gen-go@latest` |
-| **protoc-gen-go-grpc** | Go gRPC stub generation | `go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest` |
-| **golangci-lint** *(optional)* | Linter | `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest` |
 
-You can install all Go-based tools at once with:
+All other tools (protoc, protoc-gen-go, protoc-gen-go-grpc, golangci-lint) are managed automatically:
 
 ```sh
-make tools
+make tools   # installs protoc-gen-go, protoc-gen-go-grpc, golangci-lint v2
+make proto   # downloads protoc v33.5 automatically (no system install required)
 ```
 
 ## Getting started
@@ -144,7 +141,12 @@ Look at the `examples/` directory for working reference implementations:
 - `examples/zhi-transform-pokedex/` -- a transform plugin that evolves starter Pokemon
 - `examples/zhi-store-json/` -- a store plugin persisting trees as JSON files
 - `examples/zhi-store-memory/` -- a minimal in-memory store plugin
+- `examples/zhi-store-vault/` -- a store plugin backed by HashiCorp Vault KV v2
+- `examples/zhi-store-mirror/` -- a meta-plugin that mirrors writes to multiple stores
 - `examples/zhi-ui-httpapi/` -- a UI plugin exposing an HTTP/JSON API
+- `examples/zhi-ui-mcp-sse/` -- a UI plugin exposing an MCP server over HTTP
+- `examples/zhi-ui-webui/` -- a browser-based Web UI plugin
+- `examples/zhi-config-javabean/` -- a Java config plugin with Bean Validation
 
 Each example includes tests that use `goplugin.TestPluginGRPCConn()` for
 in-process gRPC testing without starting a subprocess.

--- a/README.md
+++ b/README.md
@@ -3,37 +3,39 @@
 # zhi
 
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev)
+[![Go Reference](https://pkg.go.dev/badge/github.com/MrWong99/zhi.svg)](https://pkg.go.dev/github.com/MrWong99/zhi)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 **zhi** is a modern platform for **configuration management** and **provisioning**.
-It provides an extensible plugin system that automatically generates a user-friendly terminal UI, while keeping all configurations **secure by default**.
+It gives you an extensible plugin system that auto-generates a friendly terminal UI, while keeping all your configs **secure by default**. Think of it as *"Vault meets Terraform, but for your app config"*. 🔐
 
-Core principles:
+### 🎯 Core Principles
 
-1. **Configuration & Validation** -- structured, validated settings that prevent misconfiguration before deployment.
-2. **Secure Storage** -- encrypted at rest, ensuring confidentiality and compliance without extra setup.
-3. **Modularity** -- built around an extensible plugin system, enabling support for multiple provisioning backends (Docker Compose, Kubernetes, Helm, and beyond).
-
----
-
-## Features
-
-- **Encrypted configuration at rest** -- store plugin layer supports encryption and key rotation
-- **Automatic validation** -- config plugins define validation rules, including cross-value checks
-- **Plugin-based extensibility** -- [gRPC-based plugin system](https://github.com/hashicorp/go-plugin) with four plugin types (config, transform, store, UI) and a [meta-plugin SDK](docs/plugin-development/meta-plugin.md) for composing plugins
-- **Auto-generated TUI** -- interactive terminal interface built with [Bubbletea](https://github.com/charmbracelet/bubbletea)
-- **MCP server** -- expose configuration management to LLM clients (Claude Desktop, Claude Code, Cursor) via the [Model Context Protocol](https://modelcontextprotocol.io)
-- **Component model** -- group configuration into toggleable bundles with dependencies
-- **Template-based exports** -- render configuration to JSON, YAML, TOML, dotenv, or custom templates
-- **Provisioning** -- trigger external commands (Docker Compose, kubectl, Ansible, etc.) with exported configuration
-- **Plugin sharing** -- [install, update, and publish](docs/user-guide/sharing-and-registries.md) plugins via OCI registries with signature verification, version pinning, rollback, and binary integrity checks
-- **Marketplace** -- search and rate plugins, verified publisher program, vulnerability advisories
-- **Enterprise mirror** -- [`zhi-mirror`](docs/user-guide/enterprise-mirror.md) provides a local OCI pull-through cache with policy controls, audit logging, and air-gapped export/import
+1. **🛡️ Configuration & Validation** -- structured, validated settings that catch misconfigurations before they reach production.
+2. **🔐 Secure Storage** -- encrypted at rest, so confidentiality and compliance come out of the box.
+3. **🧩 Modularity** -- an extensible plugin system that supports multiple provisioning backends (Docker Compose, Kubernetes, Helm, and beyond).
 
 ---
 
-## Getting Started
+## ✨ Features
+
+- **🔒 Encrypted configuration at rest** -- store plugin layer supports encryption and key rotation
+- **✅ Automatic validation** -- config plugins define validation rules, including cross-value checks
+- **🔌 Plugin-based extensibility** -- [gRPC-based plugin system](https://github.com/hashicorp/go-plugin) with four plugin types (config, transform, store, UI) and a [meta-plugin SDK](docs/plugin-development/meta-plugin.md) for composing plugins
+- **💻 Auto-generated TUI** -- interactive terminal interface built with [Bubbletea](https://github.com/charmbracelet/bubbletea)
+- **🌐 Web UI** -- browser-based editor served on localhost for a richer editing experience
+- **🤖 MCP server** -- expose configuration management to LLM clients (Claude Desktop, Claude Code, Cursor) via the [Model Context Protocol](https://modelcontextprotocol.io)
+- **📦 Component model** -- group configuration into toggleable bundles with dependencies
+- **📄 Template-based exports** -- render configuration to JSON, YAML, TOML, dotenv, or custom templates
+- **🚀 Provisioning** -- trigger external commands (Docker Compose, kubectl, Ansible, etc.) with exported configuration
+- **📡 Plugin sharing** -- [install, update, and publish](docs/user-guide/sharing-and-registries.md) plugins via OCI registries with signature verification, version pinning, rollback, and binary integrity checks
+- **🏪 Marketplace** -- search and rate plugins, verified publisher program, vulnerability advisories
+- **🏢 Enterprise mirror** -- [`zhi-mirror`](docs/user-guide/enterprise-mirror.md) provides a local OCI pull-through cache with policy controls, audit logging, and air-gapped export/import
+
+---
+
+## 🚀 Getting Started
 
 ### Prerequisites
 
@@ -67,7 +69,7 @@ cd zhi
 make build
 ```
 
-The binary is placed in `bin/`.
+The binary lands in `bin/`. You're ready to roll! 🎉
 
 ### Quick Start
 
@@ -94,17 +96,17 @@ zhi export --format json
 zhi edit
 ```
 
-### Interactive TUI Editor
+### 💻 Interactive TUI Editor
 
 ![zhi edit tui](assets/tui.gif)
 
-### Web UI Editor
+### 🌐 Web UI Editor
 
 ![zhi edit webui](assets/webui.png)
 
-### MCP Server (for LLM Clients)
+### 🤖 MCP Server (for LLM Clients)
 
-zhi includes built-in MCP (Model Context Protocol) support, allowing LLM clients like Claude Desktop, Claude Code, and Cursor to manage configurations programmatically.
+zhi includes built-in MCP (Model Context Protocol) support, allowing LLM clients like Claude Desktop, Claude Code, and Cursor to manage configurations programmatically. Your AI assistant can now tweak your configs -- what a time to be alive!
 
 **Stdio transport** (recommended for local use):
 
@@ -128,7 +130,7 @@ Configure in Claude Desktop's `claude_desktop_config.json`:
 
 **HTTP transport** (for remote/network access): install the `zhi-ui-mcp-sse` external plugin. See [`examples/zhi-ui-mcp-sse/`](examples/zhi-ui-mcp-sse/).
 
-### Components
+### 📦 Components
 
 Components group related configuration into named bundles that users can toggle:
 
@@ -145,7 +147,7 @@ zhi component disable monitoring
 
 Components defined in `zhi.yaml` control which paths appear in exports and the TUI. See the [Components guide](docs/user-guide/components.md) for details.
 
-### Verbose / Debug Logging
+### 🔍 Verbose / Debug Logging
 
 Pass `--verbose` to any command to enable debug-level logging to stderr:
 
@@ -155,7 +157,7 @@ zhi validate --verbose
 
 ---
 
-## User Guide
+## 📚 User Guide
 
 Detailed documentation for using zhi:
 
@@ -167,13 +169,15 @@ Detailed documentation for using zhi:
 - [Apply](docs/user-guide/apply.md) -- running provisioning commands
 - [Plugin Discovery](docs/user-guide/plugin-discovery.md) -- discovering and using external plugins
 - [Sharing and Registries](docs/user-guide/sharing-and-registries.md) -- installing, publishing, and updating plugins via OCI registries
+- [Marketplace Indexing](docs/user-guide/marketplace-indexing.md) -- adding plugins to the marketplace search index
 - [Enterprise Mirror](docs/user-guide/enterprise-mirror.md) -- local OCI mirror for air-gapped environments
+- [Web UI](docs/user-guide/web-ui.md) -- browser-based configuration editor
 
 ---
 
-## Plugin Development
+## 🔌 Plugin Development
 
-zhi's plugin system supports four types: **config**, **transform**, **store**, and **UI**. Plugins are separate binaries communicating over gRPC.
+zhi's plugin system supports four types: **config**, **transform**, **store**, and **UI**. Plugins are separate binaries communicating over gRPC -- so they can be written in any language that speaks gRPC.
 
 - [Plugin Development Overview](docs/plugin-development/overview.md) -- shared concepts, binary structure, testing
 - [Config Plugin API](docs/plugin-development/config-plugin.md) -- manage configuration values
@@ -182,22 +186,25 @@ zhi's plugin system supports four types: **config**, **transform**, **store**, a
 - [UI Plugin API](docs/plugin-development/ui-plugin.md) -- provide interactive frontends
 - [Meta-Plugin SDK](docs/plugin-development/meta-plugin.md) -- launch, delegate, and compose child plugins
 - [Structured File Provider](docs/plugin-development/structuredfile-provider.md) -- built-in file-based config provider
+- [Java Plugin Development](docs/plugin-development/java-plugin.md) -- build plugins in Java with GraalVM
+- [Plugin Scaffolding](docs/plugin-development/scaffolding.md) -- generate a new plugin project with `zhi plugin new`
 
-### Examples
+### 🧪 Examples
 
-The [`examples/`](examples/) directory contains fully working plugins you can build and experiment with:
+The [`examples/`](examples/) directory contains fully working plugins you can build and experiment with. Go ahead, break things -- that's what examples are for! 🔬
 
 | Example | Type | What it demonstrates |
 |---------|------|---------------------|
-| [zhi-config-pokedex](examples/zhi-config-pokedex/) | Config | Typed values, metadata, validation |
+| [zhi-config-pokedex](examples/zhi-config-pokedex/) | Config | Typed values, metadata, validation -- gotta validate 'em all! |
 | [zhi-transform-pokedex](examples/zhi-transform-pokedex/) | Transform | Tree mutation, value mapping |
 | [zhi-store-json](examples/zhi-store-json/) | Store | File-based persistence |
 | [zhi-store-memory](examples/zhi-store-memory/) | Store | Minimal in-memory store |
 | [zhi-store-vault](examples/zhi-store-vault/) | Store | HashiCorp Vault KV v2 backend |
+| [zhi-store-mirror](examples/zhi-store-mirror/) | Store (meta) | Meta-plugin: mirrors writes to memory + JSON file |
 | [zhi-ui-httpapi](examples/zhi-ui-httpapi/) | UI | HTTP/JSON API with SSE streaming |
 | [zhi-ui-mcp-sse](examples/zhi-ui-mcp-sse/) | UI | MCP server over HTTP for LLM clients |
+| [zhi-ui-webui](examples/zhi-ui-webui/) | UI | Browser-based Web UI |
 | [zhi-config-javabean](examples/zhi-config-javabean/) | Config | Java plugin with Bean Validation and GraalVM native-image |
-| [zhi-store-mirror](examples/zhi-store-mirror/) | Store (meta) | Meta-plugin: mirrors writes to memory + JSON file |
 
 All Go example plugins are published to the GitHub Container Registry on every release and can be installed directly:
 
@@ -217,7 +224,7 @@ See the [examples README](examples/README.md) for more details.
 
 ---
 
-## Enterprise Mirror (`zhi-mirror`)
+## 🏢 Enterprise Mirror (`zhi-mirror`)
 
 For enterprise and air-gapped environments, `zhi-mirror` provides a local registry mirror with:
 
@@ -243,13 +250,11 @@ Clients point to the mirror by setting `sharing.defaultRegistry` in `~/.zhi/conf
 
 ---
 
-## Contributing
+## 🤝 Contributing
 
-Contributions are welcome -- whether it's a bug fix, a new plugin idea, or
-improving documentation. Every contribution helps zhi evolve.
+Contributions are welcome -- whether it's a bug fix, a new plugin idea, or improving documentation. Every contribution helps zhi evolve. ❤️
 
-Please read the [Contributing Guide](CONTRIBUTING.md) to get started. The
-short version:
+Please read the [Contributing Guide](CONTRIBUTING.md) to get started. The short version:
 
 ```sh
 git clone https://github.com/MrWong99/zhi.git
@@ -262,18 +267,16 @@ Before opening a pull request, make sure `make check` passes.
 
 ---
 
-## Community
+## 🌍 Community
 
-- [**Code of Conduct**](CODE_OF_CONDUCT.md) -- how we treat each other
-  (tl;dr: be a good Trainer)
+- [**Code of Conduct**](CODE_OF_CONDUCT.md) -- how we treat each other (tl;dr: be excellent to each other 🤙)
 - [**Contributing Guide**](CONTRIBUTING.md) -- setup, workflow, and code style
 - [**Security Policy**](SECURITY.md) -- how to report vulnerabilities
-- [**Issue Templates**](.github/ISSUE_TEMPLATE/) -- bug reports, feature
-  requests, and plugin ideas
+- [**Issue Templates**](.github/ISSUE_TEMPLATE/) -- bug reports, feature requests, and plugin ideas
 
 ---
 
-## The Origin of the Name
+## 🀄 The Origin of the Name
 
 <img src="assets/logo.png" alt="zhi logo" width="200" align="right" />
 
@@ -287,6 +290,6 @@ to **arrange systems securely**, with **wisdom in design**, while remaining **fl
 
 ---
 
-## License
+## 📜 License
 
 [MIT](LICENSE) -- Copyright (c) 2025 Lukas Schmidt

--- a/docs/plugin-development/overview.md
+++ b/docs/plugin-development/overview.md
@@ -129,9 +129,12 @@ The [`examples/`](../../examples/) directory contains working reference implemen
 | [zhi-transform-pokedex](../../examples/zhi-transform-pokedex/) | Transform | Tree mutation, value mapping |
 | [zhi-store-json](../../examples/zhi-store-json/) | Store | File-based persistence |
 | [zhi-store-memory](../../examples/zhi-store-memory/) | Store | Minimal in-memory store |
-| [zhi-ui-httpapi](../../examples/zhi-ui-httpapi/) | UI | HTTP/JSON API with SSE streaming |
-| [zhi-config-javabean](../../examples/zhi-config-javabean/) | Config | Java bean with Bean Validation, GraalVM native-image |
+| [zhi-store-vault](../../examples/zhi-store-vault/) | Store | HashiCorp Vault KV v2 backend |
 | [zhi-store-mirror](../../examples/zhi-store-mirror/) | Store (meta) | Meta-plugin: mirrors writes to memory + JSON file |
+| [zhi-ui-httpapi](../../examples/zhi-ui-httpapi/) | UI | HTTP/JSON API with SSE streaming |
+| [zhi-ui-mcp-sse](../../examples/zhi-ui-mcp-sse/) | UI | MCP server over HTTP for LLM clients |
+| [zhi-ui-webui](../../examples/zhi-ui-webui/) | UI | Browser-based Web UI |
+| [zhi-config-javabean](../../examples/zhi-config-javabean/) | Config | Java bean with Bean Validation, GraalVM native-image |
 
 All Go examples are published as OCI artifacts to `ghcr.io/mrwong99/zhi/` on every release and can be installed with `zhi plugin install oci://ghcr.io/mrwong99/zhi/<plugin-name>:<tag>`. See the [Sharing and Registries guide](../user-guide/sharing-and-registries.md#official-plugin-registry) for the full list.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,12 @@
-# Examples for Plugins in zhi
+# 🧪 Example Plugins for zhi
 
-## zhi-config-pokedex
+Welcome to the examples! Each plugin below is a fully working, buildable project you can use as a starting point for your own plugins. Build them all with `make build-examples` or go explore one at a time. 🚀
 
-A configuration plugin that manages a small Pokedex. Demonstrates:
+---
+
+## 🔴 zhi-config-pokedex
+
+A configuration plugin that manages a small Pokedex -- because every good config system needs Pokemon data. Demonstrates:
 
 - Implementing `config.Plugin` (List, Get, Set, Validate)
 - Typed values with metadata
@@ -13,9 +17,11 @@ A configuration plugin that manages a small Pokedex. Demonstrates:
 See [zhi-config-pokedex/main.go](zhi-config-pokedex/main.go) and the
 [Configuration Plugin docs](../docs/plugin-development/config-plugin.md) for details.
 
-## zhi-transform-pokedex
+---
 
-A transform plugin that evolves starter Pokemon before display. Demonstrates:
+## ⚡ zhi-transform-pokedex
+
+A transform plugin that evolves starter Pokemon before display. It's super effective! Demonstrates:
 
 - Implementing `transform.Plugin` (BeforeDisplay, AfterSave, ValidatePolicy)
 - Reading and mutating the shared configuration tree
@@ -24,9 +30,11 @@ A transform plugin that evolves starter Pokemon before display. Demonstrates:
 See [zhi-transform-pokedex/main.go](zhi-transform-pokedex/main.go) and the
 [Transform Plugin docs](../docs/plugin-development/transform-plugin.md) for details.
 
-## zhi-store-json
+---
 
-A store plugin that persists configuration trees as JSON files on disk. Demonstrates:
+## 📁 zhi-store-json
+
+A store plugin that persists configuration trees as JSON files on disk. Simple, readable, debuggable. Demonstrates:
 
 - Implementing `store.Plugin` (Save, Load, Delete, ListTrees)
 - File-based persistence with one JSON file per tree ID
@@ -37,9 +45,11 @@ This example does not support versioning or encryption.
 See [zhi-store-json/main.go](zhi-store-json/main.go) and the
 [Store Plugin docs](../docs/plugin-development/store-plugin.md) for details.
 
-## zhi-store-memory
+---
 
-A store plugin that persists configuration trees in memory. Demonstrates:
+## 🧠 zhi-store-memory
+
+A store plugin that persists configuration trees in memory. Poof -- gone when the process exits, perfect for testing. Demonstrates:
 
 - Implementing `store.Plugin` with the simplest possible backend (a Go map)
 - Minimal store plugin structure for quick prototyping
@@ -49,9 +59,11 @@ This example does not support versioning or encryption.
 See [zhi-store-memory/main.go](zhi-store-memory/main.go) and the
 [Store Plugin docs](../docs/plugin-development/store-plugin.md) for details.
 
-## zhi-store-vault
+---
 
-A store plugin backed by HashiCorp Vault's KV v2 secrets engine. Demonstrates:
+## 🔑 zhi-store-vault
+
+A store plugin backed by HashiCorp Vault's KV v2 secrets engine. For when your configs need a bodyguard. Demonstrates:
 
 - Using the Vault store provider as an external plugin binary
 - Configuration via environment variables (`VAULT_ADDR`, `VAULT_TOKEN`, `ZHI_VAULT_MOUNT`, `ZHI_VAULT_PREFIX`)
@@ -60,9 +72,25 @@ A store plugin backed by HashiCorp Vault's KV v2 secrets engine. Demonstrates:
 See [zhi-store-vault/main.go](zhi-store-vault/main.go) and the
 [Store Plugin docs](../docs/plugin-development/store-plugin.md) for details.
 
-## zhi-config-javabean
+---
 
-A config plugin written in Java using Bean Validation and GraalVM native-image. Demonstrates:
+## 🪞 zhi-store-mirror
+
+A meta-plugin that mirrors writes to multiple stores -- write once, persist everywhere. This is the prime example of the meta-plugin SDK in action. Demonstrates:
+
+- Using `pkg/zhiplugin/launch/` to start child plugin processes
+- Using `store.DelegatingPlugin` to forward calls to a base store
+- Using `store.MirroredPlugin` to replicate writes across a primary and backup store
+- Binary validation and integrity auditing for child plugins
+
+See [zhi-store-mirror/main.go](zhi-store-mirror/main.go) and the
+[Meta-Plugin SDK docs](../docs/plugin-development/meta-plugin.md) for details.
+
+---
+
+## ☕ zhi-config-javabean
+
+A config plugin written in Java using Bean Validation and GraalVM native-image. Proof that zhi plugins aren't Go-only! Demonstrates:
 
 - Implementing the gRPC ConfigService in Java
 - Mapping Java beans to zhi configuration paths with annotations (`@ConfigPrefix`, `@ConfigProperty`)
@@ -72,9 +100,11 @@ A config plugin written in Java using Bean Validation and GraalVM native-image. 
 See [zhi-config-javabean/](zhi-config-javabean/) and the
 [Java Plugin Development docs](../docs/plugin-development/java-plugin.md) for details.
 
-## zhi-ui-httpapi
+---
 
-A UI plugin that exposes the zhi configuration engine as an HTTP/JSON API. Demonstrates:
+## 🌐 zhi-ui-httpapi
+
+A UI plugin that exposes the zhi configuration engine as an HTTP/JSON API. REST lovers, this one's for you. Demonstrates:
 
 - Implementing `ui.Plugin` (Run, Capabilities) with `RequiresTTY: false`
 - Using the `Controller` interface for all core operations (tree, export, apply, components)
@@ -85,9 +115,11 @@ A UI plugin that exposes the zhi configuration engine as an HTTP/JSON API. Demon
 See [zhi-ui-httpapi/main.go](zhi-ui-httpapi/main.go) and the
 [UI Plugin docs](../docs/plugin-development/ui-plugin.md) for details.
 
-## zhi-ui-mcp-sse
+---
 
-A UI plugin that exposes the zhi configuration engine as an MCP (Model Context Protocol) server over HTTP. Demonstrates:
+## 🤖 zhi-ui-mcp-sse
+
+A UI plugin that exposes the zhi configuration engine as an MCP (Model Context Protocol) server over HTTP. Let your LLM do the configuring! Demonstrates:
 
 - Implementing `ui.Plugin` (Run, Capabilities) with `RequiresTTY: false`
 - Using the shared `pkg/mcpbridge/` library to register all MCP tools, resources, and prompts
@@ -98,4 +130,17 @@ A UI plugin that exposes the zhi configuration engine as an MCP (Model Context P
 A builtin MCP stdio plugin (`mcp-stdio`) is also available for direct use with LLM clients that support stdio transport (e.g. Claude Desktop, Claude Code). Launch it with `zhi edit --ui mcp-stdio`.
 
 See [zhi-ui-mcp-sse/main.go](zhi-ui-mcp-sse/main.go) and the
+[UI Plugin docs](../docs/plugin-development/ui-plugin.md) for details.
+
+---
+
+## 🖥️ zhi-ui-webui
+
+A browser-based Web UI plugin that serves a full configuration editor on localhost. For when the terminal isn't fancy enough. Demonstrates:
+
+- Implementing `ui.Plugin` (Run, Capabilities) with `RequiresTTY: false`
+- Serving a web frontend with an embedded HTTP server
+- Integration with the `Controller` interface for all core operations
+
+See [zhi-ui-webui/](zhi-ui-webui/) and the
 [UI Plugin docs](../docs/plugin-development/ui-plugin.md) for details.


### PR DESCRIPTION
- README: add pkg.go.dev badge, emojis, friendlier tone, add missing
  examples (zhi-ui-webui, zhi-store-mirror) and doc links (marketplace
  indexing, web UI, Java plugin dev, scaffolding)
- CONTRIBUTING: fix prerequisites (protoc is auto-downloaded by make
  proto, not a manual install), add missing example plugins to the
  writing-a-plugin section
- CLAUDE.md: update examples list in Key Directories
- examples/README: add emojis, friendly descriptions, add missing
  zhi-store-mirror and zhi-ui-webui sections
- docs/plugin-development/overview.md: add missing examples
  (zhi-store-vault, zhi-ui-mcp-sse, zhi-ui-webui) to the table
- .claude/skills: fix incorrect import paths (itsluketwist -> MrWong99)
  in config-plugin, store-plugin, and transform-plugin SKILL.md

https://claude.ai/code/session_019z3N1wwAYToPkj7tZSYSbZ