### PR TITLE
style: fix gofmt alignment in templateFuncMap

### DIFF
--- a/pkg/providers/ui/webui/templates.go
+++ b/pkg/providers/ui/webui/templates.go
@@ -36,19 +36,19 @@ type templateEngine struct {
 // templateFuncMap returns the shared template function map.
 func templateFuncMap() template.FuncMap {
 	return template.FuncMap{
-		"csrfToken":    csrfTokenFunc,
-		"csrfField":    csrfFieldFunc,
-		"nonce":        nonceFunc,
-		"icon":         iconFunc,
-		"activeNav":    activeNavFunc,
-		"json":         jsonFunc,
-		"pathSegments": pathSegmentsFunc,
-		"pathID":       pathToID,
-		"seq":          seqFunc,
-		"sub":                func(a, b int) int { return a - b },
-		"add":                func(a, b int) int { return a + b },
-		"assetPath":          assetPathFunc,
-		"formatValidation":   formatValidationMessage,
+		"csrfToken":        csrfTokenFunc,
+		"csrfField":        csrfFieldFunc,
+		"nonce":            nonceFunc,
+		"icon":             iconFunc,
+		"activeNav":        activeNavFunc,
+		"json":             jsonFunc,
+		"pathSegments":     pathSegmentsFunc,
+		"pathID":           pathToID,
+		"seq":              seqFunc,
+		"sub":              func(a, b int) int { return a - b },
+		"add":              func(a, b int) int { return a + b },
+		"assetPath":        assetPathFunc,
+		"formatValidation": formatValidationMessage,
 	}
 }
 


### PR DESCRIPTION
Normalize map literal value alignment to column 20 (max key width "formatValidation": at 19 chars + 1 space padding) so all entries are consistently formatted by gofmt -s.

## What does this PR do?

<!--
A clear description of the change. Link any related issues with
"Closes #123" or "Relates to #456".
-->

## Why is this change needed?

<!--
Explain the motivation. What problem does it solve? What feature
does it add? A Trainer always knows *why* they're heading to the
next Gym.
-->

## How was this tested?

<!--
Describe the tests you ran or added. Did you run `make check`?
Any manual verification steps?
-->

- [ ] `make check` passes
- [ ] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [ ] My code follows the project's code style (`gofmt`, `go vet`)
- [ ] I have added/updated tests for my changes
- [ ] I have updated documentation if needed
- [ ] If I changed `.proto` files, I ran `make proto` and committed the generated code
- [ ] My commits are focused and have clear messages

## Additional Notes

<!--
Anything else reviewers should know? Screenshots of TUI changes,
performance considerations, migration steps, or just a fun Pokemon
fact to brighten our day -- all welcome.
-->
