### PR TITLE
Add metadata labels support to tree UI with filtering and readonly enforcement

### DIFF
--- a/pkg/providers/ui/webui/editor.go
+++ b/pkg/providers/ui/webui/editor.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/labels"
 	"github.com/MrWong99/zhi/pkg/zhiplugin/ui"
 )
 
@@ -56,10 +57,6 @@ func (s *Server) handleSaveValue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rawValue := r.FormValue("value")
-	valType := r.FormValue("value_type")
-	val := parseFormValue(rawValue, valType)
-
 	tree, err := s.ctrl.LoadTree(ctx)
 	if err != nil {
 		http.Error(w, "failed to load tree", http.StatusInternalServerError)
@@ -68,6 +65,17 @@ func (s *Server) handleSaveValue(w http.ResponseWriter, r *http.Request) {
 
 	// Preserve existing metadata.
 	existing, _ := tree.Get(path)
+
+	// Reject edits to readonly or immutable values.
+	if labels.IsReadonly(existing.Metadata) || labels.IsImmutable(existing.Metadata) {
+		http.Error(w, "this value is read-only", http.StatusForbidden)
+		return
+	}
+
+	rawValue := r.FormValue("value")
+	valType := r.FormValue("value_type")
+	val := parseFormValue(rawValue, valType)
+
 	newValue := config.Value{
 		Val:      val,
 		Metadata: existing.Metadata,
@@ -98,7 +106,8 @@ func (s *Server) handleSaveValue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Success: return display mode and mark unsaved.
-	w.Header().Set("HX-Trigger", `{"markUnsaved": true}`)
+	// Also trigger valueChanged so tree content can refresh (for showIf visibility).
+	w.Header().Set("HX-Trigger", `{"markUnsaved": true, "valueChanged": true}`)
 	ed := newEditorData(path, newValue, compMap)
 	if err := s.engine.renderFragment(w, "value_display", ed); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -189,6 +198,7 @@ type editorData struct {
 	Path              string
 	PathID            string
 	Name              string
+	DisplayName       string // ui.displayName: human-readable name shown instead of raw path segment
 	DisplayValue      string
 	EditValue         string
 	ValueType         string
@@ -196,8 +206,23 @@ type editorData struct {
 	ComponentEnabled  bool
 	Metadata          map[string]any
 	IsMultiline       bool
-	Options           []string
-	Placeholder       string
+	Options           []string // ui.enum: allowed values for dropdown
+	Placeholder       string   // ui.placeholder
+	IsReadonly        bool     // ui.readonly or config.immutable
+	IsPassword        bool     // ui.password: mask input
+	IsRequired        bool     // config.required
+	IsDeprecated      bool     // core.deprecated is set
+	DeprecatedMsg     string   // core.deprecated message text
+	ShouldConfirm     bool     // ui.confirm: require confirmation before save
+	Pattern           string   // ui.pattern: regex for input validation
+	Description       string   // core.description
+	DocURL            string   // core.doc: link to documentation
+	SemanticType      string   // core.type: email, url, hostname, etc.
+	Unit              string   // core.unit: seconds, MB, percent, etc.
+	Example           string   // core.example
+	Format            string   // ui.format: json, yaml, code, etc.
+	Section           string   // ui.section
+	Group             string   // ui.group
 	Error             string
 	ValidationResults []validationItem
 }
@@ -211,6 +236,8 @@ func newEditorData(path string, value config.Value, compMap map[string]ui.Compon
 	segments := strings.Split(path, "/")
 	name := segments[len(segments)-1]
 
+	meta := value.Metadata
+
 	ed := editorData{
 		Path:         path,
 		PathID:       pathToID(path),
@@ -218,7 +245,7 @@ func newEditorData(path string, value config.Value, compMap map[string]ui.Compon
 		DisplayValue: formatValue(value.Val),
 		EditValue:    formatEditValue(value.Val),
 		ValueType:    valueType(value.Val),
-		Metadata:     value.Metadata,
+		Metadata:     meta,
 	}
 
 	// Component ownership.
@@ -227,19 +254,40 @@ func newEditorData(path string, value config.Value, compMap map[string]ui.Compon
 		ed.ComponentEnabled = comp.Enabled
 	}
 
-	// Extract metadata hints.
-	if value.Metadata != nil {
-		if p, ok := value.Metadata["ui.placeholder"].(string); ok {
-			ed.Placeholder = p
-		}
-		if _, ok := value.Metadata["ui.multiline"]; ok {
-			ed.IsMultiline = true
-		}
-		if opts, ok := value.Metadata["ui.options"].([]any); ok {
-			for _, o := range opts {
-				ed.Options = append(ed.Options, fmt.Sprintf("%v", o))
-			}
-		}
+	// Extract all metadata labels using the labels helpers.
+	ed.DisplayName = labels.GetDisplayName(meta)
+	ed.Placeholder = labels.GetPlaceholder(meta)
+	ed.IsMultiline = labels.IsMultiline(meta)
+	ed.IsReadonly = labels.IsReadonly(meta) || labels.IsImmutable(meta)
+	ed.IsPassword = labels.IsPassword(meta)
+	ed.IsRequired = labels.IsRequired(meta)
+	ed.ShouldConfirm = labels.ShouldConfirm(meta)
+	ed.Pattern = labels.GetPattern(meta)
+	ed.Description = labels.GetDescription(meta)
+	ed.DocURL = labels.GetDocURL(meta)
+	ed.SemanticType = labels.GetSemanticType(meta)
+	ed.Unit = labels.GetString(meta, labels.LabelCoreUnit, "")
+	ed.Format = labels.GetString(meta, labels.LabelUIFormat, "")
+	ed.Section = labels.GetSection(meta)
+	ed.Group = labels.GetGroup(meta)
+
+	// core.deprecated
+	ed.DeprecatedMsg = labels.GetString(meta, labels.LabelCoreDeprecated, "")
+	ed.IsDeprecated = ed.DeprecatedMsg != ""
+
+	// core.example
+	if ex, ok := labels.GetAny(meta, labels.LabelCoreExample); ok {
+		ed.Example = fmt.Sprintf("%v", ex)
+	}
+
+	// ui.enum: dropdown options.
+	if enumOpts := labels.GetEnum(meta); len(enumOpts) > 0 {
+		ed.Options = enumOpts
+	}
+
+	// Password values: mask display.
+	if ed.IsPassword {
+		ed.DisplayValue = "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022"
 	}
 
 	// Multiline detection: strings with newlines.

--- a/pkg/providers/ui/webui/routes.go
+++ b/pkg/providers/ui/webui/routes.go
@@ -113,13 +113,14 @@ func (s *Server) handleTree(w http.ResponseWriter, r *http.Request) {
 
 	filter := r.URL.Query().Get("filter")
 
-	// Apply filter if present.
+	// Apply filter if present. Keep a reference to the full tree
+	// so buildNestedTree can evaluate ui.showIf conditions.
 	var reader config.TreeReader = tree
 	if filter != "" {
 		reader = filterTree(tree, filter)
 	}
 
-	nodes := buildNestedTree(reader, components)
+	nodes := buildNestedTree(reader, tree, components)
 
 	data := pageData{
 		WorkspaceName: wsName,

--- a/pkg/providers/ui/webui/static/css/editor.css
+++ b/pkg/providers/ui/webui/static/css/editor.css
@@ -32,6 +32,7 @@
   align-items: center;
   gap: var(--space-2);
   margin-bottom: var(--space-1);
+  flex-wrap: wrap;
 }
 
 .editor-header .leaf-name {
@@ -47,6 +48,59 @@
 .value-textarea {
   resize: vertical;
   min-height: 80px;
+}
+
+/* Description shown below the editor header */
+.editor-description {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  font-family: var(--font-sans);
+  line-height: var(--leading-normal);
+}
+
+/* Deprecation warning in editor */
+.editor-deprecated-warning {
+  font-size: var(--text-sm);
+  color: #856404;
+  background: var(--color-warning-bg);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-sans);
+}
+
+/* Read-only value display inside form */
+.editor-readonly-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-tertiary);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-light);
+}
+
+/* Hint text for patterns, examples, doc links */
+.editor-hint {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+}
+
+.editor-hint code {
+  font-family: var(--font-mono);
+  background: var(--color-bg-tertiary);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+}
+
+.editor-hint a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.editor-hint a:hover {
+  color: var(--color-primary-hover);
 }
 
 .editor-meta {
@@ -66,6 +120,25 @@
 
 .meta-tag {
   font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-tertiary);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+}
+
+.meta-semantic-type {
+  color: var(--color-primary);
+}
+
+.meta-unit {
+  color: var(--color-text-muted);
+}
+
+.meta-format {
+  color: var(--color-info);
+}
+
+.meta-section {
   color: var(--color-text-secondary);
 }
 

--- a/pkg/providers/ui/webui/static/css/tree.css
+++ b/pkg/providers/ui/webui/static/css/tree.css
@@ -61,6 +61,7 @@
   padding: var(--space-1) var(--space-2);
   margin-left: var(--space-4);
   border-radius: var(--radius-sm);
+  flex-wrap: wrap;
 }
 
 .tree-leaf:hover {
@@ -99,6 +100,30 @@
   color: var(--color-warning);
 }
 
+.tree-leaf .leaf-value .value-password {
+  color: var(--color-text-muted);
+  letter-spacing: 0.1em;
+}
+
+/* Deprecated leaf styling */
+.tree-leaf-deprecated {
+  opacity: 0.7;
+}
+
+.deprecated-text {
+  text-decoration: line-through;
+  color: var(--color-text-muted);
+}
+
+/* Description shown below the leaf line */
+.leaf-description {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-left: var(--space-8);
+  padding: 0 var(--space-2) var(--space-1) var(--space-2);
+  font-family: var(--font-sans);
+}
+
 /* Component badges */
 .tree-component-badge {
   margin-left: var(--space-2);
@@ -106,6 +131,77 @@
 
 .tree-component-badge.disabled {
   opacity: 0.5;
+}
+
+/* Metadata label badges in tree */
+.badge-readonly {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+  font-weight: var(--font-medium);
+}
+
+.badge-required {
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
+  font-size: var(--text-xs);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+  font-weight: var(--font-medium);
+}
+
+.badge-deprecated {
+  background: var(--color-warning-bg);
+  color: #856404;
+  font-size: var(--text-xs);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+  font-weight: var(--font-medium);
+}
+
+.badge-password {
+  background: var(--color-primary-bg);
+  color: var(--color-primary);
+  font-size: var(--text-xs);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+  font-weight: var(--font-medium);
+}
+
+.badge-group {
+  background: var(--color-info-bg);
+  color: var(--color-info);
+  font-size: var(--text-xs);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+  font-weight: var(--font-medium);
+}
+
+/* Section headers in tree */
+.tree-section-header {
+  margin-left: var(--space-4);
+  margin-top: var(--space-3);
+  margin-bottom: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.tree-section-header .section-label {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-family: var(--font-sans);
+}
+
+/* Value unit display */
+.value-unit {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-left: var(--space-1);
 }
 
 /* Filter input */

--- a/pkg/providers/ui/webui/static/js/app.js
+++ b/pkg/providers/ui/webui/static/js/app.js
@@ -264,6 +264,22 @@
   registerShortcut("Esc", "Close edit form / Cancel", function () {});
   registerShortcut("?", "Show shortcut overlay", function () {});
 
+  // ---------- Boolean Toggle Text Sync ----------
+  // When a boolean toggle checkbox is changed via HTMX-swapped content,
+  // update the adjacent text label to match.
+  document.body.addEventListener("change", function (e) {
+    if (
+      e.target &&
+      e.target.classList.contains("toggle-input") &&
+      e.target.type === "checkbox"
+    ) {
+      var textSpan = e.target.parentElement.querySelector(".toggle-text");
+      if (textSpan) {
+        textSpan.textContent = e.target.checked ? "true" : "false";
+      }
+    }
+  });
+
   // ---------- Login Page Auth Method Selector ----------
 
   var authMethodSelect = document.getElementById("auth-method-select");

--- a/pkg/providers/ui/webui/templates/fragments/tree_node.html
+++ b/pkg/providers/ui/webui/templates/fragments/tree_node.html
@@ -1,24 +1,39 @@
 {{define "tree_node"}}
 {{if .IsLeaf}}
+  {{if .ShowSectionHeader}}
+    <div class="tree-section-header">
+      <span class="section-label">{{.SectionHeaderLabel}}</span>
+    </div>
+  {{end}}
   <div class="tree-value" id="tree-value-{{.PathID}}">
-    <div class="tree-leaf">
+    <div class="tree-leaf{{if .IsDeprecated}} tree-leaf-deprecated{{end}}">
       <span class="leaf-icon">&#9679;</span>
-      <span class="leaf-name">{{.Name}}</span>
+      <span class="leaf-name{{if .IsDeprecated}} deprecated-text{{end}}">{{if .DisplayName}}{{.DisplayName}}{{else}}{{.Name}}{{end}}</span>
+      {{if .IsReadonly}}<span class="badge badge-readonly">ro</span>{{end}}
+      {{if .IsRequired}}<span class="badge badge-required">req</span>{{end}}
+      {{if .IsDeprecated}}<span class="badge badge-deprecated">depr</span>{{end}}
+      {{if .Group}}<span class="badge badge-group">{{.Group}}</span>{{end}}
       {{if .Component}}
         <span class="badge badge-primary tree-component-badge{{if not .ComponentEnabled}} disabled{{end}}">{{.Component}}</span>
       {{end}}
       <span class="leaf-value">
-        {{if eq .ValueType "string"}}<span class="value-string">"{{.DisplayValue}}"</span>
+        {{if .IsPassword}}<span class="value-password">{{.DisplayValue}}</span>
+        {{else if eq .ValueType "string"}}<span class="value-string">"{{.DisplayValue}}"</span>
         {{else if eq .ValueType "number"}}<span class="value-number">{{.DisplayValue}}</span>
         {{else if eq .ValueType "bool"}}<span class="value-bool">{{.DisplayValue}}</span>
         {{else}}<span>{{.DisplayValue}}</span>
         {{end}}
       </span>
-      <button class="btn btn-sm btn-outline edit-btn"
-              hx-get="/tree/edit/{{.Path}}"
-              hx-target="#tree-value-{{.PathID}}"
-              hx-swap="outerHTML">Edit</button>
+      {{if not .IsReadonly}}
+        <button class="btn btn-sm btn-outline edit-btn"
+                hx-get="/tree/edit/{{.Path}}"
+                hx-target="#tree-value-{{.PathID}}"
+                hx-swap="outerHTML">Edit</button>
+      {{end}}
     </div>
+    {{if .Description}}
+      <div class="leaf-description">{{.Description}}</div>
+    {{end}}
   </div>
 {{else}}
   <div class="tree-node">

--- a/pkg/providers/ui/webui/templates/fragments/value_display.html
+++ b/pkg/providers/ui/webui/templates/fragments/value_display.html
@@ -2,21 +2,31 @@
 <div class="tree-value" id="tree-value-{{.PathID}}">
   <div class="tree-leaf">
     <span class="leaf-icon">&#9679;</span>
-    <span class="leaf-name">{{.Name}}</span>
+    <span class="leaf-name{{if .IsDeprecated}} deprecated-text{{end}}">{{if .DisplayName}}{{.DisplayName}}{{else}}{{.Name}}{{end}}</span>
+    {{if .IsReadonly}}<span class="badge badge-readonly">ro</span>{{end}}
+    {{if .IsRequired}}<span class="badge badge-required">req</span>{{end}}
+    {{if .IsDeprecated}}<span class="badge badge-deprecated">depr</span>{{end}}
     {{if .Component}}
       <span class="badge badge-primary tree-component-badge{{if not .ComponentEnabled}} disabled{{end}}">{{.Component}}</span>
     {{end}}
     <span class="leaf-value">
-      {{if eq .ValueType "string"}}<span class="value-string">"{{.DisplayValue}}"</span>
+      {{if .IsPassword}}<span class="value-password">{{.DisplayValue}}</span>
+      {{else if eq .ValueType "string"}}<span class="value-string">"{{.DisplayValue}}"</span>
       {{else if eq .ValueType "number"}}<span class="value-number">{{.DisplayValue}}</span>
       {{else if eq .ValueType "bool"}}<span class="value-bool">{{.DisplayValue}}</span>
       {{else}}<span>{{.DisplayValue}}</span>
       {{end}}
+      {{if .Unit}}<span class="value-unit">{{.Unit}}</span>{{end}}
     </span>
-    <button class="btn btn-sm btn-outline edit-btn"
-            hx-get="/tree/edit/{{.Path}}"
-            hx-target="#tree-value-{{.PathID}}"
-            hx-swap="outerHTML">Edit</button>
+    {{if not .IsReadonly}}
+      <button class="btn btn-sm btn-outline edit-btn"
+              hx-get="/tree/edit/{{.Path}}"
+              hx-target="#tree-value-{{.PathID}}"
+              hx-swap="outerHTML">Edit</button>
+    {{end}}
   </div>
+  {{if .Description}}
+    <div class="leaf-description">{{.Description}}</div>
+  {{end}}
 </div>
 {{end}}

--- a/pkg/providers/ui/webui/templates/fragments/value_form.html
+++ b/pkg/providers/ui/webui/templates/fragments/value_form.html
@@ -3,16 +3,31 @@
   <form class="editor-form"
         hx-post="/tree/values/{{.Path}}"
         hx-target="#tree-value-{{.PathID}}"
-        hx-swap="outerHTML">
+        hx-swap="outerHTML"
+        {{if .ShouldConfirm}}hx-confirm="Are you sure you want to change this value?"{{end}}>
     <div class="editor-header">
       <span class="leaf-icon">&#9679;</span>
-      <span class="leaf-name">{{.Name}}</span>
+      <span class="leaf-name{{if .IsDeprecated}} deprecated-text{{end}}">{{if .DisplayName}}{{.DisplayName}}{{else}}{{.Name}}{{end}}</span>
+      {{if .IsReadonly}}<span class="badge badge-readonly">readonly</span>{{end}}
+      {{if .IsRequired}}<span class="badge badge-required">required</span>{{end}}
+      {{if .IsPassword}}<span class="badge badge-password">password</span>{{end}}
+      {{if .IsDeprecated}}<span class="badge badge-deprecated">deprecated</span>{{end}}
       {{if .Component}}
         <span class="badge badge-primary tree-component-badge{{if not .ComponentEnabled}} disabled{{end}}">{{.Component}}</span>
       {{end}}
+      {{if .Group}}<span class="badge badge-group">{{.Group}}</span>{{end}}
     </div>
+    {{if .Description}}
+      <div class="editor-description">{{.Description}}</div>
+    {{end}}
+    {{if .IsDeprecated}}
+      <div class="editor-deprecated-warning">Deprecated: {{.DeprecatedMsg}}</div>
+    {{end}}
     <input type="hidden" name="value_type" value="{{.ValueType}}">
-    {{if .Options}}
+    {{if .IsReadonly}}
+      {{/* Read-only display: show value but no editable input */}}
+      <div class="editor-readonly-value">{{.EditValue}}</div>
+    {{else if .Options}}
       <select name="value" class="input value-input" autofocus>
         {{range .Options}}
           <option value="{{.}}" {{if eq . $.EditValue}}selected{{end}}>{{.}}</option>
@@ -28,15 +43,27 @@
       <textarea name="value" class="input value-input value-textarea" autofocus
                 rows="4"
                 {{if .Placeholder}}placeholder="{{.Placeholder}}"{{end}}
+                {{if .Pattern}}pattern="{{.Pattern}}"{{end}}
                 hx-post="/validate/inline/{{.Path}}"
                 hx-trigger="input changed delay:500ms"
                 hx-target="#validation-inline-{{.PathID}}"
                 hx-swap="innerHTML"
                 hx-include="[name='value_type']">{{.EditValue}}</textarea>
+    {{else if .IsPassword}}
+      <input type="password" name="value" value="{{.EditValue}}"
+             class="input value-input" autofocus
+             {{if .Placeholder}}placeholder="{{.Placeholder}}"{{end}}
+             {{if .Pattern}}pattern="{{.Pattern}}"{{end}}
+             hx-post="/validate/inline/{{.Path}}"
+             hx-trigger="input changed delay:500ms"
+             hx-target="#validation-inline-{{.PathID}}"
+             hx-swap="innerHTML"
+             hx-include="[name='value_type']">
     {{else if eq .ValueType "number"}}
       <input type="number" name="value" value="{{.EditValue}}"
              class="input value-input" autofocus step="any"
              {{if .Placeholder}}placeholder="{{.Placeholder}}"{{end}}
+             {{if .Pattern}}pattern="{{.Pattern}}"{{end}}
              hx-post="/validate/inline/{{.Path}}"
              hx-trigger="input changed delay:500ms"
              hx-target="#validation-inline-{{.PathID}}"
@@ -46,11 +73,15 @@
       <input type="text" name="value" value="{{.EditValue}}"
              class="input value-input" autofocus
              {{if .Placeholder}}placeholder="{{.Placeholder}}"{{end}}
+             {{if .Pattern}}pattern="{{.Pattern}}"{{end}}
              hx-post="/validate/inline/{{.Path}}"
              hx-trigger="input changed delay:500ms"
              hx-target="#validation-inline-{{.PathID}}"
              hx-swap="innerHTML"
              hx-include="[name='value_type']">
+    {{end}}
+    {{if .Pattern}}
+      <div class="editor-hint">Pattern: <code>{{.Pattern}}</code></div>
     {{end}}
     <div id="validation-inline-{{.PathID}}" class="validation-inline">
       {{if .ValidationResults}}
@@ -64,14 +95,21 @@
     {{end}}
     <div class="editor-meta">
       <span class="meta-type">{{.ValueType}}</span>
-      {{if .Metadata}}
-        {{range $k, $v := .Metadata}}
-          <span class="meta-tag">{{$k}}: {{$v}}</span>
-        {{end}}
-      {{end}}
+      {{if .SemanticType}}<span class="meta-tag meta-semantic-type">{{.SemanticType}}</span>{{end}}
+      {{if .Unit}}<span class="meta-tag meta-unit">{{.Unit}}</span>{{end}}
+      {{if .Format}}<span class="meta-tag meta-format">{{.Format}}</span>{{end}}
+      {{if .Section}}<span class="meta-tag meta-section">{{.Section}}</span>{{end}}
     </div>
+    {{if .Example}}
+      <div class="editor-hint">Example: <code>{{.Example}}</code></div>
+    {{end}}
+    {{if .DocURL}}
+      <div class="editor-hint">Docs: <a href="{{.DocURL}}" target="_blank" rel="noopener noreferrer">{{.DocURL}}</a></div>
+    {{end}}
     <div class="editor-actions">
-      <button type="submit" class="btn btn-primary btn-sm">Save</button>
+      {{if not .IsReadonly}}
+        <button type="submit" class="btn btn-primary btn-sm">Save</button>
+      {{end}}
       <button type="button" class="btn btn-outline btn-sm"
               hx-get="/tree/display/{{.Path}}"
               hx-target="#tree-value-{{.PathID}}"

--- a/pkg/providers/ui/webui/templates/pages/tree.html
+++ b/pkg/providers/ui/webui/templates/pages/tree.html
@@ -16,7 +16,12 @@
   >
 </div>
 
-<div id="tree-content">
+<div id="tree-content"
+     hx-get="/tree"
+     hx-trigger="valueChanged from:body"
+     hx-target="#tree-content"
+     hx-select="#tree-content"
+     hx-swap="outerHTML">
   {{template "tree_content" .}}
 </div>
 {{end}}

--- a/pkg/providers/ui/webui/tree.go
+++ b/pkg/providers/ui/webui/tree.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/labels"
 	"github.com/MrWong99/zhi/pkg/zhiplugin/ui"
 )
 
@@ -20,31 +21,63 @@ type treeNode struct {
 	ValueType        string
 	Component        string
 	ComponentEnabled bool
+
+	// Label-aware fields for leaf nodes.
+	DisplayName        string // ui.displayName: shown instead of Name
+	IsPassword         bool   // ui.password: mask the displayed value
+	IsReadonly         bool   // ui.readonly or config.immutable
+	IsRequired         bool   // config.required
+	IsDeprecated       bool   // core.deprecated is set
+	Description        string // core.description: tooltip / subtitle
+	Section            string // ui.section: collapsible grouping
+	Group              string // ui.group: visual group badge
+	Order              int    // ui.order: sort key
+	ShowSectionHeader  bool   // true if this node starts a new section
+	SectionHeaderLabel string // the section name to display as header
 }
 
 // buildNestedTree converts flat config paths into a hierarchical tree of
-// treeNodes suitable for template rendering.
-func buildNestedTree(tree config.TreeReader, components []ui.ComponentInfo) []*treeNode {
+// treeNodes suitable for template rendering. fullTree is used for evaluating
+// ui.showIf conditions and may differ from displayTree when a text filter
+// is active.
+func buildNestedTree(displayTree config.TreeReader, fullTree config.TreeReader, components []ui.ComponentInfo) []*treeNode {
 	compMap := buildComponentMap(components)
 
-	paths := tree.List()
+	paths := displayTree.List()
 	sort.Strings(paths)
 
 	root := &treeNode{}
 	for _, path := range paths {
-		value, ok := tree.Get(path)
+		value, ok := displayTree.Get(path)
 		if !ok {
 			continue
 		}
+
+		// ui.hidden: skip entirely.
+		if labels.IsHidden(value.Metadata) {
+			continue
+		}
+
+		// ui.showIf: evaluate against the full tree.
+		if condPath, condVal := labels.ParseShowIf(value.Metadata); condPath != "" {
+			depVal, depOk := fullTree.Get(condPath)
+			if !depOk || fmt.Sprintf("%v", depVal.Val) != condVal {
+				continue
+			}
+		}
+
 		segments := strings.Split(path, "/")
 		insertTreeNode(root, segments, path, value, compMap)
 	}
+
+	// Sort children at every level and inject section headers.
+	sortTreeChildren(root)
 
 	return root.Children
 }
 
 // filterTree filters tree paths to those matching the filter string
-// (prefix or substring match on the full path).
+// (prefix or substring match on the full path or display name).
 func filterTree(tree config.TreeReader, filter string) config.TreeReader {
 	if filter == "" {
 		return tree
@@ -52,11 +85,14 @@ func filterTree(tree config.TreeReader, filter string) config.TreeReader {
 	filtered := config.NewTree()
 	lower := strings.ToLower(filter)
 	for _, path := range tree.List() {
-		if strings.Contains(strings.ToLower(path), lower) {
-			value, ok := tree.Get(path)
-			if ok {
-				_ = filtered.Set(path, &value)
-			}
+		value, ok := tree.Get(path)
+		if !ok {
+			continue
+		}
+		// Match against path or display name.
+		dn := strings.ToLower(labels.GetDisplayName(value.Metadata))
+		if strings.Contains(strings.ToLower(path), lower) || (dn != "" && strings.Contains(dn, lower)) {
+			_ = filtered.Set(path, &value)
 		}
 	}
 	return filtered
@@ -90,13 +126,28 @@ func insertTreeNode(parent *treeNode, segments []string, fullPath string, value 
 
 	if len(segments) == 1 {
 		// Leaf node.
+		meta := value.Metadata
+		displayVal := formatValue(value.Val)
+		if labels.IsPassword(meta) {
+			displayVal = "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022"
+		}
+
 		leaf := &treeNode{
 			Name:         name,
 			Path:         fullPath,
 			PathID:       pathToID(fullPath),
 			IsLeaf:       true,
-			DisplayValue: formatValue(value.Val),
+			DisplayValue: displayVal,
 			ValueType:    valueType(value.Val),
+			DisplayName:  labels.GetDisplayName(meta),
+			IsPassword:   labels.IsPassword(meta),
+			IsReadonly:   labels.IsReadonly(meta) || labels.IsImmutable(meta),
+			IsRequired:   labels.IsRequired(meta),
+			IsDeprecated: labels.IsDeprecatedValue(meta),
+			Description:  labels.GetDescription(meta),
+			Section:      labels.GetSection(meta),
+			Group:        labels.GetGroup(meta),
+			Order:        labels.GetOrder(meta),
 		}
 		if comp, ok := findComponent(fullPath, compMap); ok {
 			leaf.Component = comp.Name
@@ -120,6 +171,45 @@ func insertTreeNode(parent *treeNode, segments []string, fullPath string, value 
 	}
 
 	insertTreeNode(existing, segments[1:], fullPath, value, compMap)
+}
+
+// sortTreeChildren recursively sorts children at every level by ui.order,
+// then ui.section, then name. It also injects ShowSectionHeader flags
+// when the section changes between consecutive leaf children.
+func sortTreeChildren(node *treeNode) {
+	if len(node.Children) == 0 {
+		return
+	}
+
+	// Sort children: by Order, then Section, then Name.
+	sort.SliceStable(node.Children, func(i, j int) bool {
+		a, b := node.Children[i], node.Children[j]
+		if a.Order != b.Order {
+			return a.Order < b.Order
+		}
+		if a.Section != b.Section {
+			return a.Section < b.Section
+		}
+		return a.Name < b.Name
+	})
+
+	// Inject section headers for leaf children when section changes.
+	lastSection := ""
+	for _, child := range node.Children {
+		if child.IsLeaf && child.Section != "" && child.Section != lastSection {
+			child.ShowSectionHeader = true
+			child.SectionHeaderLabel = child.Section
+		}
+		if child.IsLeaf {
+			lastSection = child.Section
+		} else {
+			// Non-leaf (directory) nodes reset the section tracking.
+			lastSection = ""
+		}
+
+		// Recurse.
+		sortTreeChildren(child)
+	}
 }
 
 func findComponent(path string, compMap map[string]ui.ComponentInfo) (ui.ComponentInfo, bool) {

--- a/pkg/providers/ui/webui/webui_test.go
+++ b/pkg/providers/ui/webui/webui_test.go
@@ -452,7 +452,7 @@ func TestBuildNestedTree(t *testing.T) {
 	_ = tree.Set("db/port", &config.Value{Val: float64(5432)})
 	_ = tree.Set("app/name", &config.Value{Val: "myapp"})
 
-	nodes := buildNestedTree(tree, nil)
+	nodes := buildNestedTree(tree, tree, nil)
 	if len(nodes) != 2 {
 		t.Fatalf("got %d root nodes, want 2", len(nodes))
 	}
@@ -483,7 +483,7 @@ func TestBuildNestedTreeWithComponents(t *testing.T) {
 		{Name: "database", Enabled: true, Paths: []string{"db"}},
 	}
 
-	nodes := buildNestedTree(tree, components)
+	nodes := buildNestedTree(tree, tree, components)
 	if len(nodes) != 1 {
 		t.Fatalf("got %d nodes, want 1", len(nodes))
 	}
@@ -1050,7 +1050,7 @@ func TestTreeNodeHasPathID(t *testing.T) {
 	tree := config.NewTree()
 	_ = tree.Set("db/host", &config.Value{Val: "localhost"})
 
-	nodes := buildNestedTree(tree, nil)
+	nodes := buildNestedTree(tree, tree, nil)
 	leaf := nodes[0].Children[0]
 	if leaf.PathID != "db--host" {
 		t.Errorf("PathID = %q, want 'db--host'", leaf.PathID)
@@ -2391,7 +2391,7 @@ func BenchmarkTemplateRenderPage(b *testing.B) {
 	_ = tree.Set("db/host", &config.Value{Val: "localhost"})
 	_ = tree.Set("db/port", &config.Value{Val: float64(5432)})
 	_ = tree.Set("app/name", &config.Value{Val: "myapp"})
-	nodes := buildNestedTree(tree, nil)
+	nodes := buildNestedTree(tree, tree, nil)
 
 	data := pageData{
 		WorkspaceName: "bench",
@@ -2415,7 +2415,7 @@ func BenchmarkTemplateRenderFragment(b *testing.B) {
 	tree := config.NewTree()
 	_ = tree.Set("db/host", &config.Value{Val: "localhost"})
 	_ = tree.Set("db/port", &config.Value{Val: float64(5432)})
-	nodes := buildNestedTree(tree, nil)
+	nodes := buildNestedTree(tree, tree, nil)
 
 	data := pageData{
 		TreeNodes: nodes,
@@ -2437,7 +2437,7 @@ func BenchmarkBuildNestedTree(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		buildNestedTree(tree, nil)
+		buildNestedTree(tree, tree, nil)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR enhances the web UI tree view with comprehensive metadata label support, enabling rich configuration display with filtering, visibility conditions, and access control. Key changes include:

- **Metadata label extraction**: Integrate the `labels` package to extract and display configuration metadata (display names, descriptions, deprecation status, readonly/required flags, sections, groups, etc.)
- **Conditional visibility**: Implement `ui.showIf` condition evaluation and `ui.hidden` filtering in the tree builder
- **Readonly enforcement**: Prevent edits to readonly or immutable values at the API level
- **Tree filtering**: Enhance filter to match against both paths and display names
- **Tree organization**: Add section headers and sorting by `ui.order`, `ui.section`, and name
- **Enhanced UI**: Display metadata badges (readonly, required, deprecated, password, group), descriptions, deprecation warnings, and additional hints (pattern, example, doc URL, unit)
- **Password masking**: Mask password fields in both tree view and editor
- **Dynamic tree refresh**: Trigger tree content refresh when values change to update visibility based on `ui.showIf` conditions

## Why is this change needed?

Configuration values often have rich metadata that should be displayed to users (descriptions, deprecation warnings, access restrictions, semantic types, etc.). This PR makes that metadata visible and actionable in the UI, improving usability and preventing accidental edits to protected values. The filtering and visibility features help users navigate large configuration trees more effectively.

## How was this tested?

- Updated existing unit tests in `webui_test.go` to pass the new `fullTree` parameter to `buildNestedTree`
- Existing test coverage for tree building and filtering remains intact
- Manual verification of metadata display, filtering, and readonly enforcement would be needed

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor / code cleanup

## Checklist

- [x] My code follows the project's code style
- [x] I have updated tests for my changes
- [x] My commits are focused and have clear messages

## Additional Notes

The changes maintain backward compatibility—configurations without metadata labels will display normally. The `buildNestedTree` function now requires both a display tree (filtered) and full tree (for evaluating conditions), allowing proper handling of visibility rules even when filters are active.

https://claude.ai/code/session_01JZeDCrVdEQc6dZgHWMHsMS