### PR TITLE
fix(vault): cacert option key, bootstrap mount, orphan child tokens

### DIFF
--- a/docs/user-guide/vault-credentials.md
+++ b/docs/user-guide/vault-credentials.md
@@ -161,7 +161,7 @@ path "auth/approle/role/zhi-*/secret-id" {
   capabilities = ["create", "update"]
 }
 
-path "auth/token/create" {
+path "auth/token/create-orphan" {
   capabilities = ["create", "update"]
 }
 EOF

--- a/examples/zhi-store-vault/main.go
+++ b/examples/zhi-store-vault/main.go
@@ -10,9 +10,9 @@
 //	mount / ZHI_VAULT_MOUNT — KV v2 mount point (default: secret)
 //	prefix / ZHI_VAULT_PREFIX — Key prefix within the mount (default: zhi)
 //	namespace / VAULT_NAMESPACE — Vault namespace (optional, enterprise only)
-//	ca_cert / VAULT_CACERT      — CA certificate path (optional)
-//	client_cert / VAULT_CLIENT_CERT — Client certificate path (optional)
-//	client_key / VAULT_CLIENT_KEY   — Client private key path (optional)
+//	cacert (or ca_cert) / VAULT_CACERT      — CA certificate path (optional)
+//	clientcert (or client_cert) / VAULT_CLIENT_CERT — Client certificate path (optional)
+//	clientkey (or client_key) / VAULT_CLIENT_KEY   — Client private key path (optional)
 //	skip_verify / VAULT_SKIP_VERIFY — Disable TLS verification (optional)
 package main
 
@@ -36,9 +36,9 @@ func parseConfig(opts map[string]any) vault.Config {
 		Mount:      pluginopts.String(opts, "mount", "ZHI_VAULT_MOUNT", "secret"),
 		Prefix:     pluginopts.String(opts, "prefix", "ZHI_VAULT_PREFIX", "zhi"),
 		Namespace:  pluginopts.String(opts, "namespace", "VAULT_NAMESPACE", ""),
-		CACert:     pluginopts.String(opts, "ca_cert", "VAULT_CACERT", ""),
-		ClientCert: pluginopts.String(opts, "client_cert", "VAULT_CLIENT_CERT", ""),
-		ClientKey:  pluginopts.String(opts, "client_key", "VAULT_CLIENT_KEY", ""),
+		CACert:     pluginopts.StringAlias(opts, []string{"cacert", "ca_cert"}, "VAULT_CACERT", ""),
+		ClientCert: pluginopts.StringAlias(opts, []string{"clientcert", "client_cert"}, "VAULT_CLIENT_CERT", ""),
+		ClientKey:  pluginopts.StringAlias(opts, []string{"clientkey", "client_key"}, "VAULT_CLIENT_KEY", ""),
 		SkipVerify: skipVerify == "true" || skipVerify == "1",
 	}
 }

--- a/internal/cli/vault_credentials.go
+++ b/internal/cli/vault_credentials.go
@@ -139,9 +139,19 @@ func runVaultCredentialsRefresh(cmd *cobra.Command, _ []string) error {
 func runVaultCredentialsBootstrap(cmd *cobra.Command, _ []string) error {
 	w := cmd.OutOrStdout()
 
-	// Default mount and prefix for the vault-manager plugin.
+	// Read mount and prefix from workspace config, falling back to defaults.
 	mount := "secret"
 	prefix := "zhi"
+	if eng, err := engineFromCmd(cmd); err == nil {
+		if ws := eng.Workspace(); ws != nil {
+			if v, ok := ws.Store.Options["mount"].(string); ok && v != "" {
+				mount = v
+			}
+			if v, ok := ws.Store.Options["prefix"].(string); ok && v != "" {
+				prefix = v
+			}
+		}
+	}
 
 	policy := bootstrapPolicyHCLForCLI(mount, prefix)
 
@@ -180,7 +190,7 @@ func bootstrapPolicyHCLForCLI(mount, prefix string) string {
 		{"sys/policies/acl/zhi-*", []string{"read", "create", "update", "delete", "list"}},
 		{"auth/approle/role/zhi-*", []string{"read", "create", "update", "delete", "list"}},
 		{"auth/approle/role/zhi-*/secret-id", []string{"create", "update"}},
-		{"auth/token/create", []string{"create", "update"}},
+		{"auth/token/create-orphan", []string{"create", "update"}},
 	}
 	for i, p := range paths {
 		if i > 0 {

--- a/internal/cli/vault_credentials_test.go
+++ b/internal/cli/vault_credentials_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MrWong99/zhi/internal/core"
+)
+
+func TestBootstrapPolicyUsesWorkspaceMount(t *testing.T) {
+	eng := setupTestEngine(t, nil)
+	// Override the workspace store options with a custom mount and prefix.
+	ws := eng.Workspace()
+	ws.Store.Options = map[string]any{
+		"mount":  "kv",
+		"prefix": "myapp",
+	}
+
+	ctx := context.WithValue(context.Background(), engineKey, eng)
+	ctx = context.WithValue(ctx, registryKey, core.NewRegistry())
+
+	cmd := &cobra.Command{
+		Use:  "bootstrap",
+		RunE: runVaultCredentialsBootstrap,
+	}
+	cmd.Flags().BoolVar(&bootstrapDryRun, "dry-run", false, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--dry-run"})
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("runVaultCredentialsBootstrap: %v", err)
+	}
+
+	output := buf.String()
+
+	// Should use workspace mount "kv", not default "secret".
+	if strings.Contains(output, "secret/data/") {
+		t.Error("policy contains default mount 'secret' instead of workspace mount 'kv'")
+	}
+	if !strings.Contains(output, "kv/data/myapp/*") {
+		t.Errorf("expected 'kv/data/myapp/*' in policy, got:\n%s", output)
+	}
+	if !strings.Contains(output, "kv/metadata/myapp/*") {
+		t.Errorf("expected 'kv/metadata/myapp/*' in policy, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Mount: kv") {
+		t.Errorf("expected 'Mount: kv' in header, got:\n%s", output)
+	}
+}
+
+func TestBootstrapPolicyDefaultsWithoutWorkspaceOptions(t *testing.T) {
+	eng := setupTestEngine(t, nil)
+	// No store options set — should fall back to defaults.
+
+	ctx := context.WithValue(context.Background(), engineKey, eng)
+	ctx = context.WithValue(ctx, registryKey, core.NewRegistry())
+
+	cmd := &cobra.Command{
+		Use:  "bootstrap",
+		RunE: runVaultCredentialsBootstrap,
+	}
+	cmd.Flags().BoolVar(&bootstrapDryRun, "dry-run", false, "")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--dry-run"})
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("runVaultCredentialsBootstrap: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "secret/data/zhi/*") {
+		t.Errorf("expected default 'secret/data/zhi/*' in policy, got:\n%s", output)
+	}
+}
+
+func TestBootstrapPolicyIncludesOrphanTokenPath(t *testing.T) {
+	policy := bootstrapPolicyHCLForCLI("secret", "zhi")
+	if !strings.Contains(policy, "auth/token/create-orphan") {
+		t.Errorf("policy should reference auth/token/create-orphan, got:\n%s", policy)
+	}
+	if strings.Contains(policy, `"auth/token/create"`) {
+		t.Errorf("policy should not reference auth/token/create (non-orphan), got:\n%s", policy)
+	}
+}

--- a/pkg/providers/store/vaultmanager/adminclient.go
+++ b/pkg/providers/store/vaultmanager/adminclient.go
@@ -132,9 +132,11 @@ func (c *AdminClient) GenerateSecretID(ctx context.Context, roleName, wrapTTL st
 
 // --- Token operations ---
 
-// CreateToken creates a new Vault token with the given policies and TTL.
+// CreateToken creates a new orphan Vault token with the given policies and TTL.
+// It uses the auth/token/create-orphan endpoint so the child token's policies
+// do not need to be a subset of the parent token's policies.
 func (c *AdminClient) CreateToken(ctx context.Context, policies []string, ttl string) (string, error) {
-	resp, err := c.Request(ctx, http.MethodPost, "auth/token/create", map[string]any{
+	resp, err := c.Request(ctx, http.MethodPost, "auth/token/create-orphan", map[string]any{
 		"policies": policies,
 		"ttl":      ttl,
 		"num_uses": 0,

--- a/pkg/providers/store/vaultmanager/adminclient_test.go
+++ b/pkg/providers/store/vaultmanager/adminclient_test.go
@@ -244,8 +244,8 @@ func TestAdminClient_CreateToken(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %s, want POST", r.Method)
 		}
-		if r.URL.Path != "/v1/auth/token/create" {
-			t.Errorf("path = %s, want /v1/auth/token/create", r.URL.Path)
+		if r.URL.Path != "/v1/auth/token/create-orphan" {
+			t.Errorf("path = %s, want /v1/auth/token/create-orphan", r.URL.Path)
 		}
 		json.NewDecoder(r.Body).Decode(&gotBody)
 		json.NewEncoder(w).Encode(map[string]any{

--- a/pkg/providers/store/vaultmanager/integration_test.go
+++ b/pkg/providers/store/vaultmanager/integration_test.go
@@ -71,7 +71,7 @@ func TestIntegration_FullLifecycle(t *testing.T) {
 				},
 			})
 
-		case r.Method == http.MethodPost && path == "/v1/auth/token/create":
+		case r.Method == http.MethodPost && path == "/v1/auth/token/create-orphan":
 			tokensCreated++
 			json.NewEncoder(w).Encode(map[string]any{
 				"auth": map[string]any{

--- a/pkg/providers/store/vaultmanager/options.go
+++ b/pkg/providers/store/vaultmanager/options.go
@@ -42,9 +42,9 @@ func ParseConfig(opts map[string]any) (*Config, error) {
 		Mount:      pluginopts.String(opts, "mount", "ZHI_VAULT_MOUNT", "secret"),
 		Prefix:     pluginopts.String(opts, "prefix", "ZHI_VAULT_PREFIX", "zhi"),
 		Namespace:  pluginopts.String(opts, "namespace", "VAULT_NAMESPACE", ""),
-		CACert:     pluginopts.String(opts, "ca_cert", "VAULT_CACERT", ""),
-		ClientCert: pluginopts.String(opts, "client_cert", "VAULT_CLIENT_CERT", ""),
-		ClientKey:  pluginopts.String(opts, "client_key", "VAULT_CLIENT_KEY", ""),
+		CACert:     pluginopts.StringAlias(opts, []string{"cacert", "ca_cert"}, "VAULT_CACERT", ""),
+		ClientCert: pluginopts.StringAlias(opts, []string{"clientcert", "client_cert"}, "VAULT_CLIENT_CERT", ""),
+		ClientKey:  pluginopts.StringAlias(opts, []string{"clientkey", "client_key"}, "VAULT_CLIENT_KEY", ""),
 		SkipVerify: skipVerify == "true" || skipVerify == "1",
 		Workspace:  pluginopts.String(opts, "workspace", "", "default"),
 	}

--- a/pkg/providers/store/vaultmanager/options_test.go
+++ b/pkg/providers/store/vaultmanager/options_test.go
@@ -76,6 +76,38 @@ func TestParseConfig_TLSFields(t *testing.T) {
 	}
 }
 
+func TestParseConfig_CACertAlias(t *testing.T) {
+	opts := map[string]any{
+		"cacert": "/path/to/ca.pem",
+	}
+
+	cfg, err := ParseConfig(opts)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if cfg.CACert != "/path/to/ca.pem" {
+		t.Errorf("CACert = %q, want /path/to/ca.pem (cacert alias should work)", cfg.CACert)
+	}
+}
+
+func TestParseConfig_ClientCertAliases(t *testing.T) {
+	opts := map[string]any{
+		"clientcert": "/path/to/client.pem",
+		"clientkey":  "/path/to/client-key.pem",
+	}
+
+	cfg, err := ParseConfig(opts)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if cfg.ClientCert != "/path/to/client.pem" {
+		t.Errorf("ClientCert = %q, want /path/to/client.pem", cfg.ClientCert)
+	}
+	if cfg.ClientKey != "/path/to/client-key.pem" {
+		t.Errorf("ClientKey = %q, want /path/to/client-key.pem", cfg.ClientKey)
+	}
+}
+
 func TestChildVaultOptions_IncludesTLS(t *testing.T) {
 	cfg := &Config{
 		Addr:       "https://vault:8200",

--- a/pkg/providers/store/vaultmanager/store_test.go
+++ b/pkg/providers/store/vaultmanager/store_test.go
@@ -109,7 +109,7 @@ func TestStore_Login_AuthenticatesChild(t *testing.T) {
 			policyWritten = body.Policy
 			w.WriteHeader(http.StatusNoContent)
 
-		case path == "auth/token/create" && r.Method == http.MethodPost:
+		case path == "auth/token/create-orphan" && r.Method == http.MethodPost:
 			json.NewEncoder(w).Encode(map[string]any{
 				"auth": map[string]any{
 					"client_token": childToken,

--- a/pkg/zhiplugin/pluginopts/options.go
+++ b/pkg/zhiplugin/pluginopts/options.go
@@ -52,6 +52,26 @@ func String(opts map[string]any, key, envKey, defaultVal string) string {
 	return defaultVal
 }
 
+// StringAlias works like String but checks multiple option keys in order
+// before falling back to the environment variable and default value.
+// This is useful when an option has been renamed or has a common alias
+// (e.g. "cacert" vs "ca_cert").
+func StringAlias(opts map[string]any, keys []string, envKey, defaultVal string) string {
+	if opts != nil {
+		for _, key := range keys {
+			if v, ok := opts[key].(string); ok {
+				return v
+			}
+		}
+	}
+	if envKey != "" {
+		if v := os.Getenv(envKey); v != "" {
+			return v
+		}
+	}
+	return defaultVal
+}
+
 // Bool returns a boolean option value for key. If the key is absent or
 // not a bool, it returns defaultVal.
 func Bool(opts map[string]any, key string, defaultVal bool) bool {

--- a/pkg/zhiplugin/pluginopts/options_test.go
+++ b/pkg/zhiplugin/pluginopts/options_test.go
@@ -59,6 +59,46 @@ func TestStringFallbackToDefault(t *testing.T) {
 	}
 }
 
+func TestStringAlias_FirstKeyMatches(t *testing.T) {
+	opts := map[string]any{"cacert": "/path/to/ca.pem"}
+	got := StringAlias(opts, []string{"cacert", "ca_cert"}, "VAULT_CACERT", "")
+	if got != "/path/to/ca.pem" {
+		t.Errorf("StringAlias() = %q, want /path/to/ca.pem", got)
+	}
+}
+
+func TestStringAlias_SecondKeyMatches(t *testing.T) {
+	opts := map[string]any{"ca_cert": "/path/to/ca.pem"}
+	got := StringAlias(opts, []string{"cacert", "ca_cert"}, "VAULT_CACERT", "")
+	if got != "/path/to/ca.pem" {
+		t.Errorf("StringAlias() = %q, want /path/to/ca.pem", got)
+	}
+}
+
+func TestStringAlias_FirstKeyTakesPrecedence(t *testing.T) {
+	opts := map[string]any{"cacert": "/first", "ca_cert": "/second"}
+	got := StringAlias(opts, []string{"cacert", "ca_cert"}, "", "")
+	if got != "/first" {
+		t.Errorf("StringAlias() = %q, want /first (first key should take precedence)", got)
+	}
+}
+
+func TestStringAlias_FallbackToEnv(t *testing.T) {
+	t.Setenv("VAULT_CACERT", "/from-env")
+	opts := map[string]any{"other": "val"}
+	got := StringAlias(opts, []string{"cacert", "ca_cert"}, "VAULT_CACERT", "")
+	if got != "/from-env" {
+		t.Errorf("StringAlias() = %q, want /from-env", got)
+	}
+}
+
+func TestStringAlias_FallbackToDefault(t *testing.T) {
+	got := StringAlias(nil, []string{"cacert", "ca_cert"}, "", "default-val")
+	if got != "default-val" {
+		t.Errorf("StringAlias() = %q, want default-val", got)
+	}
+}
+
 func TestBool(t *testing.T) {
 	opts := map[string]any{"debug": true}
 	if !Bool(opts, "debug", false) {


### PR DESCRIPTION
## Summary

Fixes three vault-related bugs discovered during home-server deployment testing:

- **Bug — `cacert` option ignored for TLS**: Users writing `cacert` in zhi.yaml got silently ignored because `ParseConfig` looked for `ca_cert` (with underscore). Added `pluginopts.StringAlias()` to accept both key forms (`cacert`/`ca_cert`, `clientcert`/`client_cert`, `clientkey`/`client_key`). Applied to both vault-manager and standalone vault store plugins.
- **Bug — `bootstrap --dry-run` ignores workspace mount**: The command hardcoded `mount=secret` and `prefix=zhi` instead of reading from workspace config. Now reads `engine.Workspace().Store.Options` with fallback to defaults.
- **Bug — child token creation fails (policy subset rule)**: `CreateToken()` used `auth/token/create` which requires child policies to be a subset of the parent's. Switched to `auth/token/create-orphan` which has no such constraint, eliminating the undocumented manual step of adding the child policy to the admin user.

## Test plan

- [x] New `pluginopts.StringAlias()` unit tests (first key, second key, precedence, env fallback, default)
- [x] New `ParseConfig` alias tests (`cacert`, `clientcert`, `clientkey` without underscores)
- [x] New `vault_credentials_test.go` tests (workspace mount/prefix reading, default fallback, orphan token path in policy)
- [x] Updated existing test mocks to use `auth/token/create-orphan` endpoint
- [x] Full `make check` passes (fmt, vet, lint, all tests including integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)