### PR TITLE
fix(tlsutil): validate TLS file paths before use for clearer errors

### DIFF
--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -42,6 +42,29 @@ func (c *Config) Enabled() bool {
 	return c.CertFile != "" && c.KeyFile != ""
 }
 
+// Validate checks that all configured file paths exist and are accessible.
+// It is called automatically by [TLSConfig] but can also be called early
+// at startup to catch configuration errors before they cause opaque
+// failures deep in the TLS handshake.
+func (c *Config) Validate() error {
+	if c.CertFile != "" {
+		if _, err := os.Stat(c.CertFile); err != nil {
+			return fmt.Errorf("TLS certificate file not found at %q: %w", c.CertFile, err)
+		}
+	}
+	if c.KeyFile != "" {
+		if _, err := os.Stat(c.KeyFile); err != nil {
+			return fmt.Errorf("TLS key file not found at %q: %w", c.KeyFile, err)
+		}
+	}
+	if c.ClientCAFile != "" {
+		if _, err := os.Stat(c.ClientCAFile); err != nil {
+			return fmt.Errorf("client CA file not found at %q: %w", c.ClientCAFile, err)
+		}
+	}
+	return nil
+}
+
 // TLSConfig builds a [tls.Config] from the configuration. It returns an
 // error if the certificate cannot be loaded, the client CA cannot be
 // parsed, an unknown cipher suite name is given, or the minimum version
@@ -49,6 +72,9 @@ func (c *Config) Enabled() bool {
 //
 // The caller should only call TLSConfig when [Enabled] returns true.
 func (c *Config) TLSConfig() (*tls.Config, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
 	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("loading TLS certificate: %w", err)
@@ -136,11 +162,37 @@ func (c *ClientConfig) Enabled() bool {
 	return (c.CertFile != "" && c.KeyFile != "") || c.CAFile != "" || c.InsecureSkipVerify
 }
 
+// Validate checks that all configured file paths exist and are accessible.
+// It is called automatically by [HTTPClient] but can also be called early
+// at startup to catch configuration errors before they cause opaque
+// failures deep in the TLS handshake.
+func (c *ClientConfig) Validate() error {
+	if c.CAFile != "" {
+		if _, err := os.Stat(c.CAFile); err != nil {
+			return fmt.Errorf("CA certificate file not found at %q: %w", c.CAFile, err)
+		}
+	}
+	if c.CertFile != "" {
+		if _, err := os.Stat(c.CertFile); err != nil {
+			return fmt.Errorf("client certificate file not found at %q: %w", c.CertFile, err)
+		}
+	}
+	if c.KeyFile != "" {
+		if _, err := os.Stat(c.KeyFile); err != nil {
+			return fmt.Errorf("client key file not found at %q: %w", c.KeyFile, err)
+		}
+	}
+	return nil
+}
+
 // HTTPClient returns an [http.Client] configured with the client TLS
 // settings. If no settings are configured it returns nil.
 func (c *ClientConfig) HTTPClient(timeout time.Duration) (*http.Client, error) {
 	if !c.Enabled() {
 		return nil, nil
+	}
+	if err := c.Validate(); err != nil {
+		return nil, err
 	}
 	tc, err := c.tlsConfig()
 	if err != nil {

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -277,6 +278,67 @@ func TestRegisterFlags(t *testing.T) {
 	}
 }
 
+// --- Config.Validate tests ---
+
+func TestConfig_Validate_Empty(t *testing.T) {
+	c := &Config{}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate() on empty config: %v", err)
+	}
+}
+
+func TestConfig_Validate_ValidFiles(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := generateTestCert(t, dir, "")
+
+	c := &Config{CertFile: certFile, KeyFile: keyFile}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate() with valid files: %v", err)
+	}
+}
+
+func TestConfig_Validate_MissingCert(t *testing.T) {
+	c := &Config{CertFile: "/nonexistent/cert.pem", KeyFile: "/nonexistent/key.pem"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("expected error for missing cert file")
+	}
+	if !strings.Contains(err.Error(), "TLS certificate file not found") {
+		t.Errorf("error should mention TLS certificate file, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "/nonexistent/cert.pem") {
+		t.Errorf("error should include file path, got: %v", err)
+	}
+}
+
+func TestConfig_Validate_MissingKey(t *testing.T) {
+	dir := t.TempDir()
+	certFile, _ := generateTestCert(t, dir, "")
+
+	c := &Config{CertFile: certFile, KeyFile: "/nonexistent/key.pem"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("expected error for missing key file")
+	}
+	if !strings.Contains(err.Error(), "TLS key file not found") {
+		t.Errorf("error should mention TLS key file, got: %v", err)
+	}
+}
+
+func TestConfig_Validate_MissingClientCA(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := generateTestCert(t, dir, "")
+
+	c := &Config{CertFile: certFile, KeyFile: keyFile, ClientCAFile: "/nonexistent/ca.pem"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("expected error for missing client CA file")
+	}
+	if !strings.Contains(err.Error(), "client CA file not found") {
+		t.Errorf("error should mention client CA file, got: %v", err)
+	}
+}
+
 // --- ClientConfig tests ---
 
 func TestClientConfig_Enabled(t *testing.T) {
@@ -381,6 +443,65 @@ func TestClientConfig_HTTPClient_InsecureSkipVerify(t *testing.T) {
 	}
 	if !tr.TLSClientConfig.InsecureSkipVerify {
 		t.Error("InsecureSkipVerify should be true in TLS config")
+	}
+}
+
+// --- ClientConfig.Validate tests ---
+
+func TestClientConfig_Validate_Empty(t *testing.T) {
+	c := &ClientConfig{}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate() on empty config: %v", err)
+	}
+}
+
+func TestClientConfig_Validate_ValidCA(t *testing.T) {
+	dir := t.TempDir()
+	caFile, _ := generateTestCert(t, dir, "ca-")
+
+	c := &ClientConfig{CAFile: caFile}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate() with valid CA: %v", err)
+	}
+}
+
+func TestClientConfig_Validate_MissingCA(t *testing.T) {
+	c := &ClientConfig{CAFile: "/nonexistent/ca.pem"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("expected error for missing CA file")
+	}
+	if !strings.Contains(err.Error(), "CA certificate file not found") {
+		t.Errorf("error should mention CA certificate file, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "/nonexistent/ca.pem") {
+		t.Errorf("error should include file path, got: %v", err)
+	}
+}
+
+func TestClientConfig_Validate_MissingCert(t *testing.T) {
+	c := &ClientConfig{CertFile: "/nonexistent/c.pem", KeyFile: "/nonexistent/k.pem"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("expected error for missing cert file")
+	}
+	// CA is checked first (empty here), then cert.
+	if !strings.Contains(err.Error(), "client certificate file not found") {
+		t.Errorf("error should mention client certificate file, got: %v", err)
+	}
+}
+
+func TestClientConfig_Validate_MissingKey(t *testing.T) {
+	dir := t.TempDir()
+	certFile, _ := generateTestCert(t, dir, "client-")
+
+	c := &ClientConfig{CertFile: certFile, KeyFile: "/nonexistent/k.pem"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("expected error for missing key file")
+	}
+	if !strings.Contains(err.Error(), "client key file not found") {
+		t.Errorf("error should mention client key file, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `Validate()` methods to `tlsutil.Config` and `tlsutil.ClientConfig` that check file existence with descriptive error messages before TLS setup attempts to read them
- Call `Validate()` automatically from `TLSConfig()` and `HTTPClient()`, so all callers across the codebase benefit without code changes: vault plugin, vault-manager, webui, mirror, marketplace, and CLI plugin commands
- Add 10 tests covering both `Validate()` methods (empty config, valid files, missing cert/key/CA with message assertions)

## Context

When a plugin is configured with a TLS file path that doesn't exist (e.g. `ca_cert: /path/to/ca.crt` placeholder left in `zhi.yaml`), the error surfaces as a generic go-plugin handshake failure:

```
Unrecognized remote plugin message:
Failed to read any lines from plugin's stdout
```

The actual cause (`os.ReadFile` on a nonexistent path) was logged to the plugin's stderr but never reached the user. Now the error is caught early with a clear message like:

```
CA certificate file not found at "/path/to/ca.crt": stat /path/to/ca.crt: no such file or directory
```

## Test plan

- [x] All existing `tlsutil` tests pass (no behavior change for valid configs)
- [x] New `Validate()` tests verify error messages include file purpose and path
- [x] `vault`, `vaultmanager`, `webui` package tests pass
- [x] Full build (`make build build-examples`) succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)