### PR TITLE
Add interactive Runme tutorial for zhi

### DIFF
--- a/this_is_cool/01-what-is-zhi.md
+++ b/this_is_cool/01-what-is-zhi.md
@@ -1,0 +1,171 @@
+# Lesson 1: What is zhi?
+
+**zhi** is a security-first platform for configuration management and provisioning.
+Think of it as a framework where you define *what* your configuration looks like,
+*how* it gets transformed, *where* it's stored, and *how* you interact with it --
+all through a plugin system.
+
+## The Big Picture
+
+```text {"excludeFromRunAll": true}
+┌──────────────┐     ┌───────────────┐     ┌──────────────┐
+│   Config     │────▶│   Transform   │────▶│    Store     │
+│   Plugin     │     │   Plugin      │     │    Plugin    │
+│              │     │               │     │              │
+│ Defines the  │     │ Mutates or    │     │ Persists the │
+│ structure &  │     │ validates the │     │ config tree  │
+│ defaults     │     │ tree          │     │ (Vault, JSON,│
+│              │     │               │     │  memory...)  │
+└──────────────┘     └───────────────┘     └──────────────┘
+        │                                         │
+        └──────────────┐  ┌───────────────────────┘
+                       ▼  ▼
+                 ┌─────────────┐
+                 │  UI Plugin  │
+                 │             │
+                 │ TUI, Web,   │
+                 │ MCP/AI,     │
+                 │ HTTP API    │
+                 └─────────────┘
+```
+
+Four plugin types, one composable system. Let's install it and see for ourselves.
+
+---
+
+## Step 1: Install zhi
+
+We'll download the latest release from GitHub. The script auto-detects your OS and architecture.
+
+```sh {"name": "install-zhi", "interactive": true}
+# Detect OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+esac
+
+# Get the latest release tag
+LATEST=$(curl -s https://api.github.com/repos/MrWong99/zhi/releases/latest | jq -r '.tag_name')
+VERSION="${LATEST#v}"
+echo "Latest version: $LATEST ($OS/$ARCH)"
+
+# Download and extract
+TARBALL="zhi_${VERSION}_${OS}_${ARCH}.tar.gz"
+curl -sL "https://github.com/MrWong99/zhi/releases/download/${LATEST}/${TARBALL}" -o "/tmp/${TARBALL}"
+tar -xzf "/tmp/${TARBALL}" -C /tmp zhi
+
+# Move to a directory in your PATH
+sudo mv /tmp/zhi /usr/local/bin/zhi
+rm "/tmp/${TARBALL}"
+
+echo "Installed zhi ${VERSION} to /usr/local/bin/zhi"
+```
+
+### Verify the installation
+
+```sh {"name": "verify-zhi"}
+zhi version
+```
+
+> **Try it yourself:** If you prefer a different install location, adjust the `mv` target above.
+> You can also download directly from [GitHub Releases](https://github.com/MrWong99/zhi/releases).
+
+---
+
+## Step 2: Explore the CLI
+
+zhi's CLI is organized into subcommands. Let's see what's available.
+
+```sh {"name": "zhi-help"}
+zhi --help
+```
+
+The key commands you'll use throughout this tutorial:
+
+| Command | Purpose |
+|---------|---------|
+| `zhi init` | Create a new workspace |
+| `zhi list paths` | Browse the configuration tree |
+| `zhi get <path>` | Read a specific value |
+| `zhi set <path> <value>` | Update a value |
+| `zhi validate` | Check all validation rules |
+| `zhi export` | Render templates to files |
+| `zhi apply` | Run provisioning commands |
+| `zhi edit` | Open the interactive editor (TUI/Web/MCP) |
+
+### Try a few commands
+
+```sh {"name": "zhi-list-help", "interactive": true}
+# Explore subcommand help
+zhi list paths --help
+```
+
+```sh {"name": "zhi-plugin-help", "interactive": true}
+# Plugin management commands
+zhi plugin --help
+```
+
+---
+
+## Step 3: Understand the Workspace
+
+Every zhi project starts with a **workspace** -- a `zhi.yaml` file that declares:
+
+```yaml {"excludeFromRunAll": true}
+# Example zhi.yaml structure (don't run this, just read!)
+version: "1"
+
+config:
+  provider: structuredfile        # Where config definitions live
+  options:
+    directory: ./config           # YAML files defining the tree
+
+transform:                        # Optional: mutate/validate the tree
+  - provider: my-transform
+
+store:
+  provider: vault                 # Where values are persisted
+  options:
+    addr: http://127.0.0.1:8200
+
+ui:
+  provider: webui                 # How you interact with it
+  options:
+    addr: 127.0.0.1:8080
+
+components:                       # Logical groupings of config paths
+  - name: database
+    paths: ["database/"]
+
+export:                           # Files to generate from config
+  templates:
+    - name: docker-compose
+      template: ./templates/docker-compose.yml.tmpl
+      output: ./docker-compose.yml
+
+apply:
+  command: docker compose up -d   # Provisioning command
+```
+
+The magic: everything is **pluggable**. Swap `vault` for `json` storage, replace `webui`
+with `tui` or MCP -- the config tree stays the same.
+
+---
+
+## Check your work
+
+```sh {"name": "check-01"}
+if command -v zhi &>/dev/null; then
+  echo "✓ zhi is installed: $(zhi version 2>&1 | head -1)"
+else
+  echo "✗ zhi not found in PATH. Check the installation step above."
+  exit 1
+fi
+```
+
+---
+
+**Next up:** [Lesson 2 - Your First Workspace](02-your-first-workspace.md) -- we'll create
+a workspace from scratch and explore the config tree hands-on.

--- a/this_is_cool/01-what-is-zhi.md
+++ b/this_is_cool/01-what-is-zhi.md
@@ -167,5 +167,14 @@ fi
 
 ---
 
+## Further Reading
+
+- [Getting Started](../docs/user-guide/getting-started.md) -- installation and first workspace
+- [CLI Reference](../docs/user-guide/cli-reference.md) -- full command reference
+- [Workspace Configuration](../docs/user-guide/workspace-configuration.md) -- the `zhi.yaml` file format
+- [Plugin Development Overview](../docs/plugin-development/overview.md) -- building your own plugins
+
+---
+
 **Next up:** [Lesson 2 - Your First Workspace](02-your-first-workspace.md) -- we'll create
 a workspace from scratch and explore the config tree hands-on.

--- a/this_is_cool/02-your-first-workspace.md
+++ b/this_is_cool/02-your-first-workspace.md
@@ -26,10 +26,14 @@ cat /tmp/zhi-playground/zhi.yaml
 ```
 
 You should see:
-- `zhi.yaml` -- the workspace configuration
+- `zhi.yaml` -- the workspace configuration (a Pokedex example)
 - `config/` -- where you define your configuration structure
 - `templates/` -- where export templates live
+- `app-data/` -- example application data (from the Pokedex demo)
 - `.zhi/` -- internal state (component toggles, etc.)
+
+> **Note:** `zhi init` creates a Pokedex example workspace by default. In the next
+> step, we'll replace the config and `zhi.yaml` with our own.
 
 ---
 
@@ -41,6 +45,9 @@ This is a **structuredfile** config -- plain YAML that zhi reads as a config tre
 Validators use Go code that returns `[]config.ValidationResult`:
 
 ```sh {"name": "create-config", "interactive": true}
+# Remove the default Pokedex config so only our custom config is loaded
+rm -f /tmp/zhi-playground/config/app.yaml
+
 cat > /tmp/zhi-playground/config/app.yml << 'YAML'
 app:
   name:
@@ -395,12 +402,12 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-# Check validation passes
-if zhi validate 2>&1 | grep -q "blocking"; then
+# Check validation passes (exit code 0 means no blocking errors)
+if zhi validate >/dev/null 2>&1; then
+  echo "✓ Validation passes"
+else
   echo "✗ Validation has blocking errors -- fix them first!"
   ERRORS=$((ERRORS + 1))
-else
-  echo "✓ Validation passes"
 fi
 
 # Check export works

--- a/this_is_cool/02-your-first-workspace.md
+++ b/this_is_cool/02-your-first-workspace.md
@@ -218,11 +218,84 @@ cat /tmp/zhi-playground/app-config.json
 ```
 
 You just went from structured config definition to a rendered JSON file.
-This is the core loop: **define** -> **edit** -> **validate** -> **export**.
 
 ---
 
-## Step 6: Add Components
+## Step 6: Apply Configuration
+
+Exporting renders config into files -- but what about actually *doing* something
+with those files? That's where `zhi apply` comes in.
+
+`zhi apply` runs a shell command you define in `zhi.yaml`. Typically this is
+something like `docker compose up -d`, `kubectl apply`, or any provisioning tool.
+When `pre-export: true` is set, zhi re-exports all templates before running the command.
+
+Let's add an apply command to our workspace:
+
+```sh {"name": "add-apply", "interactive": true}
+cat > /tmp/zhi-playground/zhi.yaml << 'YAML'
+version: "1"
+
+config:
+  provider: structuredfile
+  options:
+    directory: ./config
+
+export:
+  templates:
+    - name: app-config
+      template: ./templates/app-config.json.tmpl
+      output: ./app-config.json
+
+apply:
+  command: "echo 'Configuration applied! Generated app-config.json:' && cat ./app-config.json"
+  pre-export: true
+  timeout: 30
+YAML
+
+echo "Workspace updated with apply command!"
+```
+
+Now run it:
+
+```sh {"name": "run-apply", "interactive": true}
+cd /tmp/zhi-playground && zhi apply
+```
+
+The apply system:
+
+1. Runs `zhi export` first (because `pre-export: true`)
+2. Executes the configured `command` in a shell
+3. Streams stdout/stderr in real-time
+4. Reports the exit code
+
+You can preview what would run without executing:
+
+```sh {"name": "dry-run-apply", "interactive": true}
+cd /tmp/zhi-playground && zhi apply --dry-run
+```
+
+You can also define **named targets** for different operations (deploy, destroy, restart):
+
+```yaml {"excludeFromRunAll": true}
+# Example: named apply targets (don't run this, just read!)
+apply:
+  default:
+    command: "docker compose up -d"
+    pre-export: true
+  destroy:
+    command: "docker compose down -v"
+  restart:
+    command: "docker compose restart"
+```
+
+Run them with `zhi apply destroy` or `zhi apply restart`.
+
+This is the full core loop: **define** -> **edit** -> **validate** -> **export** -> **apply**.
+
+---
+
+## Step 7: Add Components
 
 Components let you group config paths and toggle them on/off.
 Let's add a database section and make it optional.
@@ -249,7 +322,7 @@ database:
       display-name: "DB Name"
 YAML
 
-# Update zhi.yaml with components
+# Update zhi.yaml with components (keep apply from Step 6)
 cat > /tmp/zhi-playground/zhi.yaml << 'YAML'
 version: "1"
 
@@ -272,6 +345,11 @@ export:
     - name: app-config
       template: ./templates/app-config.json.tmpl
       output: ./app-config.json
+
+apply:
+  command: "echo 'Configuration applied!' && cat ./app-config.json"
+  pre-export: true
+  timeout: 30
 YAML
 
 echo "Added database component!"
@@ -333,6 +411,14 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+# Check apply works
+if zhi apply 2>&1 | grep -q "exit code 0"; then
+  echo "✓ Apply runs successfully"
+else
+  echo "✗ Apply failed"
+  ERRORS=$((ERRORS + 1))
+fi
+
 if [ $ERRORS -eq 0 ]; then
   echo ""
   echo "All checks passed! You're ready for Lesson 3."
@@ -347,6 +433,17 @@ fi
 rm -rf /tmp/zhi-playground
 echo "Playground cleaned up."
 ```
+
+---
+
+## Further Reading
+
+- [Getting Started](../docs/user-guide/getting-started.md) -- installation and first workspace
+- [Workspace Configuration](../docs/user-guide/workspace-configuration.md) -- full `zhi.yaml` reference
+- [Export and Templates](../docs/user-guide/export-and-templates.md) -- template syntax and built-in formats
+- [Apply](../docs/user-guide/apply.md) -- apply commands, named targets, and streaming output
+- [Components](../docs/user-guide/components.md) -- grouping and toggling config paths
+- [Structured File Provider](../docs/plugin-development/structuredfile-provider.md) -- config file format and validation code
 
 ---
 

--- a/this_is_cool/02-your-first-workspace.md
+++ b/this_is_cool/02-your-first-workspace.md
@@ -1,0 +1,354 @@
+# Lesson 2: Your First Workspace
+
+In this lesson you'll create a workspace from scratch, explore the config tree,
+edit values, trigger validation, and export rendered files. All without any external
+services -- just zhi and your terminal.
+
+---
+
+## Step 1: Initialize a Workspace
+
+Let's create a playground workspace in a temporary directory.
+
+```sh {"name": "init-workspace", "interactive": true}
+# Create a fresh workspace
+mkdir -p /tmp/zhi-playground
+cd /tmp/zhi-playground
+zhi init
+```
+
+```sh {"name": "inspect-workspace"}
+# See what zhi init created
+ls -la /tmp/zhi-playground/
+echo ""
+echo "--- zhi.yaml ---"
+cat /tmp/zhi-playground/zhi.yaml
+```
+
+You should see:
+- `zhi.yaml` -- the workspace configuration
+- `config/` -- where you define your configuration structure
+- `templates/` -- where export templates live
+- `.zhi/` -- internal state (component toggles, etc.)
+
+---
+
+## Step 2: Define Some Configuration
+
+Let's create a config file that defines a small application's settings.
+This is a **structuredfile** config -- plain YAML that zhi reads as a config tree.
+
+Validators use Go code that returns `[]config.ValidationResult`:
+
+```sh {"name": "create-config", "interactive": true}
+cat > /tmp/zhi-playground/config/app.yml << 'YAML'
+app:
+  name:
+    val: "my-cool-app"
+    metadata:
+      description: "Application name"
+      display-name: "App Name"
+    validation: |-
+      name, ok := v.Val.(string)
+      if !ok || name == "" {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "app name must be a non-empty string",
+        }}, nil
+      }
+      return nil, nil
+
+  port:
+    val: 8080
+    metadata:
+      description: "HTTP port the application listens on"
+      display-name: "Port"
+    validation: |-
+      port, ok := v.Val.(int)
+      if !ok {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "port must be a number",
+        }}, nil
+      }
+      if port < 1024 || port > 65535 {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "port must be between 1024 and 65535",
+        }}, nil
+      }
+      return nil, nil
+
+  debug:
+    val: false
+    metadata:
+      description: "Enable debug mode"
+      display-name: "Debug Mode"
+
+  log-level:
+    val: "info"
+    metadata:
+      description: "Logging verbosity"
+      display-name: "Log Level"
+    validation: |-
+      level, ok := v.Val.(string)
+      if !ok {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "log-level must be a string",
+        }}, nil
+      }
+      allowed := map[string]bool{"trace": true, "debug": true, "info": true, "warn": true, "error": true}
+      if !allowed[level] {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "must be one of: trace, debug, info, warn, error",
+        }}, nil
+      }
+      return nil, nil
+YAML
+echo "Config created!"
+```
+
+---
+
+## Step 3: Browse the Config Tree
+
+Now let's see how zhi reads that file.
+
+```sh {"name": "list-tree", "interactive": true}
+cd /tmp/zhi-playground && zhi list paths
+```
+
+```sh {"name": "get-value", "interactive": true}
+# Read a specific value
+cd /tmp/zhi-playground && zhi get app/port
+```
+
+> **Try it yourself:** Run `zhi get app/name` or `zhi get app/debug` to read other values.
+
+```sh {"name": "try-get", "interactive": true}
+# Your turn! Get any value from the tree:
+cd /tmp/zhi-playground && zhi get app/name
+```
+
+---
+
+## Step 4: Edit Values
+
+You can set values directly from the CLI.
+
+```sh {"name": "set-value", "interactive": true}
+cd /tmp/zhi-playground && zhi set app/port 3000
+echo ""
+echo "New value:"
+zhi get app/port
+```
+
+### Trigger a Validation Error
+
+Remember the validator on `port`? It requires 1024-65535. Let's break it.
+
+```sh {"name": "set-invalid-value", "interactive": true}
+cd /tmp/zhi-playground && zhi set app/port 80
+echo ""
+echo "Validation results:"
+zhi validate
+```
+
+You should see a **blocking** validation error. Let's fix it:
+
+```sh {"name": "fix-value", "interactive": true}
+cd /tmp/zhi-playground && zhi set app/port 3000
+echo ""
+zhi validate
+```
+
+> **Try it yourself:** Try setting `app/log-level` to an invalid value like `"verbose"`,
+> then check `zhi validate`. Fix it afterward!
+
+```sh {"name": "try-validation", "interactive": true}
+# Your turn! Try breaking and fixing a value:
+cd /tmp/zhi-playground && zhi set app/log-level "verbose"
+zhi validate
+```
+
+---
+
+## Step 5: Export Templates
+
+Let's create a template that renders our config into a real file.
+
+```sh {"name": "create-template", "interactive": true}
+cat > /tmp/zhi-playground/templates/app-config.json.tmpl << 'TMPL'
+{
+  "name": "{{ .Get "app/name" }}",
+  "port": {{ .Get "app/port" }},
+  "debug": {{ .Get "app/debug" }},
+  "logLevel": "{{ .Get "app/log-level" }}"
+}
+TMPL
+
+# Register the template in zhi.yaml
+cat > /tmp/zhi-playground/zhi.yaml << 'YAML'
+version: "1"
+
+config:
+  provider: structuredfile
+  options:
+    directory: ./config
+
+export:
+  templates:
+    - name: app-config
+      template: ./templates/app-config.json.tmpl
+      output: ./app-config.json
+YAML
+
+echo "Template and workspace config updated!"
+```
+
+Now export:
+
+```sh {"name": "export-config", "interactive": true}
+cd /tmp/zhi-playground && zhi export
+echo ""
+echo "--- Generated app-config.json ---"
+cat /tmp/zhi-playground/app-config.json
+```
+
+You just went from structured config definition to a rendered JSON file.
+This is the core loop: **define** -> **edit** -> **validate** -> **export**.
+
+---
+
+## Step 6: Add Components
+
+Components let you group config paths and toggle them on/off.
+Let's add a database section and make it optional.
+
+```sh {"name": "add-database-config", "interactive": true}
+cat > /tmp/zhi-playground/config/database.yml << 'YAML'
+database:
+  host:
+    val: "localhost"
+    metadata:
+      description: "Database hostname"
+      display-name: "DB Host"
+
+  port:
+    val: 5432
+    metadata:
+      description: "Database port"
+      display-name: "DB Port"
+
+  name:
+    val: "myapp"
+    metadata:
+      description: "Database name"
+      display-name: "DB Name"
+YAML
+
+# Update zhi.yaml with components
+cat > /tmp/zhi-playground/zhi.yaml << 'YAML'
+version: "1"
+
+config:
+  provider: structuredfile
+  options:
+    directory: ./config
+
+components:
+  - name: app
+    paths: ["app/"]
+    mandatory: true
+
+  - name: database
+    paths: ["database/"]
+    mandatory: false
+
+export:
+  templates:
+    - name: app-config
+      template: ./templates/app-config.json.tmpl
+      output: ./app-config.json
+YAML
+
+echo "Added database component!"
+```
+
+```sh {"name": "list-components", "interactive": true}
+cd /tmp/zhi-playground && zhi component list
+```
+
+```sh {"name": "toggle-component", "interactive": true}
+# Disable the database component
+cd /tmp/zhi-playground && zhi component disable database
+echo ""
+echo "Components after disable:"
+zhi component list
+echo ""
+echo "Tree (database paths should be excluded):"
+zhi list paths
+```
+
+```sh {"name": "enable-component", "interactive": true}
+# Re-enable it
+cd /tmp/zhi-playground && zhi component enable database
+echo ""
+zhi list paths
+```
+
+---
+
+## Checkpoint
+
+Let's verify everything works:
+
+```sh {"name": "check-02"}
+cd /tmp/zhi-playground
+ERRORS=0
+
+# Check config tree has values
+if zhi get app/port &>/dev/null; then
+  echo "✓ Config tree is readable"
+else
+  echo "✗ Config tree not readable"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Check validation passes
+if zhi validate 2>&1 | grep -q "blocking"; then
+  echo "✗ Validation has blocking errors -- fix them first!"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✓ Validation passes"
+fi
+
+# Check export works
+if [ -f app-config.json ]; then
+  echo "✓ Export file exists"
+else
+  echo "✗ Export file missing -- run 'zhi export'"
+  ERRORS=$((ERRORS + 1))
+fi
+
+if [ $ERRORS -eq 0 ]; then
+  echo ""
+  echo "All checks passed! You're ready for Lesson 3."
+fi
+```
+
+---
+
+## Cleanup
+
+```sh {"name": "cleanup-02", "interactive": true, "excludeFromRunAll": true}
+rm -rf /tmp/zhi-playground
+echo "Playground cleaned up."
+```
+
+---
+
+**Next up:** [Lesson 3 - Deploy Vault](03-vault-setup.md) -- we'll deploy a real HashiCorp
+Vault instance and experience zhi's three different editing environments.

--- a/this_is_cool/03-vault-setup.md
+++ b/this_is_cool/03-vault-setup.md
@@ -271,5 +271,14 @@ fi
 
 ---
 
+## Further Reading
+
+- [Apply](../docs/user-guide/apply.md) -- apply commands, named targets, and streaming output
+- [Web UI](../docs/user-guide/web-ui.md) -- browser-based editing, keyboard shortcuts, TLS
+- [Vault Credential Management](../docs/user-guide/vault-credentials.md) -- AppRole and token generation for deployed apps
+- [Export and Templates](../docs/user-guide/export-and-templates.md) -- template syntax, component-aware rendering
+
+---
+
 **Next up:** [Lesson 4 - zhi Infrastructure](04-zhi-infrastructure.md) -- we'll deploy
 a plugin marketplace and mirror, then import all the published zhi plugins.

--- a/this_is_cool/03-vault-setup.md
+++ b/this_is_cool/03-vault-setup.md
@@ -4,7 +4,7 @@ Time to deploy real infrastructure. We'll use zhi's **Vault deployment workspace
 to stand up a HashiCorp Vault server -- and along the way, experience three different
 ways to edit configuration.
 
-This lesson has three parts:
+This lesson has four parts:
 
 1. **Deploy Vault** using the CLI (quick path)
 2. **Explore the TUI** -- zhi's terminal editor

--- a/this_is_cool/03-vault-setup.md
+++ b/this_is_cool/03-vault-setup.md
@@ -1,0 +1,275 @@
+# Lesson 3: Deploy Vault
+
+Time to deploy real infrastructure. We'll use zhi's **Vault deployment workspace**
+to stand up a HashiCorp Vault server -- and along the way, experience three different
+ways to edit configuration.
+
+This lesson has three parts:
+
+1. **Deploy Vault** using the CLI (quick path)
+2. **Explore the TUI** -- zhi's terminal editor
+3. **Explore the Web UI** -- browser-based editing
+4. **Explore MCP + AI** -- let Claude help you configure
+
+---
+
+## Part 1: Deploy Vault via CLI
+
+The `deploy/vault` workspace in the zhi repo is a complete Vault deployment system.
+Let's use it.
+
+### Set the admin password
+
+The workspace requires an admin password. Everything else has sensible defaults.
+
+```sh {"name": "set-vault-password", "interactive": true}
+cd ../deploy/vault
+
+# Set the admin password (this is for a local dev instance)
+zhi set vault-auth/admin-password "tutorial-password-123"
+```
+
+### Validate the configuration
+
+```sh {"name": "validate-vault", "interactive": true}
+cd ../deploy/vault && zhi validate
+```
+
+You should see no blocking errors. The workspace defines validators for everything:
+port ranges, auth method names, unseal threshold vs. shares, and more.
+
+### Browse the full config tree
+
+```sh {"name": "list-vault-config", "interactive": true}
+cd ../deploy/vault && zhi list paths
+```
+
+> **Try it yourself:** Inspect specific values to understand the defaults:
+
+```sh {"name": "explore-vault-values", "interactive": true}
+cd ../deploy/vault
+
+echo "=== Deployment Mode ==="
+zhi get vault-deploy/mode
+
+echo ""
+echo "=== Vault Version ==="
+zhi get vault-deploy/vault-version
+
+echo ""
+echo "=== Unseal Config ==="
+zhi get vault-deploy/unseal-shares
+zhi get vault-deploy/unseal-threshold
+
+echo ""
+echo "=== Auth Methods ==="
+zhi get vault-auth/methods
+```
+
+### Export and Apply
+
+This is the moment -- zhi will render all templates and run the bootstrap script.
+The script starts Vault in Docker, initializes it, unseals it, creates an admin user,
+and revokes the root token.
+
+```sh {"name": "export-vault", "interactive": true}
+cd ../deploy/vault && zhi export
+echo ""
+echo "Generated files:"
+ls -la apply.sh docker-compose.yml vault-config.hcl
+```
+
+```sh {"name": "apply-vault", "interactive": true}
+cd ../deploy/vault && zhi apply
+```
+
+> **Important:** The apply script prints **unseal keys** and a **root token** to your
+> terminal. In a real deployment, you'd save these securely. For this tutorial, the
+> admin user (`admin` / `tutorial-password-123`) is all you need.
+
+### Verify Vault is Running
+
+```sh {"name": "check-vault"}
+# Check Vault status
+curl -s http://127.0.0.1:8200/v1/sys/health | jq .
+```
+
+```sh {"name": "vault-login-test", "interactive": true}
+# Login with the admin user we created
+curl -s http://127.0.0.1:8200/v1/auth/userpass/login/admin \
+  -d '{"password": "tutorial-password-123"}' | jq '.auth.client_token'
+```
+
+Vault is running and bootstrapped -- entirely configured and deployed by zhi.
+
+---
+
+## Part 2: The TUI (Terminal UI)
+
+zhi's default editor is a full terminal UI built with Bubbletea. It gives you a
+navigable tree view, inline editing, validation dashboard, and more.
+
+```sh {"name": "launch-tui", "interactive": true, "excludeFromRunAll": true}
+# Launch the TUI editor
+# Navigate with arrow keys, Enter to edit, Tab to switch views
+# Press q or Ctrl+C to quit when you're done exploring
+cd ../deploy/vault && zhi edit --ui tui
+```
+
+**What to try in the TUI:**
+
+- Use `↑`/`↓` to browse the config tree
+- Press `Enter` on a value to edit it
+- Press `Tab` to switch between views (tree, validation, components, export)
+- Try the validation view to see all rules
+- Press `c` to manage components (try disabling `vault-secrets`)
+- Press `q` to quit
+
+> The TUI requires a terminal with TTY support. If you're running this in a
+> non-interactive environment, skip to the Web UI below.
+
+---
+
+## Part 3: The Web UI
+
+The Web UI is a browser-based editor. The Vault workspace is pre-configured to
+serve it on port 9090.
+
+```sh {"name": "launch-webui", "background": true, "interactive": false}
+# Start the Web UI in the background
+# It will auto-open your browser (if supported)
+cd ../deploy/vault && zhi edit --ui webui
+```
+
+Open your browser to **http://127.0.0.1:9090** (it may open automatically).
+
+**What to try in the Web UI:**
+
+- Browse the config tree on the left sidebar
+- Click a value to edit it inline
+- Use the keyboard shortcuts: `g t` (tree), `g v` (validation), `g c` (components)
+- Navigate to the **Validation** tab to see all rules
+- Try **Export** to preview generated files
+- Check out the **Marketplace** tab (empty for now -- we'll fill it in Lesson 4!)
+
+> When you're done, press `Ctrl+C` in the terminal to stop the Web UI,
+> or use the cell below:
+
+```sh {"name": "stop-webui", "interactive": true, "excludeFromRunAll": true}
+# Kill any running zhi edit process on port 9090
+lsof -ti:9090 | xargs -r kill 2>/dev/null
+echo "Web UI stopped."
+```
+
+---
+
+## Part 4: MCP + AI Editing
+
+This is where it gets interesting. zhi can run as an **MCP server**, which means
+AI assistants like Claude Code can read, edit, validate, and apply your configuration
+through natural language.
+
+### Option A: Claude Code (recommended)
+
+If you have Claude Code installed, register zhi as an MCP server:
+
+```sh {"name": "register-mcp", "interactive": true, "excludeFromRunAll": true}
+# Register zhi as an MCP server for this project
+claude mcp add zhi \
+  --scope project \
+  -- zhi edit --ui mcp-stdio --workspace ../deploy/vault/zhi.yaml
+```
+
+Then start Claude Code and try prompts like:
+
+- *"Show me the current Vault configuration"*
+- *"Change the unseal threshold to 2"*
+- *"What auth methods are enabled?"*
+- *"Validate the configuration and fix any issues"*
+- *"Enable the vault-secrets component and add the transit engine"*
+
+```sh {"name": "launch-claude", "interactive": true, "excludeFromRunAll": true}
+# Launch Claude Code (it will see zhi as an MCP tool)
+claude
+```
+
+### Option B: Any MCP-compatible client
+
+You can also run zhi as an HTTP-based MCP server (SSE transport) for any
+MCP-compatible client:
+
+```sh {"name": "launch-mcp-sse", "background": true, "interactive": false, "excludeFromRunAll": true}
+# Start MCP SSE server (requires the mcp-sse plugin)
+cd ../deploy/vault && zhi edit --ui mcp-sse
+```
+
+This serves the MCP protocol over HTTP at `http://127.0.0.1:8091/mcp`.
+
+### What MCP exposes
+
+When running as an MCP server, zhi provides:
+
+| MCP Tool | What it does |
+|----------|-------------|
+| `reload_tree` | Read the full config tree |
+| `set_value` | Update a config value |
+| `save` | Persist changes to store |
+| `validate` | Run all validators |
+| `export` | Render templates |
+| `apply` | Run provisioning commands |
+| `enable_component` / `disable_component` | Toggle components |
+| `store_login` / `store_logout` | Authenticate to the store |
+| `marketplace_search` / `marketplace_install` | Search and install plugins |
+
+The AI gets the full config structure with metadata, descriptions, and validation
+rules -- so it can make informed suggestions.
+
+```sh {"name": "stop-mcp-sse", "interactive": true, "excludeFromRunAll": true}
+# Stop the MCP SSE server
+lsof -ti:8091 | xargs -r kill 2>/dev/null
+echo "MCP SSE server stopped."
+```
+
+---
+
+## Checkpoint
+
+```sh {"name": "check-03"}
+ERRORS=0
+
+# Vault should be running
+if curl -sf http://127.0.0.1:8200/v1/sys/health > /dev/null 2>&1; then
+  echo "✓ Vault is running and healthy"
+else
+  echo "✗ Vault is not running. Check Docker."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Admin login should work
+TOKEN=$(curl -sf http://127.0.0.1:8200/v1/auth/userpass/login/admin \
+  -d '{"password": "tutorial-password-123"}' | jq -r '.auth.client_token')
+if [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ]; then
+  echo "✓ Admin login works"
+else
+  echo "✗ Admin login failed"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# KV v2 engine should be enabled
+MOUNTS=$(curl -sf -H "X-Vault-Token: $TOKEN" http://127.0.0.1:8200/v1/sys/mounts | jq -r 'keys[]')
+if echo "$MOUNTS" | grep -q "kv/"; then
+  echo "✓ KV v2 secret engine is mounted"
+else
+  echo "⚠ KV v2 not found. Enable the vault-secrets component and re-apply if needed."
+fi
+
+if [ $ERRORS -eq 0 ]; then
+  echo ""
+  echo "Vault is ready! Moving on to Lesson 4."
+fi
+```
+
+---
+
+**Next up:** [Lesson 4 - zhi Infrastructure](04-zhi-infrastructure.md) -- we'll deploy
+a plugin marketplace and mirror, then import all the published zhi plugins.

--- a/this_is_cool/04-zhi-infrastructure.md
+++ b/this_is_cool/04-zhi-infrastructure.md
@@ -223,12 +223,60 @@ If you prefer a visual experience, launch `zhi edit --ui webui` and navigate to
 the **Marketplace** tab (`g m`). Search for plugins by name or type, and click
 **Install** to pull them from the registry.
 
-### Search for plugins via CLI
+### Index plugins in the marketplace
 
-```sh {"name": "search-plugins", "interactive": true}
-# Search the marketplace from the CLI
-zhi plugin search store --type store 2>/dev/null || echo "(marketplace may need indexing first)"
+The installed plugins need to be indexed in the marketplace so they're searchable.
+The marketplace API requires `name`, `type`, and `ociRef` fields:
+
+```sh {"name": "index-marketplace", "interactive": true}
+MARKETPLACE="http://127.0.0.1:8090"
+API_KEY="tutorial-key-123"
+
+# Index each plugin with the marketplace
+for entry in \
+  "zhi-config-pokedex config" \
+  "zhi-transform-pokedex transform" \
+  "zhi-store-json store" \
+  "zhi-store-memory store" \
+  "zhi-store-mirror store" \
+  "zhi-ui-httpapi ui" \
+  "zhi-ui-mcp-sse ui" \
+  "zhi-ui-webui ui"; do
+
+  plugin="${entry%% *}"
+  ptype="${entry##* }"
+  echo -n "Indexing $plugin ($ptype)... "
+  curl -sf -X POST "$MARKETPLACE/api/v1/plugins" \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\": \"$plugin\", \"type\": \"$ptype\", \"ociRef\": \"ghcr.io/mrwong99/zhi/$plugin\"}" \
+    && echo "✓" || echo "⚠ (may already exist)"
+done
 ```
+
+### Search the marketplace
+
+You can search via curl or the Web UI:
+
+**Option A: curl**
+
+```sh {"name": "search-marketplace", "interactive": true}
+# Search for all indexed plugins
+curl -sf "http://127.0.0.1:8090/api/v1/search" | jq '.results[].name'
+```
+
+```sh {"name": "search-store-plugins", "interactive": true}
+# Search specifically for store plugins
+curl -sf "http://127.0.0.1:8090/api/v1/search?q=store&type=store" | jq '.results[].name'
+```
+
+> **Try it yourself:** Search for `ui`, `config`, or `transform` plugins!
+
+**Option B: Web UI Marketplace**
+
+Launch `zhi edit --ui webui` and navigate to the **Marketplace** tab (`g m`).
+Browse and search for plugins visually — the web UI reads from the same marketplace
+index you just populated via curl above.
 
 ---
 

--- a/this_is_cool/04-zhi-infrastructure.md
+++ b/this_is_cool/04-zhi-infrastructure.md
@@ -5,35 +5,71 @@ Now that Vault is running, we'll deploy zhi's own infrastructure:
 - **zhi-mirror** -- a pull-through cache and policy engine for plugins
 - **zhi-marketplace** -- a registry for browsing, searching, and rating plugins
 
-Then we'll populate them with the real plugins published at `ghcr.io/mrwong99/zhi/`.
+The zhi project publishes **pre-built workspaces** to the GitHub Container Registry.
+Instead of configuring everything from scratch, we'll install them with
+`zhi workspace install` -- which pulls the workspace files *and* automatically
+installs any required plugins.
 
 ---
 
-## Step 1: Install the Vault Store Plugin
+## Step 1: Install the Vault Workspace from OCI
 
-The zhi infrastructure workspace stores its config *in Vault* (the one we deployed
-in Lesson 3). To connect, we need the Vault store plugins.
+The Vault workspace we used in Lesson 3 is also available as an OCI artifact.
+Let's see how `zhi workspace install` works by installing it into a fresh directory.
 
-```sh {"name": "install-vault-plugins", "interactive": true}
+```sh {"name": "workspace-install-demo", "interactive": true}
 # Determine the latest release version
 ZHI_TAG=$(curl -sf https://api.github.com/repos/MrWong99/zhi/releases/latest | jq -r '.tag_name')
-echo "Using plugin version: $ZHI_TAG"
+echo "Latest version: $ZHI_TAG"
 
-# Install the Vault store plugins
-zhi plugin install "oci://ghcr.io/mrwong99/zhi/zhi-store-vault:${ZHI_TAG}" --skip-verify
-zhi plugin install "oci://ghcr.io/mrwong99/zhi/zhi-store-vault-manager:${ZHI_TAG}" --skip-verify
+# Install the Vault deployment workspace from the OCI registry
+# This downloads the workspace files AND installs any declared plugin dependencies
+zhi workspace install "oci://ghcr.io/mrwong99/zhi/zhi-workspace-vault:${ZHI_TAG}" /tmp/zhi-vault-demo
+
+echo ""
+echo "--- Installed workspace contents ---"
+ls -la /tmp/zhi-vault-demo/
+```
+
+That single command:
+
+1. **Pulled** the workspace OCI artifact from `ghcr.io`
+2. **Extracted** `zhi.yaml`, templates, config files, and apply scripts
+3. **Installed** any plugin dependencies declared in the workspace's lock file
+
+This is the recommended way to distribute and consume zhi workspaces -- no
+manual plugin installation, no copy-pasting config files.
+
+```sh {"name": "cleanup-vault-demo", "interactive": true, "excludeFromRunAll": true}
+rm -rf /tmp/zhi-vault-demo
+```
+
+---
+
+## Step 2: Install the zhi Infrastructure Workspace
+
+Now let's install the workspace that deploys the mirror and marketplace.
+This workspace stores its config in the Vault instance from Lesson 3.
+
+```sh {"name": "install-zhi-workspace", "interactive": true}
+ZHI_TAG=$(curl -sf https://api.github.com/repos/MrWong99/zhi/releases/latest | jq -r '.tag_name')
+
+# Install the zhi infrastructure workspace
+# --skip-plugins if you already have the vault plugins from Lesson 3
+zhi workspace install "oci://ghcr.io/mrwong99/zhi/zhi-workspace-zhi:${ZHI_TAG}" /tmp/zhi-infra
 
 echo ""
 echo "Installed plugins:"
 zhi plugin list
 ```
 
-> We use `--skip-verify` because this is a tutorial. In production, you'd configure
-> signing keys and let zhi verify plugin signatures automatically.
+> `zhi workspace install` automatically installs declared plugin dependencies.
+> If you already have them (e.g. the Vault store plugins from Lesson 3), the
+> existing versions are kept unless the workspace requires a newer version.
 
 ---
 
-## Step 2: Login to Vault
+## Step 3: Login to Vault
 
 The workspace needs to authenticate to Vault to read/write its configuration.
 The login happens interactively through the editor -- `zhi edit` provides a
@@ -43,7 +79,7 @@ For this tutorial, we'll configure the store auth directly in the workspace conf
 so it works non-interactively:
 
 ```sh {"name": "vault-login", "interactive": true}
-cd ../deploy/zhi
+cd /tmp/zhi-infra
 
 # Get a Vault token using the admin credentials from Lesson 3
 VAULT_TOKEN=$(curl -sf http://127.0.0.1:8200/v1/auth/userpass/login/admin \
@@ -57,66 +93,67 @@ export VAULT_TOKEN
 
 ```sh {"name": "verify-vault-store", "interactive": true}
 # Verify we can read from the store
-cd ../deploy/zhi && zhi list paths
+cd /tmp/zhi-infra && zhi list paths
 ```
 
 You should see the zhi infrastructure config tree, with values persisted in Vault.
 
 ---
 
-## Step 3: Configure the Infrastructure
+## Step 4: Configure via the Web UI Marketplace
 
-Let's review and adjust the settings. The workspace has three components:
+Instead of configuring via CLI, let's use the Web UI -- which includes a
+**Marketplace** tab for browsing and installing plugins visually.
 
-```sh {"name": "list-zhi-components", "interactive": true}
-cd ../deploy/zhi && zhi component list
-```
-
-### Review the defaults
-
-```sh {"name": "explore-zhi-config", "interactive": true}
-cd ../deploy/zhi
-
-echo "=== General Settings ==="
-zhi get zhi/registry
-
-echo ""
-echo "=== Mirror Settings ==="
-zhi get zhi-mirror/port
-zhi get zhi-mirror/marketplace
-zhi get zhi-mirror/signatures
-
-echo ""
-echo "=== Marketplace Settings ==="
-zhi get zhi-marketplace/port
-```
-
-### Set an API key for the marketplace
-
-The marketplace needs at least one API key for plugin indexing.
+First, set the API key for the marketplace so plugin indexing works:
 
 ```sh {"name": "set-marketplace-key", "interactive": true}
-cd ../deploy/zhi
+cd /tmp/zhi-infra
 
 # Set an API key (format: key=provider)
 zhi set zhi-marketplace/api-keys "tutorial-key-123=tutorial"
 ```
 
-> Note: `zhi set` automatically persists changes to the store (Vault), so there's
-> no separate save step needed.
+Now launch the Web UI:
 
-### Validate
+```sh {"name": "launch-webui-marketplace", "background": true, "interactive": false}
+cd /tmp/zhi-infra && zhi edit --ui webui
+```
 
-```sh {"name": "validate-zhi", "interactive": true}
-cd ../deploy/zhi && zhi validate
+Open your browser to the address shown (default **http://127.0.0.1:9090**).
+
+**What to explore in the Web UI:**
+
+- **Configuration Tree** (`g t`) -- browse and edit all infrastructure settings
+- **Components** (`g c`) -- enable/disable the marketplace and mirror components
+- **Validation** (`g v`) -- check for configuration errors
+- **Marketplace** (`g m`) -- browse, search, and install plugins from OCI registries
+- **Installed Plugins** (`g p`) -- view installed plugins, check for updates
+
+The Marketplace tab replaces manual `curl` calls to the API. It provides:
+
+- Full-text search by name, type, or keyword
+- Filtering by plugin type (config, transform, store, ui)
+- One-click install directly from the registry
+- Version info, ratings, and publisher details
+
+> When you're done exploring, press `Ctrl+C` in the terminal or run the cell below:
+
+```sh {"name": "stop-webui-marketplace", "interactive": true, "excludeFromRunAll": true}
+lsof -ti:9090 | xargs -r kill 2>/dev/null
+echo "Web UI stopped."
 ```
 
 ---
 
-## Step 4: Deploy the Infrastructure
+## Step 5: Deploy the Infrastructure
+
+```sh {"name": "validate-zhi", "interactive": true}
+cd /tmp/zhi-infra && zhi validate
+```
 
 ```sh {"name": "deploy-zhi-infra", "interactive": true}
-cd ../deploy/zhi
+cd /tmp/zhi-infra
 
 # Export generates docker-compose.yml, mirror policy, and API keys file
 zhi export
@@ -126,7 +163,7 @@ cat docker-compose.yml
 ```
 
 ```sh {"name": "apply-zhi-infra", "interactive": true}
-cd ../deploy/zhi && zhi apply
+cd /tmp/zhi-infra && zhi apply
 ```
 
 ### Verify the services
@@ -137,22 +174,22 @@ sleep 3
 
 echo "=== Mirror (port 8080) ==="
 curl -sf http://127.0.0.1:8080/.well-known/zhi-marketplace.json 2>/dev/null \
-  && echo " ✓ responding" || echo "starting..."
+  && echo " responding" || echo "starting..."
 
 echo ""
 echo "=== Marketplace (port 8090) ==="
 curl -sf http://127.0.0.1:8090/.well-known/zhi-marketplace.json 2>/dev/null \
-  && echo " ✓ responding" || echo "starting..."
+  && echo " responding" || echo "starting..."
 ```
 
 ---
 
-## Step 5: Populate with Real Plugins
+## Step 6: Install Plugins from the Registry
 
-Now the exciting part -- let's import all the published zhi plugins
-from GitHub Container Registry into our local mirror.
+Now let's install the published zhi plugins from GitHub Container Registry.
+You can do this via CLI or through the Web UI Marketplace tab:
 
-These are the real plugins from the zhi project:
+### Option A: CLI
 
 ```sh {"name": "import-plugins", "interactive": true}
 # Determine the latest release version
@@ -160,7 +197,7 @@ ZHI_TAG=$(curl -sf https://api.github.com/repos/MrWong99/zhi/releases/latest | j
 echo "Installing plugins at version: $ZHI_TAG"
 echo ""
 
-# Install each plugin (|| true to continue on already-installed)
+# Install plugins from the OCI registry
 for plugin in \
   zhi-config-pokedex \
   zhi-transform-pokedex \
@@ -173,68 +210,29 @@ for plugin in \
 
   echo -n "  $plugin... "
   zhi plugin install "oci://ghcr.io/mrwong99/zhi/${plugin}:${ZHI_TAG}" --skip-verify 2>&1 \
-    | tail -1 && echo "" || echo "⚠"
+    | tail -1 && echo "" || echo "(may already be installed)"
 done
 
 echo ""
 echo "Done! All plugins imported."
 ```
 
-### Index plugins in the marketplace
+### Option B: Web UI Marketplace
 
-Now let's tell the marketplace to index these plugins so they're searchable.
-The API requires `name`, `type`, and `ociRef` fields:
+If you prefer a visual experience, launch `zhi edit --ui webui` and navigate to
+the **Marketplace** tab (`g m`). Search for plugins by name or type, and click
+**Install** to pull them from the registry.
 
-```sh {"name": "index-marketplace", "interactive": true}
-MARKETPLACE="http://127.0.0.1:8090"
-API_KEY="tutorial-key-123"
+### Search for plugins via CLI
 
-# Index each plugin with the marketplace
-for entry in \
-  "zhi-config-pokedex config" \
-  "zhi-transform-pokedex transform" \
-  "zhi-store-json store" \
-  "zhi-store-memory store" \
-  "zhi-store-vault store" \
-  "zhi-store-vault-manager store" \
-  "zhi-store-mirror store" \
-  "zhi-ui-httpapi ui" \
-  "zhi-ui-mcp-sse ui" \
-  "zhi-ui-webui ui"; do
-
-  plugin="${entry%% *}"
-  ptype="${entry##* }"
-  echo -n "Indexing $plugin ($ptype)... "
-  curl -sf -X POST "$MARKETPLACE/api/v1/plugins" \
-    -H "Authorization: Bearer $API_KEY" \
-    -H "Content-Type: application/json" \
-    -d "{\"name\": \"$plugin\", \"type\": \"$ptype\", \"ociRef\": \"ghcr.io/mrwong99/zhi/$plugin\"}" \
-    && echo "✓" || echo "⚠ (may already exist)"
-done
-```
-
-### Search the marketplace
-
-```sh {"name": "search-marketplace", "interactive": true}
-# Search for all plugins via the marketplace API
-curl -sf "http://127.0.0.1:8090/api/v1/search" | jq '.results[].name'
-```
-
-```sh {"name": "search-store-plugins", "interactive": true}
-# Search specifically for store plugins
-curl -sf "http://127.0.0.1:8090/api/v1/search?q=store&type=store" | jq '.results[].name'
-```
-
-> **Try it yourself:** Search for `ui`, `config`, or `transform` plugins!
-
-```sh {"name": "try-search", "interactive": true}
-# Your turn!
-curl -sf "http://127.0.0.1:8090/api/v1/search?q=ui&type=ui" | jq '.results[].name'
+```sh {"name": "search-plugins", "interactive": true}
+# Search the marketplace from the CLI
+zhi plugin search store --type store 2>/dev/null || echo "(marketplace may need indexing first)"
 ```
 
 ---
 
-## Step 6: List Installed Plugins
+## Step 7: List Installed Plugins
 
 ```sh {"name": "list-installed", "interactive": true}
 zhi plugin list
@@ -243,7 +241,7 @@ zhi plugin list
 You now have a fully functional plugin ecosystem:
 - **Vault** stores the infrastructure config securely
 - **Mirror** caches OCI artifacts locally with policy enforcement
-- **Marketplace** provides search and discovery
+- **Marketplace** provides search and discovery via Web UI and CLI
 
 ---
 
@@ -284,5 +282,24 @@ fi
 
 ---
 
-**Next up:** [Lesson 5 - Plugins](05-plugins.md) -- we'll use the Pokedex plugins to
-see config, transforms, and validation in action.
+## Cleanup
+
+```sh {"name": "cleanup-04", "interactive": true, "excludeFromRunAll": true}
+rm -rf /tmp/zhi-infra
+echo "Infrastructure workspace cleaned up."
+```
+
+---
+
+## Further Reading
+
+- [Sharing and Registries](../docs/user-guide/sharing-and-registries.md) -- OCI plugin distribution, signing, and updates
+- [Plugin Discovery](../docs/user-guide/plugin-discovery.md) -- filesystem-based plugin discovery
+- [Enterprise Mirror](../docs/user-guide/enterprise-mirror.md) -- air-gapped OCI mirror for enterprise environments
+- [Web UI](../docs/user-guide/web-ui.md) -- browser-based editing and marketplace browsing
+- [Marketplace Indexing](../docs/user-guide/marketplace-indexing.md) -- indexing plugins for search and discovery
+
+---
+
+**Next up:** [Lesson 5 - Metadata Labels](05-plugins.md) -- we'll explore metadata labels
+that control how plugins interpret configuration values.

--- a/this_is_cool/04-zhi-infrastructure.md
+++ b/this_is_cool/04-zhi-infrastructure.md
@@ -1,0 +1,288 @@
+# Lesson 4: zhi Infrastructure
+
+Now that Vault is running, we'll deploy zhi's own infrastructure:
+
+- **zhi-mirror** -- a pull-through cache and policy engine for plugins
+- **zhi-marketplace** -- a registry for browsing, searching, and rating plugins
+
+Then we'll populate them with the real plugins published at `ghcr.io/mrwong99/zhi/`.
+
+---
+
+## Step 1: Install the Vault Store Plugin
+
+The zhi infrastructure workspace stores its config *in Vault* (the one we deployed
+in Lesson 3). To connect, we need the Vault store plugins.
+
+```sh {"name": "install-vault-plugins", "interactive": true}
+# Determine the latest release version
+ZHI_TAG=$(curl -sf https://api.github.com/repos/MrWong99/zhi/releases/latest | jq -r '.tag_name')
+echo "Using plugin version: $ZHI_TAG"
+
+# Install the Vault store plugins
+zhi plugin install "oci://ghcr.io/mrwong99/zhi/zhi-store-vault:${ZHI_TAG}" --skip-verify
+zhi plugin install "oci://ghcr.io/mrwong99/zhi/zhi-store-vault-manager:${ZHI_TAG}" --skip-verify
+
+echo ""
+echo "Installed plugins:"
+zhi plugin list
+```
+
+> We use `--skip-verify` because this is a tutorial. In production, you'd configure
+> signing keys and let zhi verify plugin signatures automatically.
+
+---
+
+## Step 2: Login to Vault
+
+The workspace needs to authenticate to Vault to read/write its configuration.
+The login happens interactively through the editor -- `zhi edit` provides a
+login view where you enter your Vault credentials.
+
+For this tutorial, we'll configure the store auth directly in the workspace config
+so it works non-interactively:
+
+```sh {"name": "vault-login", "interactive": true}
+cd ../deploy/zhi
+
+# Get a Vault token using the admin credentials from Lesson 3
+VAULT_TOKEN=$(curl -sf http://127.0.0.1:8200/v1/auth/userpass/login/admin \
+  -d '{"password": "tutorial-password-123"}' | jq -r '.auth.client_token')
+
+echo "Got Vault token: ${VAULT_TOKEN:0:10}..."
+
+# Temporarily set the token as an environment variable for the store
+export VAULT_TOKEN
+```
+
+```sh {"name": "verify-vault-store", "interactive": true}
+# Verify we can read from the store
+cd ../deploy/zhi && zhi list paths
+```
+
+You should see the zhi infrastructure config tree, with values persisted in Vault.
+
+---
+
+## Step 3: Configure the Infrastructure
+
+Let's review and adjust the settings. The workspace has three components:
+
+```sh {"name": "list-zhi-components", "interactive": true}
+cd ../deploy/zhi && zhi component list
+```
+
+### Review the defaults
+
+```sh {"name": "explore-zhi-config", "interactive": true}
+cd ../deploy/zhi
+
+echo "=== General Settings ==="
+zhi get zhi/registry
+
+echo ""
+echo "=== Mirror Settings ==="
+zhi get zhi-mirror/port
+zhi get zhi-mirror/marketplace
+zhi get zhi-mirror/signatures
+
+echo ""
+echo "=== Marketplace Settings ==="
+zhi get zhi-marketplace/port
+```
+
+### Set an API key for the marketplace
+
+The marketplace needs at least one API key for plugin indexing.
+
+```sh {"name": "set-marketplace-key", "interactive": true}
+cd ../deploy/zhi
+
+# Set an API key (format: key=provider)
+zhi set zhi-marketplace/api-keys "tutorial-key-123=tutorial"
+```
+
+> Note: `zhi set` automatically persists changes to the store (Vault), so there's
+> no separate save step needed.
+
+### Validate
+
+```sh {"name": "validate-zhi", "interactive": true}
+cd ../deploy/zhi && zhi validate
+```
+
+---
+
+## Step 4: Deploy the Infrastructure
+
+```sh {"name": "deploy-zhi-infra", "interactive": true}
+cd ../deploy/zhi
+
+# Export generates docker-compose.yml, mirror policy, and API keys file
+zhi export
+echo ""
+echo "--- Generated docker-compose.yml ---"
+cat docker-compose.yml
+```
+
+```sh {"name": "apply-zhi-infra", "interactive": true}
+cd ../deploy/zhi && zhi apply
+```
+
+### Verify the services
+
+```sh {"name": "check-services", "interactive": true}
+# Wait a moment for containers to start
+sleep 3
+
+echo "=== Mirror (port 8080) ==="
+curl -sf http://127.0.0.1:8080/.well-known/zhi-marketplace.json 2>/dev/null \
+  && echo " ✓ responding" || echo "starting..."
+
+echo ""
+echo "=== Marketplace (port 8090) ==="
+curl -sf http://127.0.0.1:8090/.well-known/zhi-marketplace.json 2>/dev/null \
+  && echo " ✓ responding" || echo "starting..."
+```
+
+---
+
+## Step 5: Populate with Real Plugins
+
+Now the exciting part -- let's import all the published zhi plugins
+from GitHub Container Registry into our local mirror.
+
+These are the real plugins from the zhi project:
+
+```sh {"name": "import-plugins", "interactive": true}
+# Determine the latest release version
+ZHI_TAG=$(curl -sf https://api.github.com/repos/MrWong99/zhi/releases/latest | jq -r '.tag_name')
+echo "Installing plugins at version: $ZHI_TAG"
+echo ""
+
+# Install each plugin (|| true to continue on already-installed)
+for plugin in \
+  zhi-config-pokedex \
+  zhi-transform-pokedex \
+  zhi-store-json \
+  zhi-store-memory \
+  zhi-store-mirror \
+  zhi-ui-httpapi \
+  zhi-ui-mcp-sse \
+  zhi-ui-webui; do
+
+  echo -n "  $plugin... "
+  zhi plugin install "oci://ghcr.io/mrwong99/zhi/${plugin}:${ZHI_TAG}" --skip-verify 2>&1 \
+    | tail -1 && echo "" || echo "⚠"
+done
+
+echo ""
+echo "Done! All plugins imported."
+```
+
+### Index plugins in the marketplace
+
+Now let's tell the marketplace to index these plugins so they're searchable.
+The API requires `name`, `type`, and `ociRef` fields:
+
+```sh {"name": "index-marketplace", "interactive": true}
+MARKETPLACE="http://127.0.0.1:8090"
+API_KEY="tutorial-key-123"
+
+# Index each plugin with the marketplace
+for entry in \
+  "zhi-config-pokedex config" \
+  "zhi-transform-pokedex transform" \
+  "zhi-store-json store" \
+  "zhi-store-memory store" \
+  "zhi-store-vault store" \
+  "zhi-store-vault-manager store" \
+  "zhi-store-mirror store" \
+  "zhi-ui-httpapi ui" \
+  "zhi-ui-mcp-sse ui" \
+  "zhi-ui-webui ui"; do
+
+  plugin="${entry%% *}"
+  ptype="${entry##* }"
+  echo -n "Indexing $plugin ($ptype)... "
+  curl -sf -X POST "$MARKETPLACE/api/v1/plugins" \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\": \"$plugin\", \"type\": \"$ptype\", \"ociRef\": \"ghcr.io/mrwong99/zhi/$plugin\"}" \
+    && echo "✓" || echo "⚠ (may already exist)"
+done
+```
+
+### Search the marketplace
+
+```sh {"name": "search-marketplace", "interactive": true}
+# Search for all plugins via the marketplace API
+curl -sf "http://127.0.0.1:8090/api/v1/search" | jq '.results[].name'
+```
+
+```sh {"name": "search-store-plugins", "interactive": true}
+# Search specifically for store plugins
+curl -sf "http://127.0.0.1:8090/api/v1/search?q=store&type=store" | jq '.results[].name'
+```
+
+> **Try it yourself:** Search for `ui`, `config`, or `transform` plugins!
+
+```sh {"name": "try-search", "interactive": true}
+# Your turn!
+curl -sf "http://127.0.0.1:8090/api/v1/search?q=ui&type=ui" | jq '.results[].name'
+```
+
+---
+
+## Step 6: List Installed Plugins
+
+```sh {"name": "list-installed", "interactive": true}
+zhi plugin list
+```
+
+You now have a fully functional plugin ecosystem:
+- **Vault** stores the infrastructure config securely
+- **Mirror** caches OCI artifacts locally with policy enforcement
+- **Marketplace** provides search and discovery
+
+---
+
+## Checkpoint
+
+```sh {"name": "check-04"}
+ERRORS=0
+
+# Check mirror
+if curl -sf http://127.0.0.1:8080/.well-known/zhi-marketplace.json > /dev/null 2>&1; then
+  echo "✓ Mirror is running"
+else
+  echo "✗ Mirror is not running"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Check marketplace
+if curl -sf http://127.0.0.1:8090/.well-known/zhi-marketplace.json > /dev/null 2>&1; then
+  echo "✓ Marketplace is running"
+else
+  echo "✗ Marketplace is not running"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Check plugins are installed
+PLUGIN_COUNT=$(zhi plugin list 2>/dev/null | wc -l)
+if [ "$PLUGIN_COUNT" -gt 5 ]; then
+  echo "✓ $PLUGIN_COUNT plugins installed"
+else
+  echo "⚠ Only $PLUGIN_COUNT plugins found (expected 8+)"
+fi
+
+if [ $ERRORS -eq 0 ]; then
+  echo ""
+  echo "Infrastructure is ready! Moving on to Lesson 5."
+fi
+```
+
+---
+
+**Next up:** [Lesson 5 - Plugins](05-plugins.md) -- we'll use the Pokedex plugins to
+see config, transforms, and validation in action.

--- a/this_is_cool/05-plugins.md
+++ b/this_is_cool/05-plugins.md
@@ -1,312 +1,424 @@
-# Lesson 5: Plugins in Action
+# Lesson 5: Metadata Labels and the Java Plugin
 
-Now that we have plugins installed and a marketplace running, let's use them.
-We'll create a workspace powered by the **Pokedex** plugins -- a playful example
-that demonstrates config validation, cross-value rules, and transforms.
+Every configuration value in zhi can carry **metadata labels** -- semantic
+annotations that tell plugins how to interpret, display, and handle that value.
+Labels follow a namespace convention (`<namespace>.<name>`) and are the primary
+way to communicate intent across plugin boundaries.
+
+In this lesson you'll:
+
+1. Discover available labels via the CLI
+2. Use labels in a structuredfile config to control UI behavior, store handling, and validation
+3. See how the Java config plugin uses Bean Validation annotations to achieve the same thing
 
 ---
 
-## Step 1: Create a Pokedex Workspace
+## Step 1: Discover Available Labels
 
-```sh {"name": "create-pokedex-workspace", "interactive": true}
-mkdir -p /tmp/zhi-pokedex
-cd /tmp/zhi-pokedex
-zhi init
+zhi ships with a built-in label registry. Let's explore it.
+
+```sh {"name": "list-all-labels", "interactive": true}
+# List every registered metadata label, grouped by namespace
+zhi labels list
 ```
 
-Now wire it up to use the Pokedex config and transform plugins, with in-memory storage:
+Labels are organized into namespaces that correspond to plugin types:
 
-```sh {"name": "configure-pokedex", "interactive": true}
-cat > /tmp/zhi-pokedex/zhi.yaml << 'YAML'
-version: "1"
+| Namespace | Interpreted by | Purpose |
+|-----------|---------------|---------|
+| `ui.*` | UI plugins (TUI, Web UI) | Control how values are displayed and edited |
+| `store.*` | Store plugins (Vault, JSON) | Control persistence behavior |
+| `transform.*` | Transform plugins | Control which transforms apply |
+| `config.*` | Config plugins | Mark values as required, immutable, etc. |
+| `core.*` | The engine itself | Descriptions, types, deprecation notices |
 
-config:
-  provider: pokedex
+### Filter by namespace
 
-transform:
-  - provider: pokedex
+```sh {"name": "list-ui-labels", "interactive": true}
+zhi labels list --namespace ui
+```
 
-store:
-  provider: json
-  options:
-    path: ./store.json
+```sh {"name": "list-store-labels", "interactive": true}
+zhi labels list --namespace store
+```
 
-ui:
-  provider: webui
-  options:
-    addr: "127.0.0.1:9091"
-    auto_open: false
+### Get detailed info about a label
 
-components:
-  - name: trainer
-    description: "Pokemon trainer identity"
-    paths: ["pokedex/trainer.name", "pokedex/region"]
-    mandatory: true
-  - name: pokemon
-    description: "Starter Pokemon selection"
-    paths: ["pokedex/starter", "pokedex/starter.original"]
-    mandatory: true
-  - name: goals
-    description: "Pokedex completion goals"
-    paths: ["pokedex/pokedex.goal"]
-    mandatory: true
+```sh {"name": "label-info-password", "interactive": true}
+zhi labels info ui.password
+```
 
-export:
-  templates:
-    - name: trainer-card
-      template: ./templates/trainer-card.txt.tmpl
-      output: ./trainer-card.txt
+```sh {"name": "label-info-writeonly", "interactive": true}
+zhi labels info store.writeonly
+```
+
+> **Try it yourself:** Run `zhi labels info config.required` or `zhi labels info ui.readonly`
+> to see their descriptions, types, defaults, and examples.
+
+```sh {"name": "try-label-info", "interactive": true}
+# Your turn!
+zhi labels info config.required
+```
+
+---
+
+## Step 2: Use Labels in a Structuredfile Config
+
+Let's create a workspace that uses metadata labels to control how the UI
+renders each field and how the store handles sensitive values.
+
+```sh {"name": "create-labels-workspace", "interactive": true}
+mkdir -p /tmp/zhi-labels/config /tmp/zhi-labels/templates
+cd /tmp/zhi-labels && zhi init --force
+```
+
+```sh {"name": "define-labeled-config", "interactive": true}
+cat > /tmp/zhi-labels/config/service.yml << 'YAML'
+service:
+  name:
+    val: "my-api"
+    metadata:
+      description: "Service name used in deployment"
+      display-name: "Service Name"
+      config.required: true
+      ui.pattern: "^[a-z][a-z0-9-]*$"
+      ui.placeholder: "e.g. my-api"
+    validation: |-
+      name, ok := v.Val.(string)
+      if !ok || name == "" {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "service name is required",
+        }}, nil
+      }
+      return nil, nil
+
+  port:
+    val: 8080
+    metadata:
+      description: "Port the service listens on"
+      display-name: "Port"
+      core.type: "port"
+      ui.order: 2
+    validation: |-
+      port, ok := v.Val.(int)
+      if !ok {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "port must be a number",
+        }}, nil
+      }
+      if port < 1024 || port > 65535 {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "port must be between 1024 and 65535",
+        }}, nil
+      }
+      return nil, nil
+
+  api-key:
+    val: ""
+    metadata:
+      description: "API key for external service"
+      display-name: "API Key"
+      config.required: true
+      ui.password: true
+      store.writeonly: true
+
+  admin-email:
+    val: ""
+    metadata:
+      description: "Admin contact email"
+      display-name: "Admin Email"
+      core.type: "email"
+      ui.pattern: "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$"
+      ui.placeholder: "admin@example.com"
+
+  log-level:
+    val: "info"
+    metadata:
+      description: "Logging verbosity"
+      display-name: "Log Level"
+      ui.enum:
+        - trace
+        - debug
+        - info
+        - warn
+        - error
+
+  notes:
+    val: ""
+    metadata:
+      description: "Deployment notes (supports multiple lines)"
+      display-name: "Notes"
+      ui.multiline: true
+
+  version:
+    val: "1.0.0"
+    metadata:
+      description: "Current deployed version (set by CI)"
+      display-name: "Version"
+      ui.readonly: true
+      config.immutable: true
+
+  cache-ttl:
+    val: 300
+    metadata:
+      description: "Cache time-to-live"
+      display-name: "Cache TTL"
+      core.unit: "seconds"
+      store.ttl: 3600
 YAML
 
-echo "Workspace configured!"
+echo "Labeled config created!"
 ```
 
-Create a template for a trainer card:
+### See how labels affect the config tree
 
-```sh {"name": "create-trainer-template", "interactive": true}
-mkdir -p /tmp/zhi-pokedex/templates
-cat > /tmp/zhi-pokedex/templates/trainer-card.txt.tmpl << 'TMPL'
-╔══════════════════════════════════╗
-║        TRAINER CARD              ║
-╠══════════════════════════════════╣
-║  Name:    {{ .Get "pokedex/trainer.name" | printf "%-20s" }}║
-║  Region:  {{ .Get "pokedex/region" | printf "%-20s" }}║
-║  Partner: {{ .Get "pokedex/starter" | printf "%-20s" }}║
-║  Goal:    {{ .Get "pokedex/pokedex.goal" | printf "%-20s" }}║
-╚══════════════════════════════════╝
-TMPL
-
-echo "Template created!"
+```sh {"name": "list-labeled-tree", "interactive": true}
+cd /tmp/zhi-labels && zhi list paths
 ```
 
----
+```sh {"name": "get-labeled-values", "interactive": true}
+cd /tmp/zhi-labels
 
-## Step 2: Explore the Config Tree
+echo "=== Service Name ==="
+zhi get service/name
 
-The Pokedex config plugin provides a pre-defined config tree with defaults and validators.
+echo ""
+echo "=== API Key (write-only, password-masked) ==="
+zhi get service/api-key
 
-```sh {"name": "list-pokedex", "interactive": true}
-cd /tmp/zhi-pokedex && zhi list paths
+echo ""
+echo "=== Version (read-only, immutable) ==="
+zhi get service/version
 ```
 
-```sh {"name": "get-pokedex-values", "interactive": true}
-cd /tmp/zhi-pokedex
+### Observe labels in the Web UI
 
-echo "=== Trainer ==="
-zhi get pokedex/trainer.name
-zhi get pokedex/region
+Labels truly shine in the Web UI. Launch it and see how each label changes the rendering:
 
-echo ""
-echo "=== Pokemon ==="
-zhi get pokedex/starter
-
-echo ""
-echo "=== Goals ==="
-zhi get pokedex/pokedex.goal
+```sh {"name": "launch-labels-webui", "background": true, "interactive": false}
+cd /tmp/zhi-labels && zhi edit --ui webui
 ```
 
-Notice the defaults: Ash from Kanto with a Pikachu, aiming to catch 150 Pokemon.
+Open **http://127.0.0.1:8080** and observe:
 
----
+- `service/api-key` shows a **password input** (masked characters) thanks to `ui.password: true`
+- `service/version` is **grayed out / read-only** thanks to `ui.readonly: true`
+- `service/log-level` shows a **dropdown** thanks to `ui.enum`
+- `service/notes` shows a **textarea** thanks to `ui.multiline: true`
+- `service/name` validates against a **regex pattern** (`ui.pattern`)
 
-## Step 3: See Transforms in Action
-
-The Pokedex transform plugin **evolves** your starter Pokemon for display.
-Watch what happens:
-
-```sh {"name": "see-transform", "interactive": true}
-cd /tmp/zhi-pokedex
-
-echo "Setting starter to charmander..."
-zhi set pokedex/starter charmander
-
-echo ""
-echo "Now reading the value back (through the transform):"
-zhi get pokedex/starter
-echo ""
-echo "The transform evolved charmander → charizard for display!"
-echo ""
-echo "The original is preserved:"
-zhi get pokedex/starter.original
-```
-
-The transform plugin:
-- **On read:** Evolves `charmander` → `charizard` (final form) and adjusts the
-  pokedex goal (+2 for the evolution stages)
-- **On save:** Maps back to the base form for storage
-- Creates a transient `starter.original` path so you can see both forms
-
-> **Try it yourself:** Set the starter to `bulbasaur` or `squirtle` and see their evolutions!
-
-```sh {"name": "try-evolution", "interactive": true}
-cd /tmp/zhi-pokedex
-
-# Your turn! Try another starter:
-zhi set pokedex/starter squirtle
-echo ""
-echo "Starter (evolved):"
-zhi get pokedex/starter
-echo ""
-echo "Original:"
-zhi get pokedex/starter.original
+```sh {"name": "stop-labels-webui", "interactive": true, "excludeFromRunAll": true}
+lsof -ti:8080 | xargs -r kill 2>/dev/null
+echo "Web UI stopped."
 ```
 
 ---
 
-## Step 4: Trigger Validation Rules
+## Step 3: Label Effects Summary
 
-The config plugin has several validators. Let's trigger them.
+Here's what each label does when applied to a configuration value:
 
-### Invalid region
+### UI Labels (interpreted by TUI and Web UI)
 
-```sh {"name": "invalid-region", "interactive": true}
-cd /tmp/zhi-pokedex
+| Label | Type | Effect |
+|-------|------|--------|
+| `ui.readonly` | bool | Field is visible but not editable |
+| `ui.password` | bool | Input is masked (dots/asterisks) |
+| `ui.hidden` | bool | Field is completely hidden from the UI |
+| `ui.multiline` | bool | Uses a textarea for input |
+| `ui.pattern` | string | Regex pattern for input validation |
+| `ui.enum` | string[] | Restricts input to a dropdown of allowed values |
+| `ui.order` | int | Controls display order (lower = first) |
+| `ui.group` | string | Groups related fields under a collapsible section |
+| `ui.placeholder` | string | Placeholder text in empty input fields |
+| `ui.confirm` | bool | Requires confirmation before changing |
 
-zhi set pokedex/region "middle-earth"
-echo ""
-zhi validate
+### Store Labels (interpreted by store plugins)
+
+| Label | Type | Effect |
+|-------|------|--------|
+| `store.writeonly` | bool | Value can be written but never read back |
+| `store.encrypt` | bool | Forces encryption even if store-wide encryption is off |
+| `store.noversion` | bool | Excludes from version history |
+| `store.ttl` | int | Auto-deletes after N seconds |
+| `store.ephemeral` | bool | In-memory only, never persisted |
+
+### Config Labels (interpreted by config plugins)
+
+| Label | Type | Effect |
+|-------|------|--------|
+| `config.required` | bool | Validation fails if value is empty |
+| `config.immutable` | bool | Value cannot be changed after initial set |
+| `config.default` | any | Default value if not set |
+| `config.env` | string | Environment variable that can override this value |
+
+### Transform Labels
+
+| Label | Type | Effect |
+|-------|------|--------|
+| `transform.hidden` | bool | Transform plugins cannot access this value |
+| `transform.skip` | string[] | List of transform plugin names to skip |
+
+---
+
+## Step 4: The Java Config Plugin -- Labels via Bean Validation
+
+The `zhi-config-javabean` example shows a different approach: instead of writing
+labels in YAML, you define your config as a **Java bean** with Jakarta Bean
+Validation annotations. The annotations map to zhi labels and validation rules.
+
+Here's the `DatabaseConfig` bean from the example:
+
+```java {"excludeFromRunAll": true}
+// This is the actual code from examples/zhi-config-javabean/
+// Don't run this -- just read!
+
+@ConfigPrefix("database")
+@SslRequiredForRemoteHost              // custom cross-value constraint
+public class DatabaseConfig {
+
+    @NotBlank(message = "database host is required")
+    @ConfigProperty(description = "Database server hostname")
+    private String host = "localhost";
+
+    @Min(value = 1, message = "port must be at least 1")
+    @Max(value = 65535, message = "port must be at most 65535")
+    @ConfigProperty(description = "Database server port")
+    private int port = 5432;
+
+    @NotBlank(message = "database name is required")
+    @ConfigProperty(description = "Name of the database")
+    private String name = "myapp";
+
+    @NotBlank(message = "username is required")
+    @ConfigProperty(description = "Database login user")
+    private String username = "admin";
+
+    @Min(value = 1, message = "max connections must be at least 1")
+    @Max(value = 1000, message = "max connections must be at most 1000")
+    @ConfigProperty(path = "max-connections",
+                    description = "Maximum number of database connections")
+    private int maxConnections = 10;
+
+    @ConfigProperty(path = "ssl-enabled",
+                    description = "Whether TLS is used for the database connection")
+    private boolean sslEnabled = false;
+}
 ```
 
-You should see a **blocking** error -- `middle-earth` isn't a valid Pokemon region.
+### How Java annotations map to zhi concepts
 
-```sh {"name": "fix-region", "interactive": true}
-cd /tmp/zhi-pokedex && zhi set pokedex/region "johto"
-```
-
-### Non-classic starter (warning)
-
-```sh {"name": "non-classic-starter", "interactive": true}
-cd /tmp/zhi-pokedex
-
-zhi set pokedex/starter "eevee"
-echo ""
-zhi validate
-```
-
-This produces a **warning** (not blocking) -- eevee isn't a classic Kanto starter,
-but it's still allowed.
+| Java Annotation | zhi Equivalent |
+|----------------|----------------|
+| `@ConfigPrefix("database")` | Path prefix -- all fields become `database/host`, `database/port`, etc. |
+| `@ConfigProperty(description="...")` | `metadata.description` label |
+| `@ConfigProperty(path="ssl-enabled")` | Overrides the default kebab-case path segment |
+| `@NotBlank` | Similar to `config.required: true` + a blocking validation |
+| `@Min(1)` / `@Max(65535)` | Blocking validation on numeric range |
+| `@SslRequiredForRemoteHost` | Cross-value validation -- warns if host is remote but SSL is off |
 
 ### Cross-value validation
 
-```sh {"name": "cross-validation", "interactive": true}
-cd /tmp/zhi-pokedex
+The `@SslRequiredForRemoteHost` annotation is a custom class-level constraint:
 
-# Set a Kanto starter with a non-Kanto region
-zhi set pokedex/starter "charmander"
-zhi set pokedex/region "johto"
+```java {"excludeFromRunAll": true}
+// Custom validator that checks two fields together
+public class SslRequiredForRemoteHostValidator
+        implements ConstraintValidator<SslRequiredForRemoteHost, DatabaseConfig> {
+    @Override
+    public boolean isValid(DatabaseConfig cfg, ConstraintValidatorContext ctx) {
+        if (cfg == null) return true;
+        boolean isLocal = "localhost".equals(cfg.getHost());
+        if (isLocal || cfg.isSslEnabled()) return true;
+
+        // SSL should be enabled for remote hosts
+        ctx.disableDefaultConstraintViolation();
+        String msg = "SSL should be enabled for remote host '" + cfg.getHost() + "'";
+        ctx.buildConstraintViolationWithTemplate(msg)
+                .addPropertyNode("sslEnabled").addConstraintViolation();
+        return false;
+    }
+}
+```
+
+Because it's annotated with `@WarnConstraint`, violations are reported as
+**Warning** (not Blocking) -- the zhi host shows them as advisory messages.
+
+### Building and running the Java plugin
+
+The plugin is built with GraalVM `native-image` for a zero-dependency binary:
+
+```sh {"name": "show-java-plugin-build", "excludeFromRunAll": true, "interactive": true}
+echo "To build the Java plugin (requires JDK 21+ and GraalVM native-image):"
 echo ""
-zhi validate
-```
-
-The config plugin performs **cross-value validation**: it notices that Charmander
-is a Kanto starter but you chose Johto as your region, and issues an info message.
-
-### Unrealistic goal
-
-```sh {"name": "high-goal", "interactive": true}
-cd /tmp/zhi-pokedex
-
-zhi set pokedex/pokedex.goal 9999
+echo "  cd examples/zhi-config-javabean"
+echo "  ./gradlew nativeCompile"
+echo "  cp build/native/nativeCompile/zhi-config-javabean ~/.zhi/plugins/"
 echo ""
-zhi validate
+echo "Then use it in zhi.yaml:"
+echo ""
+echo "  config:"
+echo '    provider: javabean'
 ```
 
-Warning: there aren't that many Pokemon!
-
-```sh {"name": "fix-goal", "interactive": true}
-cd /tmp/zhi-pokedex
-zhi set pokedex/pokedex.goal 150
-zhi set pokedex/region "kanto"
-```
+The resulting binary follows the standard naming convention (`zhi-config-javabean`),
+so zhi discovers it automatically from `~/.zhi/plugins/`.
 
 ---
 
-## Step 5: Export Your Trainer Card
+## Step 5: Compare Approaches
 
-```sh {"name": "export-trainer-card", "interactive": true}
-cd /tmp/zhi-pokedex
+Both the YAML structuredfile and the Java plugin achieve the same goal --
+defining typed, validated, labeled configuration. Choose based on your needs:
 
-zhi export
-echo ""
-cat trainer-card.txt
-```
-
-The exported card shows the **transformed** values (evolved starter, adjusted goal).
-
-> **Try it yourself:** Change the trainer name to yours, pick your favorite starter,
-> and export again!
-
-```sh {"name": "customize-and-export", "interactive": true}
-cd /tmp/zhi-pokedex
-
-# Customize these values:
-zhi set pokedex/trainer.name "Your Name"
-zhi set pokedex/starter "bulbasaur"
-zhi set pokedex/region "kanto"
-zhi set pokedex/pokedex.goal 151
-
-zhi export
-echo ""
-cat trainer-card.txt
-```
-
----
-
-## Step 6: Inspect Plugin Manifests
-
-Every plugin has a `zhi-plugin.yaml` manifest. Let's look at what's installed.
-
-```sh {"name": "plugin-info", "interactive": true}
-# List all installed plugins with details
-zhi plugin list
-
-echo ""
-echo "=== Plugin directory ==="
-ls ~/.zhi/plugins/ 2>/dev/null || echo "(empty -- plugins may be built-in)"
-```
+| Aspect | Structuredfile (YAML) | Java Bean |
+|--------|----------------------|-----------|
+| **Language** | YAML + inline Go validation | Java + Bean Validation |
+| **Labels** | Set directly in `metadata` map | Mapped from annotations |
+| **Validation** | Inline Go code (Yaegi interpreter) | Jakarta Bean Validation (`@NotBlank`, `@Min`, etc.) |
+| **Cross-value checks** | Access `tree` parameter in validation code | Class-level custom constraints |
+| **Build** | No build step (plain files) | Gradle + GraalVM native-image |
+| **Best for** | Quick configs, ops teams | Type-safe Java ecosystems, enterprise |
 
 ---
 
 ## Checkpoint
 
 ```sh {"name": "check-05"}
-cd /tmp/zhi-pokedex
+cd /tmp/zhi-labels 2>/dev/null || exit 1
 ERRORS=0
 
-# Validation should pass with correct values
-zhi set pokedex/trainer.name "Ash" 2>/dev/null
-zhi set pokedex/starter "pikachu" 2>/dev/null
-zhi set pokedex/region "kanto" 2>/dev/null
-zhi set pokedex/pokedex.goal 150 2>/dev/null
+# Check labels CLI works
+LABEL_COUNT=$(zhi labels list 2>/dev/null | grep -c "^" || true)
+if [ "$LABEL_COUNT" -gt 10 ]; then
+  echo "✓ Label registry has $LABEL_COUNT entries"
+else
+  echo "✗ Label registry seems empty"
+  ERRORS=$((ERRORS + 1))
+fi
 
+# Check labeled config loads
+if zhi list paths 2>/dev/null | grep -q "service/name"; then
+  echo "✓ Labeled config tree loads correctly"
+else
+  echo "✗ Config tree not loading"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Validate
 VALIDATION=$(zhi validate 2>&1)
-BLOCKING=$(echo "$VALIDATION" | grep -c "Blocking" || true)
-if [ "$BLOCKING" -eq 0 ]; then
-  echo "✓ Validation passes with correct values"
+if echo "$VALIDATION" | grep -qi "blocking"; then
+  echo "⚠ Validation has blocking errors (expected -- api-key and admin-email are empty)"
 else
-  echo "✗ Unexpected blocking errors"
-  ERRORS=$((ERRORS + 1))
-fi
-
-# Export should work
-if zhi export 2>/dev/null && [ -f trainer-card.txt ]; then
-  echo "✓ Export generates trainer card"
-else
-  echo "✗ Export failed"
-  ERRORS=$((ERRORS + 1))
-fi
-
-# Transform should evolve pikachu
-STARTER=$(zhi get pokedex/starter 2>/dev/null)
-if echo "$STARTER" | grep -qi "raichu"; then
-  echo "✓ Transform evolves pikachu → raichu"
-else
-  echo "⚠ Transform may not be active (got: $STARTER)"
+  echo "✓ Validation passes"
 fi
 
 if [ $ERRORS -eq 0 ]; then
   echo ""
-  echo "Plugins are working! On to the final lesson."
+  echo "Labels and validation working! On to the final lesson."
 fi
 ```
 
@@ -315,9 +427,18 @@ fi
 ## Cleanup
 
 ```sh {"name": "cleanup-05", "interactive": true, "excludeFromRunAll": true}
-rm -rf /tmp/zhi-pokedex
-echo "Pokedex workspace cleaned up."
+rm -rf /tmp/zhi-labels
+echo "Labels workspace cleaned up."
 ```
+
+---
+
+## Further Reading
+
+- [Metadata Labels API Design](../docs/design/metadata-labels-api.md) -- full design document for the label registry
+- [Structured File Provider](../docs/plugin-development/structuredfile-provider.md) -- config file format and validation code
+- [Java Plugin Development](../docs/plugin-development/java-plugin.md) -- Gradle setup, Bean Validation, GraalVM native-image
+- [Plugin Development Overview](../docs/plugin-development/overview.md) -- building plugins in Go or other languages
 
 ---
 

--- a/this_is_cool/05-plugins.md
+++ b/this_is_cool/05-plugins.md
@@ -70,6 +70,8 @@ renders each field and how the store handles sensitive values.
 ```sh {"name": "create-labels-workspace", "interactive": true}
 mkdir -p /tmp/zhi-labels/config /tmp/zhi-labels/templates
 cd /tmp/zhi-labels && zhi init --force
+# Remove default Pokedex config so only our labeled config is loaded
+rm -f /tmp/zhi-labels/config/app.yaml
 ```
 
 ```sh {"name": "define-labeled-config", "interactive": true}
@@ -233,8 +235,16 @@ Here's what each label does when applied to a configuration value:
 | `ui.enum` | string[] | Restricts input to a dropdown of allowed values |
 | `ui.order` | int | Controls display order (lower = first) |
 | `ui.group` | string | Groups related fields under a collapsible section |
+| `ui.section` | string | Assigns value to a collapsible section |
 | `ui.placeholder` | string | Placeholder text in empty input fields |
 | `ui.confirm` | bool | Requires confirmation before changing |
+| `ui.displayName` | string | Human-readable display name in the UI |
+| `ui.format` | string | Hints at display format (e.g., `json`, `yaml`) |
+| `ui.showIf` | string | Conditionally shows value based on another config value |
+| `ui.yamlSchema` | string | Description of expected YAML structure |
+| `ui.listItemPlaceholder` | string | Placeholder for list-type value items |
+| `ui.mapKeyPlaceholder` | string | Placeholder for map key input fields |
+| `ui.mapValuePlaceholder` | string | Placeholder for map value input fields |
 
 ### Store Labels (interpreted by store plugins)
 
@@ -243,6 +253,7 @@ Here's what each label does when applied to a configuration value:
 | `store.writeonly` | bool | Value can be written but never read back |
 | `store.encrypt` | bool | Forces encryption even if store-wide encryption is off |
 | `store.noversion` | bool | Excludes from version history |
+| `store.maxversions` | int | Maximum number of versions to retain |
 | `store.ttl` | int | Auto-deletes after N seconds |
 | `store.ephemeral` | bool | In-memory only, never persisted |
 
@@ -260,6 +271,7 @@ Here's what each label does when applied to a configuration value:
 | Label | Type | Effect |
 |-------|------|--------|
 | `transform.hidden` | bool | Transform plugins cannot access this value |
+| `transform.order` | int | Override the default transform order for this value |
 | `transform.skip` | string[] | List of transform plugin names to skip |
 
 ---
@@ -408,12 +420,11 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-# Validate
-VALIDATION=$(zhi validate 2>&1)
-if echo "$VALIDATION" | grep -qi "blocking"; then
-  echo "⚠ Validation has blocking errors (expected -- api-key and admin-email are empty)"
-else
+# Validate (expect blocking errors since api-key and admin-email are empty)
+if zhi validate >/dev/null 2>&1; then
   echo "✓ Validation passes"
+else
+  echo "⚠ Validation has blocking errors (expected -- api-key and admin-email are empty)"
 fi
 
 if [ $ERRORS -eq 0 ]; then

--- a/this_is_cool/05-plugins.md
+++ b/this_is_cool/05-plugins.md
@@ -1,0 +1,325 @@
+# Lesson 5: Plugins in Action
+
+Now that we have plugins installed and a marketplace running, let's use them.
+We'll create a workspace powered by the **Pokedex** plugins -- a playful example
+that demonstrates config validation, cross-value rules, and transforms.
+
+---
+
+## Step 1: Create a Pokedex Workspace
+
+```sh {"name": "create-pokedex-workspace", "interactive": true}
+mkdir -p /tmp/zhi-pokedex
+cd /tmp/zhi-pokedex
+zhi init
+```
+
+Now wire it up to use the Pokedex config and transform plugins, with in-memory storage:
+
+```sh {"name": "configure-pokedex", "interactive": true}
+cat > /tmp/zhi-pokedex/zhi.yaml << 'YAML'
+version: "1"
+
+config:
+  provider: pokedex
+
+transform:
+  - provider: pokedex
+
+store:
+  provider: json
+  options:
+    path: ./store.json
+
+ui:
+  provider: webui
+  options:
+    addr: "127.0.0.1:9091"
+    auto_open: false
+
+components:
+  - name: trainer
+    description: "Pokemon trainer identity"
+    paths: ["pokedex/trainer.name", "pokedex/region"]
+    mandatory: true
+  - name: pokemon
+    description: "Starter Pokemon selection"
+    paths: ["pokedex/starter", "pokedex/starter.original"]
+    mandatory: true
+  - name: goals
+    description: "Pokedex completion goals"
+    paths: ["pokedex/pokedex.goal"]
+    mandatory: true
+
+export:
+  templates:
+    - name: trainer-card
+      template: ./templates/trainer-card.txt.tmpl
+      output: ./trainer-card.txt
+YAML
+
+echo "Workspace configured!"
+```
+
+Create a template for a trainer card:
+
+```sh {"name": "create-trainer-template", "interactive": true}
+mkdir -p /tmp/zhi-pokedex/templates
+cat > /tmp/zhi-pokedex/templates/trainer-card.txt.tmpl << 'TMPL'
+╔══════════════════════════════════╗
+║        TRAINER CARD              ║
+╠══════════════════════════════════╣
+║  Name:    {{ .Get "pokedex/trainer.name" | printf "%-20s" }}║
+║  Region:  {{ .Get "pokedex/region" | printf "%-20s" }}║
+║  Partner: {{ .Get "pokedex/starter" | printf "%-20s" }}║
+║  Goal:    {{ .Get "pokedex/pokedex.goal" | printf "%-20s" }}║
+╚══════════════════════════════════╝
+TMPL
+
+echo "Template created!"
+```
+
+---
+
+## Step 2: Explore the Config Tree
+
+The Pokedex config plugin provides a pre-defined config tree with defaults and validators.
+
+```sh {"name": "list-pokedex", "interactive": true}
+cd /tmp/zhi-pokedex && zhi list paths
+```
+
+```sh {"name": "get-pokedex-values", "interactive": true}
+cd /tmp/zhi-pokedex
+
+echo "=== Trainer ==="
+zhi get pokedex/trainer.name
+zhi get pokedex/region
+
+echo ""
+echo "=== Pokemon ==="
+zhi get pokedex/starter
+
+echo ""
+echo "=== Goals ==="
+zhi get pokedex/pokedex.goal
+```
+
+Notice the defaults: Ash from Kanto with a Pikachu, aiming to catch 150 Pokemon.
+
+---
+
+## Step 3: See Transforms in Action
+
+The Pokedex transform plugin **evolves** your starter Pokemon for display.
+Watch what happens:
+
+```sh {"name": "see-transform", "interactive": true}
+cd /tmp/zhi-pokedex
+
+echo "Setting starter to charmander..."
+zhi set pokedex/starter charmander
+
+echo ""
+echo "Now reading the value back (through the transform):"
+zhi get pokedex/starter
+echo ""
+echo "The transform evolved charmander → charizard for display!"
+echo ""
+echo "The original is preserved:"
+zhi get pokedex/starter.original
+```
+
+The transform plugin:
+- **On read:** Evolves `charmander` → `charizard` (final form) and adjusts the
+  pokedex goal (+2 for the evolution stages)
+- **On save:** Maps back to the base form for storage
+- Creates a transient `starter.original` path so you can see both forms
+
+> **Try it yourself:** Set the starter to `bulbasaur` or `squirtle` and see their evolutions!
+
+```sh {"name": "try-evolution", "interactive": true}
+cd /tmp/zhi-pokedex
+
+# Your turn! Try another starter:
+zhi set pokedex/starter squirtle
+echo ""
+echo "Starter (evolved):"
+zhi get pokedex/starter
+echo ""
+echo "Original:"
+zhi get pokedex/starter.original
+```
+
+---
+
+## Step 4: Trigger Validation Rules
+
+The config plugin has several validators. Let's trigger them.
+
+### Invalid region
+
+```sh {"name": "invalid-region", "interactive": true}
+cd /tmp/zhi-pokedex
+
+zhi set pokedex/region "middle-earth"
+echo ""
+zhi validate
+```
+
+You should see a **blocking** error -- `middle-earth` isn't a valid Pokemon region.
+
+```sh {"name": "fix-region", "interactive": true}
+cd /tmp/zhi-pokedex && zhi set pokedex/region "johto"
+```
+
+### Non-classic starter (warning)
+
+```sh {"name": "non-classic-starter", "interactive": true}
+cd /tmp/zhi-pokedex
+
+zhi set pokedex/starter "eevee"
+echo ""
+zhi validate
+```
+
+This produces a **warning** (not blocking) -- eevee isn't a classic Kanto starter,
+but it's still allowed.
+
+### Cross-value validation
+
+```sh {"name": "cross-validation", "interactive": true}
+cd /tmp/zhi-pokedex
+
+# Set a Kanto starter with a non-Kanto region
+zhi set pokedex/starter "charmander"
+zhi set pokedex/region "johto"
+echo ""
+zhi validate
+```
+
+The config plugin performs **cross-value validation**: it notices that Charmander
+is a Kanto starter but you chose Johto as your region, and issues an info message.
+
+### Unrealistic goal
+
+```sh {"name": "high-goal", "interactive": true}
+cd /tmp/zhi-pokedex
+
+zhi set pokedex/pokedex.goal 9999
+echo ""
+zhi validate
+```
+
+Warning: there aren't that many Pokemon!
+
+```sh {"name": "fix-goal", "interactive": true}
+cd /tmp/zhi-pokedex
+zhi set pokedex/pokedex.goal 150
+zhi set pokedex/region "kanto"
+```
+
+---
+
+## Step 5: Export Your Trainer Card
+
+```sh {"name": "export-trainer-card", "interactive": true}
+cd /tmp/zhi-pokedex
+
+zhi export
+echo ""
+cat trainer-card.txt
+```
+
+The exported card shows the **transformed** values (evolved starter, adjusted goal).
+
+> **Try it yourself:** Change the trainer name to yours, pick your favorite starter,
+> and export again!
+
+```sh {"name": "customize-and-export", "interactive": true}
+cd /tmp/zhi-pokedex
+
+# Customize these values:
+zhi set pokedex/trainer.name "Your Name"
+zhi set pokedex/starter "bulbasaur"
+zhi set pokedex/region "kanto"
+zhi set pokedex/pokedex.goal 151
+
+zhi export
+echo ""
+cat trainer-card.txt
+```
+
+---
+
+## Step 6: Inspect Plugin Manifests
+
+Every plugin has a `zhi-plugin.yaml` manifest. Let's look at what's installed.
+
+```sh {"name": "plugin-info", "interactive": true}
+# List all installed plugins with details
+zhi plugin list
+
+echo ""
+echo "=== Plugin directory ==="
+ls ~/.zhi/plugins/ 2>/dev/null || echo "(empty -- plugins may be built-in)"
+```
+
+---
+
+## Checkpoint
+
+```sh {"name": "check-05"}
+cd /tmp/zhi-pokedex
+ERRORS=0
+
+# Validation should pass with correct values
+zhi set pokedex/trainer.name "Ash" 2>/dev/null
+zhi set pokedex/starter "pikachu" 2>/dev/null
+zhi set pokedex/region "kanto" 2>/dev/null
+zhi set pokedex/pokedex.goal 150 2>/dev/null
+
+VALIDATION=$(zhi validate 2>&1)
+BLOCKING=$(echo "$VALIDATION" | grep -c "Blocking" || true)
+if [ "$BLOCKING" -eq 0 ]; then
+  echo "✓ Validation passes with correct values"
+else
+  echo "✗ Unexpected blocking errors"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Export should work
+if zhi export 2>/dev/null && [ -f trainer-card.txt ]; then
+  echo "✓ Export generates trainer card"
+else
+  echo "✗ Export failed"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Transform should evolve pikachu
+STARTER=$(zhi get pokedex/starter 2>/dev/null)
+if echo "$STARTER" | grep -qi "raichu"; then
+  echo "✓ Transform evolves pikachu → raichu"
+else
+  echo "⚠ Transform may not be active (got: $STARTER)"
+fi
+
+if [ $ERRORS -eq 0 ]; then
+  echo ""
+  echo "Plugins are working! On to the final lesson."
+fi
+```
+
+---
+
+## Cleanup
+
+```sh {"name": "cleanup-05", "interactive": true, "excludeFromRunAll": true}
+rm -rf /tmp/zhi-pokedex
+echo "Pokedex workspace cleaned up."
+```
+
+---
+
+**Next up:** [Lesson 6 - Bring It Together](06-bring-it-together.md) -- we'll build
+a custom workspace backed by Vault, completing the full zhi workflow.

--- a/this_is_cool/06-bring-it-together.md
+++ b/this_is_cool/06-bring-it-together.md
@@ -1,0 +1,493 @@
+# Lesson 6: Bring It Together
+
+In this final lesson, you'll build a custom workspace from scratch that ties together
+everything from the tutorial:
+
+- A **structuredfile config** defining a web application's settings
+- The **Vault store** from Lesson 3 for persistent, encrypted storage
+- A **template** that generates a docker-compose file
+- An **apply command** that deploys it
+
+This is the real zhi workflow: define config -> edit -> validate -> export -> apply.
+
+---
+
+## Step 1: Scaffold the Workspace
+
+```sh {"name": "scaffold-workspace", "interactive": true}
+mkdir -p /tmp/zhi-myapp
+cd /tmp/zhi-myapp
+zhi init
+```
+
+---
+
+## Step 2: Define the Configuration
+
+We'll model a simple web application with a database and optional Redis cache.
+Validators use Go code that returns `[]config.ValidationResult`.
+
+```sh {"name": "define-config", "interactive": true}
+cat > /tmp/zhi-myapp/config/webapp.yml << 'YAML'
+webapp:
+  name:
+    val: "my-webapp"
+    metadata:
+      description: "Application name"
+      display-name: "App Name"
+    validation: |-
+      name, ok := v.Val.(string)
+      if !ok || name == "" {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "app name cannot be empty",
+        }}, nil
+      }
+      return nil, nil
+
+  image:
+    val: "nginx:alpine"
+    metadata:
+      description: "Docker image to deploy"
+      display-name: "Docker Image"
+    imports:
+      - strings
+    validation: |-
+      image, ok := v.Val.(string)
+      if !ok {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "image must be a string",
+        }}, nil
+      }
+      if !strings.Contains(image, ":") {
+        return []config.ValidationResult{{
+          Severity: config.Warning,
+          Message:  "image should include a tag (e.g. nginx:alpine)",
+        }}, nil
+      }
+      return nil, nil
+
+  port:
+    val: 8080
+    metadata:
+      description: "Port exposed to the host"
+      display-name: "Host Port"
+    validation: |-
+      port, ok := v.Val.(int)
+      if !ok {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "port must be a number",
+        }}, nil
+      }
+      if port < 1024 || port > 65535 {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "port must be between 1024 and 65535",
+        }}, nil
+      }
+      return nil, nil
+
+  replicas:
+    val: 1
+    metadata:
+      description: "Number of container replicas"
+      display-name: "Replicas"
+    validation: |-
+      replicas, ok := v.Val.(int)
+      if !ok {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "replicas must be a number",
+        }}, nil
+      }
+      if replicas < 1 || replicas > 10 {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "replicas must be between 1 and 10",
+        }}, nil
+      }
+      return nil, nil
+YAML
+
+cat > /tmp/zhi-myapp/config/database.yml << 'YAML'
+database:
+  engine:
+    val: "postgres"
+    metadata:
+      description: "Database engine"
+      display-name: "DB Engine"
+    validation: |-
+      engine, ok := v.Val.(string)
+      if !ok {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "engine must be a string",
+        }}, nil
+      }
+      allowed := map[string]bool{"postgres": true, "mysql": true, "mariadb": true}
+      if !allowed[engine] {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "must be postgres, mysql, or mariadb",
+        }}, nil
+      }
+      return nil, nil
+
+  version:
+    val: "16"
+    metadata:
+      description: "Database version tag"
+      display-name: "DB Version"
+
+  port:
+    val: 5432
+    metadata:
+      description: "Database port (internal)"
+      display-name: "DB Port"
+
+  name:
+    val: "appdb"
+    metadata:
+      description: "Database name to create"
+      display-name: "DB Name"
+    validation: |-
+      name, ok := v.Val.(string)
+      if !ok || name == "" {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "database name is required",
+        }}, nil
+      }
+      return nil, nil
+
+  password:
+    val: ""
+    metadata:
+      description: "Database root password"
+      display-name: "DB Password"
+      ui.password: true
+      config.required: true
+    imports:
+      - strings
+    validation: |-
+      password, ok := v.Val.(string)
+      if !ok || strings.TrimSpace(password) == "" {
+        return []config.ValidationResult{{
+          Severity: config.Blocking,
+          Message:  "database password is required",
+        }}, nil
+      }
+      if len(password) < 8 {
+        return []config.ValidationResult{{
+          Severity: config.Warning,
+          Message:  "password should be at least 8 characters",
+        }}, nil
+      }
+      return nil, nil
+YAML
+
+cat > /tmp/zhi-myapp/config/cache.yml << 'YAML'
+cache:
+  enabled:
+    val: false
+    metadata:
+      description: "Enable Redis cache"
+      display-name: "Cache Enabled"
+
+  port:
+    val: 6379
+    metadata:
+      description: "Redis port"
+      display-name: "Cache Port"
+YAML
+
+echo "Config defined!"
+```
+
+---
+
+## Step 3: Wire Up the Workspace
+
+Connect to Vault for storage, define components, and set up templates.
+
+```sh {"name": "configure-workspace", "interactive": true}
+cat > /tmp/zhi-myapp/zhi.yaml << 'YAML'
+version: "1"
+
+config:
+  provider: structuredfile
+  options:
+    directory: ./config
+
+store:
+  provider: vault-manager
+  options:
+    addr: "http://127.0.0.1:8200"
+    mount: "kv"
+    prefix: "myapp"
+    workspace: "myapp"
+
+ui:
+  provider: webui
+  options:
+    addr: "127.0.0.1:9092"
+    auto_open: false
+
+components:
+  - name: webapp
+    description: "Core web application settings"
+    paths: ["webapp/"]
+    mandatory: true
+  - name: database
+    description: "Database configuration"
+    paths: ["database/"]
+    mandatory: true
+  - name: cache
+    description: "Optional Redis cache"
+    paths: ["cache/"]
+    mandatory: false
+
+export:
+  templates:
+    - name: docker-compose
+      template: ./templates/docker-compose.yml.tmpl
+      output: ./docker-compose.yml
+
+apply:
+  command: "docker compose config"
+  workdir: "."
+  pre-export: true
+  timeout: 30
+YAML
+
+echo "Workspace wired up!"
+```
+
+---
+
+## Step 4: Create the Docker Compose Template
+
+This template uses Go's `text/template` with zhi's tree functions and conditionals
+based on component state.
+
+```sh {"name": "create-compose-template", "interactive": true}
+mkdir -p /tmp/zhi-myapp/templates
+cat > /tmp/zhi-myapp/templates/docker-compose.yml.tmpl << 'TMPL'
+services:
+  {{ .Get "webapp/name" }}:
+    image: {{ .Get "webapp/image" }}
+    ports:
+      - "{{ .Get "webapp/port" }}:80"
+    deploy:
+      replicas: {{ .Get "webapp/replicas" }}
+    depends_on:
+      - db
+{{- if .ComponentEnabled "cache" }}
+      - redis
+{{- end }}
+    environment:
+      DATABASE_URL: "{{ .Get "database/engine" }}://app:{{ .Get "database/password" }}@db:{{ .Get "database/port" }}/{{ .Get "database/name" }}"
+{{- if .ComponentEnabled "cache" }}
+      REDIS_URL: "redis://redis:{{ .Get "cache/port" }}"
+{{- end }}
+
+  db:
+    image: {{ .Get "database/engine" }}:{{ .Get "database/version" }}
+    environment:
+      POSTGRES_DB: {{ .Get "database/name" }}
+      POSTGRES_PASSWORD: {{ .Get "database/password" }}
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "{{ .Get "database/port" }}:5432"
+
+{{- if .ComponentEnabled "cache" }}
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "{{ .Get "cache/port" }}:6379"
+{{- end }}
+
+volumes:
+  db-data:
+TMPL
+
+echo "Template created!"
+```
+
+---
+
+## Step 5: Authenticate and Set Values
+
+The Vault store needs a token for authentication. We'll obtain one from the
+admin user created in Lesson 3:
+
+```sh {"name": "login-myapp", "interactive": true}
+cd /tmp/zhi-myapp
+
+# Get a Vault token using the admin credentials from Lesson 3
+export VAULT_TOKEN=$(curl -sf http://127.0.0.1:8200/v1/auth/userpass/login/admin \
+  -d '{"password": "tutorial-password-123"}' | jq -r '.auth.client_token')
+
+echo "Authenticated to Vault (token: ${VAULT_TOKEN:0:10}...)"
+```
+
+```sh {"name": "set-myapp-values", "interactive": true}
+cd /tmp/zhi-myapp
+
+# Set the required password
+zhi set database/password "super-secret-db-pass"
+
+# Customize the app
+zhi set webapp/name "cool-webapp"
+zhi set webapp/replicas 2
+
+echo ""
+echo "Values set and saved to Vault!"
+```
+
+> Note: `zhi set` automatically persists changes to the store, so there's no
+> separate save step needed.
+
+---
+
+## Step 6: Validate and Export
+
+```sh {"name": "validate-myapp", "interactive": true}
+cd /tmp/zhi-myapp && zhi validate
+```
+
+```sh {"name": "export-myapp", "interactive": true}
+cd /tmp/zhi-myapp && zhi export
+
+echo ""
+echo "--- Generated docker-compose.yml ---"
+cat docker-compose.yml
+```
+
+Notice how the generated file only includes the services for enabled components.
+
+---
+
+## Step 7: Toggle the Cache Component
+
+```sh {"name": "enable-cache", "interactive": true}
+cd /tmp/zhi-myapp
+
+echo "=== Before (no cache) ==="
+zhi component list
+echo ""
+
+# Enable the cache component
+zhi component enable cache
+
+echo ""
+echo "=== After (with cache) ==="
+zhi component list
+
+# Re-export to see the difference
+zhi export
+echo ""
+echo "--- Updated docker-compose.yml ---"
+cat docker-compose.yml
+```
+
+The Redis service now appears in the compose file, and the webapp gets a `REDIS_URL`
+environment variable. This is the power of **component-driven configuration**.
+
+---
+
+## Step 8: Apply (Dry Run)
+
+Our apply command is set to `docker compose config` -- a dry run that validates
+the generated compose file without starting anything.
+
+```sh {"name": "apply-myapp", "interactive": true}
+cd /tmp/zhi-myapp && zhi apply
+```
+
+If you wanted to actually deploy, you'd change the apply command to
+`docker compose up -d` in `zhi.yaml`.
+
+---
+
+## Step 9: Verify Vault Persistence
+
+Your configuration is stored in Vault. Let's prove it by reading directly:
+
+```sh {"name": "verify-vault-persistence", "interactive": true}
+# Get a Vault token
+TOKEN=$(curl -sf http://127.0.0.1:8200/v1/auth/userpass/login/admin \
+  -d '{"password": "tutorial-password-123"}' | jq -r '.auth.client_token')
+
+# List stored keys under the myapp prefix
+echo "=== Stored keys in Vault ==="
+curl -sf -H "X-Vault-Token: $TOKEN" \
+  "http://127.0.0.1:8200/v1/kv/metadata/myapp?list=true" | jq '.data.keys'
+```
+
+Your configuration lives securely in Vault, versioned and encrypted at rest.
+The `vault-manager` store provider handles tree serialization and versioning
+internally.
+
+---
+
+## What You've Built
+
+```text {"excludeFromRunAll": true}
+┌─────────────────────────────────────────────────────────┐
+│                    Your Setup                           │
+│                                                         │
+│  ┌──────────────┐      ┌───────────────┐                │
+│  │ Your Custom  │─────▶│ HashiCorp     │                │
+│  │ Workspace    │ store│ Vault         │                │
+│  │ (myapp)      │◀─────│ (Lesson 3)    │                │
+│  └──────┬───────┘      └───────────────┘                │
+│         │ export                                        │
+│         ▼                                               │
+│  ┌──────────────┐      ┌───────────────┐                │
+│  │ docker-      │      │ Marketplace   │                │
+│  │ compose.yml  │      │ + Mirror      │                │
+│  └──────────────┘      │ (Lesson 4)    │                │
+│                        └───────────────┘                │
+└─────────────────────────────────────────────────────────┘
+```
+
+You've completed the full zhi workflow:
+
+1. **Defined** a config structure with types, defaults, and validators
+2. **Edited** values through CLI, TUI, Web UI, and MCP
+3. **Stored** configuration securely in Vault
+4. **Exported** templates that render into deployment files
+5. **Applied** provisioning commands
+6. **Used components** to toggle optional features
+7. **Managed plugins** through a local marketplace and mirror
+
+---
+
+## Cleanup
+
+```sh {"name": "cleanup-06", "interactive": true, "excludeFromRunAll": true}
+# Remove the workspace
+rm -rf /tmp/zhi-myapp
+
+echo "Workspace cleaned up."
+echo ""
+echo "To tear down ALL tutorial infrastructure (Vault, mirror, marketplace):"
+echo "  Run the cleanup cell in README.md"
+```
+
+---
+
+## Where to Go From Here
+
+- **Build your own config plugin** -- see [Plugin Development docs](../docs/plugin-development/overview.md)
+- **Write a transform plugin** -- add validation rules, computed fields, or policy enforcement
+- **Create a workspace package** -- publish it with `zhi workspace publish` for others to install
+- **Set up for production** -- enable TLS, configure real auth methods, set up mirror policies
+- **Use zhi with AI** -- register as an MCP server and let Claude manage your infrastructure
+
+Happy configuring!

--- a/this_is_cool/06-bring-it-together.md
+++ b/this_is_cool/06-bring-it-together.md
@@ -3,10 +3,11 @@
 In this final lesson, you'll build a custom workspace from scratch that ties together
 everything from the tutorial:
 
-- A **structuredfile config** defining a web application's settings
+- A **structuredfile config** with metadata labels for UI rendering and store behavior
 - The **Vault store** from Lesson 3 for persistent, encrypted storage
 - A **template** that generates a docker-compose file
 - An **apply command** that deploys it
+- **Components** to toggle optional features
 
 This is the real zhi workflow: define config -> edit -> validate -> export -> apply.
 
@@ -25,7 +26,8 @@ zhi init
 ## Step 2: Define the Configuration
 
 We'll model a simple web application with a database and optional Redis cache.
-Validators use Go code that returns `[]config.ValidationResult`.
+Notice how we use **metadata labels** (from Lesson 5) to control UI rendering
+and store behavior. Validators use Go code that returns `[]config.ValidationResult`.
 
 ```sh {"name": "define-config", "interactive": true}
 cat > /tmp/zhi-myapp/config/webapp.yml << 'YAML'
@@ -35,6 +37,10 @@ webapp:
     metadata:
       description: "Application name"
       display-name: "App Name"
+      config.required: true
+      ui.pattern: "^[a-z][a-z0-9-]*$"
+      ui.placeholder: "e.g. my-webapp"
+      ui.order: 1
     validation: |-
       name, ok := v.Val.(string)
       if !ok || name == "" {
@@ -50,6 +56,8 @@ webapp:
     metadata:
       description: "Docker image to deploy"
       display-name: "Docker Image"
+      ui.order: 2
+      ui.placeholder: "registry/image:tag"
     imports:
       - strings
     validation: |-
@@ -73,6 +81,8 @@ webapp:
     metadata:
       description: "Port exposed to the host"
       display-name: "Host Port"
+      core.type: "port"
+      ui.order: 3
     validation: |-
       port, ok := v.Val.(int)
       if !ok {
@@ -94,6 +104,7 @@ webapp:
     metadata:
       description: "Number of container replicas"
       display-name: "Replicas"
+      ui.order: 4
     validation: |-
       replicas, ok := v.Val.(int)
       if !ok {
@@ -118,6 +129,10 @@ database:
     metadata:
       description: "Database engine"
       display-name: "DB Engine"
+      ui.enum:
+        - postgres
+        - mysql
+        - mariadb
     validation: |-
       engine, ok := v.Val.(string)
       if !ok {
@@ -146,12 +161,14 @@ database:
     metadata:
       description: "Database port (internal)"
       display-name: "DB Port"
+      core.type: "port"
 
   name:
     val: "appdb"
     metadata:
       description: "Database name to create"
       display-name: "DB Name"
+      config.required: true
     validation: |-
       name, ok := v.Val.(string)
       if !ok || name == "" {
@@ -169,6 +186,7 @@ database:
       display-name: "DB Password"
       ui.password: true
       config.required: true
+      store.writeonly: true
     imports:
       - strings
     validation: |-
@@ -195,12 +213,14 @@ cache:
     metadata:
       description: "Enable Redis cache"
       display-name: "Cache Enabled"
+      ui.confirm: true
 
   port:
     val: 6379
     metadata:
       description: "Redis port"
       display-name: "Cache Port"
+      core.type: "port"
 YAML
 
 echo "Config defined!"
@@ -458,13 +478,14 @@ internally.
 
 You've completed the full zhi workflow:
 
-1. **Defined** a config structure with types, defaults, and validators
+1. **Defined** a config structure with types, defaults, validators, and metadata labels
 2. **Edited** values through CLI, TUI, Web UI, and MCP
-3. **Stored** configuration securely in Vault
+3. **Stored** configuration securely in Vault (with `store.writeonly` for secrets)
 4. **Exported** templates that render into deployment files
-5. **Applied** provisioning commands
+5. **Applied** provisioning commands with `zhi apply`
 6. **Used components** to toggle optional features
-7. **Managed plugins** through a local marketplace and mirror
+7. **Installed workspaces** from OCI registries with automatic plugin resolution
+8. **Explored metadata labels** that control UI rendering, store behavior, and validation
 
 ---
 
@@ -484,10 +505,20 @@ echo "  Run the cleanup cell in README.md"
 
 ## Where to Go From Here
 
-- **Build your own config plugin** -- see [Plugin Development docs](../docs/plugin-development/overview.md)
+- **Build your own config plugin** -- see [Plugin Development Overview](../docs/plugin-development/overview.md)
+- **Build a Java plugin** -- see [Java Plugin Development](../docs/plugin-development/java-plugin.md) for Bean Validation integration
 - **Write a transform plugin** -- add validation rules, computed fields, or policy enforcement
 - **Create a workspace package** -- publish it with `zhi workspace publish` for others to install
 - **Set up for production** -- enable TLS, configure real auth methods, set up mirror policies
 - **Use zhi with AI** -- register as an MCP server and let Claude manage your infrastructure
+
+## Further Reading
+
+- [Workspace Configuration](../docs/user-guide/workspace-configuration.md) -- full `zhi.yaml` reference
+- [Sharing and Registries](../docs/user-guide/sharing-and-registries.md) -- OCI distribution, signing, workspace publishing
+- [Metadata Labels API Design](../docs/design/metadata-labels-api.md) -- label registry design and built-in labels
+- [Plugin Development Overview](../docs/plugin-development/overview.md) -- Go and non-Go plugin guides
+- [Java Plugin Development](../docs/plugin-development/java-plugin.md) -- Java beans, GraalVM native-image
+- [CLI Reference](../docs/user-guide/cli-reference.md) -- full command reference
 
 Happy configuring!

--- a/this_is_cool/06-bring-it-together.md
+++ b/this_is_cool/06-bring-it-together.md
@@ -19,6 +19,8 @@ This is the real zhi workflow: define config -> edit -> validate -> export -> ap
 mkdir -p /tmp/zhi-myapp
 cd /tmp/zhi-myapp
 zhi init
+# Remove default Pokedex config -- we'll define our own
+rm -f /tmp/zhi-myapp/config/app.yaml
 ```
 
 ---

--- a/this_is_cool/README.md
+++ b/this_is_cool/README.md
@@ -1,0 +1,97 @@
+# This Is Cool: An Interactive Introduction to zhi
+
+Welcome! This is a hands-on, notebook-style tutorial that walks you through **zhi** --
+a security-first platform for configuration management and provisioning.
+
+By the end you'll have:
+
+- A running **HashiCorp Vault** instance (deployed and bootstrapped by zhi)
+- A **zhi marketplace** and **mirror** serving real plugins
+- Hands-on experience with zhi's TUI, Web UI, and AI-assisted editing
+- Your own custom workspace backed by Vault
+
+## Prerequisites
+
+| Tool | Why |
+|------|-----|
+| **Docker** (with Compose plugin) | We run Vault, mirror, and marketplace as containers |
+| **curl / jq** | For downloading binaries and inspecting APIs |
+| **A terminal** | All lessons are designed for the command line |
+
+Optional but recommended:
+
+| Tool | Why |
+|------|-----|
+| **Claude Code** | Lesson 03 showcases AI-assisted config editing via MCP |
+| **A web browser** | Lesson 03 showcases the Web UI |
+
+## How to Use These Notebooks
+
+Each lesson is a Markdown file with executable code blocks. You have two ways to run them:
+
+### Option A: VS Code with Runme Extension (recommended)
+
+1. Install the [Runme extension](https://marketplace.visualstudio.com/items?itemName=stateful.runme) in VS Code
+2. Open any `.md` file in this directory
+3. Code blocks become executable cells -- click the play button next to each one
+
+This gives you the best notebook experience: inline output, easy re-runs, and
+a clear visual separation between prose and code.
+
+### Option B: Runme CLI with `runme open`
+
+If you prefer the terminal, install the Runme CLI and use `runme open` to launch
+a browser-based notebook UI:
+
+```sh {"name": "install-runme", "interactive": true}
+# Install Runme CLI (pick one)
+# macOS / Linux (Homebrew):
+brew install runme
+
+# Or via npm:
+# npm install -g runme
+
+# Or download from https://github.com/stateful/runme/releases
+```
+
+```sh {"name": "open-lesson", "excludeFromRunAll": true, "interactive": true}
+# Open a lesson in the browser-based notebook UI
+runme open --filename 01-what-is-zhi.md
+```
+
+You can also run individual named cells directly from the CLI:
+
+```sh {"name": "run-cell-example", "excludeFromRunAll": true, "interactive": true}
+# Run a specific named cell
+runme run --filename 01-what-is-zhi.md verify-zhi
+```
+
+## Lessons
+
+| # | File | What You'll Learn |
+|---|------|-------------------|
+| 1 | [What is zhi?](01-what-is-zhi.md) | Install zhi, explore the CLI, understand the plugin architecture |
+| 2 | [Your First Workspace](02-your-first-workspace.md) | Create a workspace, browse configs, edit values, validate, export |
+| 3 | [Deploy Vault](03-vault-setup.md) | Deploy Vault with Docker, experience TUI / Web UI / MCP editing |
+| 4 | [zhi Infrastructure](04-zhi-infrastructure.md) | Stand up a mirror + marketplace, import real plugins from GitHub |
+| 5 | [Plugins](05-plugins.md) | Search, install, and use plugins from your marketplace |
+| 6 | [Bring It Together](06-bring-it-together.md) | Build a custom workspace backed by your Vault |
+
+Each lesson builds on the previous one. Start with lesson 1 and work your way through.
+
+## Cleanup
+
+When you're done exploring, tear everything down:
+
+```sh {"name": "cleanup-all", "interactive": true}
+# Stop and remove all containers from the tutorial
+docker compose -f ../deploy/vault/docker-compose.yml -p vault down -v 2>/dev/null
+docker compose -f ../deploy/zhi/docker-compose.yml -p zhi down -v 2>/dev/null
+echo "All cleaned up!"
+```
+
+## Troubleshooting
+
+- **Docker not running?** Start Docker Desktop or `sudo systemctl start docker`
+- **Port conflict?** Check if 8200 (Vault), 8080 (mirror), or 8090 (marketplace) are in use
+- **Runme not found?** Make sure it's in your PATH, or use VS Code with the Runme extension

--- a/this_is_cool/README.md
+++ b/this_is_cool/README.md
@@ -71,11 +71,11 @@ runme run --filename 01-what-is-zhi.md verify-zhi
 | # | File | What You'll Learn |
 |---|------|-------------------|
 | 1 | [What is zhi?](01-what-is-zhi.md) | Install zhi, explore the CLI, understand the plugin architecture |
-| 2 | [Your First Workspace](02-your-first-workspace.md) | Create a workspace, browse configs, edit values, validate, export |
+| 2 | [Your First Workspace](02-your-first-workspace.md) | Create a workspace, browse configs, edit values, validate, export, apply |
 | 3 | [Deploy Vault](03-vault-setup.md) | Deploy Vault with Docker, experience TUI / Web UI / MCP editing |
-| 4 | [zhi Infrastructure](04-zhi-infrastructure.md) | Stand up a mirror + marketplace, import real plugins from GitHub |
-| 5 | [Plugins](05-plugins.md) | Search, install, and use plugins from your marketplace |
-| 6 | [Bring It Together](06-bring-it-together.md) | Build a custom workspace backed by your Vault |
+| 4 | [zhi Infrastructure](04-zhi-infrastructure.md) | Install workspaces from OCI registries, use the Web UI marketplace |
+| 5 | [Metadata Labels](05-plugins.md) | Discover labels, control UI/store behavior, Java config plugin |
+| 6 | [Bring It Together](06-bring-it-together.md) | Build a custom workspace backed by your Vault with labels |
 
 Each lesson builds on the previous one. Start with lesson 1 and work your way through.
 


### PR DESCRIPTION
## Summary

- Adds a 6-lesson interactive tutorial in `this_is_cool/` using [Runme](https://runme.dev)-compatible Markdown notebooks
- Designed for VS Code (with Runme extension) or `runme open` in the browser -- each code block is an executable cell
- Covers the full zhi workflow: install → workspace basics → Vault deployment → mirror/marketplace setup → plugin ecosystem → custom workspace with Vault backend
- Showcases all three editing environments: TUI, Web UI, and MCP + AI (Claude Code)
- Imports real published plugins from `ghcr.io/mrwong99/zhi/*`

### Lessons

| # | Topic | Highlights |
|---|-------|-----------|
| 1 | What is zhi? | Download release binary, CLI exploration, architecture overview |
| 2 | Your First Workspace | `zhi init`, config trees, validation with Go code validators, export |
| 3 | Deploy Vault | Docker deployment, TUI / Web UI / MCP editing showcase |
| 4 | zhi Infrastructure | Mirror + marketplace, import 10 real plugins, marketplace API |
| 5 | Plugins in Action | Pokedex config/transform: evolution chains, cross-value validation |
| 6 | Bring It Together | Custom workspace backed by Vault, component toggles, full loop |

Each lesson includes "Try it yourself" cells, validation checkpoints, and cleanup cells.

## Test plan

- [ ] Install Runme extension in VS Code, open `this_is_cool/01-what-is-zhi.md`, verify code blocks are executable
- [ ] Run through lessons 01-02 (no Docker needed)
- [ ] Run lesson 03 (requires Docker) -- verify Vault deploys and all three UI modes are accessible
- [ ] Run lessons 04-06 (requires Docker + Vault from lesson 03)
- [ ] Run cleanup cell in README.md to tear down all containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)