### PR TITLE
feat: add `zhi doctor` workspace health diagnostics (#113)

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -125,14 +125,13 @@ Exit code 1 if any check reports an error, 0 otherwise. Warnings do not affect e
 
 | Flag | Description |
 |------|-------------|
-| `--check` | Run only the given categories (`workspace`, `plugins`, `store`, `config`, `updates`). Repeatable. |
+| `--check` | Run only the given categories (`workspace`, `plugins`, `store`, `config`, `updates`, or `all`). Repeatable. |
 | `--json` | Machine-readable output |
 | `--quiet` | Suppress OK and skipped rows |
 | `--deep` | Enable slow checks (e.g., plugin binary digest verification) |
 | `--timeout` | Per-check timeout (default 10s) |
 | `--no-color` | Disable ANSI output (also honours `NO_COLOR`) |
 | `--fix` | Reserved for future releases — no fixers registered in v1 |
-| `--updates` | Shortcut for `--check updates` |
 
 **Example output:**
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -110,6 +110,30 @@ Exit code 1 if any Blocking results, 0 otherwise.
 | `--path` | Validate only a specific path |
 | `--json` | Output as JSON |
 
+### `zhi doctor`
+
+Run a battery of health checks: workspace integrity, plugin installation and compatibility, store connectivity (with Vault-specific probes), config validation, and optionally marketplace updates. See [Doctor](doctor.md) for detail.
+
+```sh
+zhi doctor
+zhi doctor --check plugins --check store
+zhi doctor --check updates
+zhi doctor --json | jq .summary
+```
+
+Exit code 1 if any check reports an error, 0 otherwise. Warnings do not affect exit code.
+
+| Flag | Description |
+|------|-------------|
+| `--check` | Run only the given categories (`workspace`, `plugins`, `store`, `config`, `updates`). Repeatable. |
+| `--json` | Machine-readable output |
+| `--quiet` | Suppress OK and skipped rows |
+| `--deep` | Enable slow checks (e.g., plugin binary digest verification) |
+| `--timeout` | Per-check timeout (default 10s) |
+| `--no-color` | Disable ANSI output (also honours `NO_COLOR`) |
+| `--fix` | Reserved for future releases — no fixers registered in v1 |
+| `--updates` | Shortcut for `--check updates` |
+
 **Example output:**
 
 ```

--- a/docs/user-guide/doctor.md
+++ b/docs/user-guide/doctor.md
@@ -1,0 +1,105 @@
+# Doctor
+
+`zhi doctor` runs a battery of health checks against the current workspace and reports findings grouped by category. Think of it as `brew doctor` for zhi: one command that answers "is my workspace healthy?".
+
+## Quick start
+
+```bash
+zhi doctor
+```
+
+Produces output similar to:
+
+```
+Running zhi doctor…
+
+[OK]   Workspace — 4/4 checks passed (1 skipped)
+  [OK] workspace present — loaded from /home/alice/projects/infra
+  [OK] workspace parses — workspace.yaml parsed successfully
+  [OK] workspace validates — workspace validates cleanly
+  [OK] plugin directory — /home/alice/.zhi/plugins
+  [SKIP] file store path — store provider is not file-backed
+
+[WARN] Plugins — 12/13 checks passed (1 warning, 1 skipped)
+  [OK] config/structuredfile — resolved
+  [WARN] config/glyphoxa — no manifest or install metadata
+         hint: plugin will still work but version-compat checks are skipped
+  ...
+
+Summary: 16/17 checks passed, 1 warning(s), 0 error(s), 2 skipped
+```
+
+`zhi doctor` exits 0 if no checks failed, 1 if any check reported an error. Warnings do not affect the exit code.
+
+## Check categories
+
+| Category | What it verifies |
+|----------|------------------|
+| `workspace` | `zhi.yaml` exists, parses, validates; plugin directories are accessible; file-backed store paths exist |
+| `plugins` | Every referenced provider resolves; installed plugins have readable metadata; version compatibility against the current zhi; plugin processes launch and respond to a cheap RPC |
+| `store` | Store plugin responds to `Capabilities()` and `ListTrees()`; Vault-specific probes when the store provider is `vault` (seal status, token validity and TTL, mount accessibility) |
+| `config` | `engine.Validate()` runs without blocking results; no `core.deprecated` fields remain in use; literal `${VAR}` patterns are flagged (zhi does not yet expand env vars) |
+| `updates` | Installed plugin versions are compared against the marketplace — opt-in, requires network |
+
+Filter with `--check`:
+
+```bash
+zhi doctor --check workspace
+zhi doctor --check plugins --check store
+zhi doctor --check updates                 # marketplace lookup
+```
+
+## JSON output
+
+```bash
+zhi doctor --json | jq .summary
+```
+
+```json
+{
+  "ok": 16,
+  "warnings": 1,
+  "errors": 0,
+  "skipped": 2,
+  "total": 17,
+  "exit_code": 0
+}
+```
+
+The full payload contains a `groups` array keyed by category, each with a `results` array of `{check_id, name, status, message, detail, hint, fixable}` objects.
+
+## Options
+
+| Flag | Purpose |
+|------|---------|
+| `--check <category>` | Run only the named category. Repeatable. |
+| `--json` | Machine-readable output. Suppresses colors and headings. |
+| `--quiet` | Skip OK and Skipped results in text output; useful when piping to review summaries. |
+| `--deep` | Enable slow checks — currently plugin signature verification against `zhi-plugins.lock`. |
+| `--timeout <duration>` | Per-check wall-clock deadline (default 10s). |
+| `--no-color` | Disable ANSI output. Also honours `NO_COLOR`. |
+| `--fix` | Apply auto-fixable remediations. The v1 fixer set is empty — this flag is reserved for future releases. |
+| `--updates` | Shortcut for `--check updates`. |
+
+## Vault checks
+
+When the workspace declares `store.provider: vault`, the `store` category runs five additional probes using the connection settings from `zhi.yaml` and the standard `VAULT_*` environment variables:
+
+- `store.vault.reachable` — hits `sys/seal-status`.
+- `store.vault.unsealed` — confirms `initialized=true, sealed=false`.
+- `store.vault.token_valid` — calls `auth/token/lookup-self`.
+- `store.vault.token_ttl` — warns when the token has under one hour remaining.
+- `store.vault.mount_accessible` — lists the configured mount/prefix to verify `list` permission.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All checks passed or produced only warnings |
+| `1` | At least one check reported an error |
+
+## What doctor does not do
+
+- It does not modify the workspace or any plugin state. `--fix` is a placeholder; no fixers are registered in this release.
+- It does not expand environment variables; zhi does not yet support `${VAR}` expansion. The `config.env_var_expansion` check flags literal patterns so you know they are stored verbatim.
+- It does not probe UI plugins. UI plugins typically need a TTY and would block a non-interactive health check.

--- a/docs/user-guide/doctor.md
+++ b/docs/user-guide/doctor.md
@@ -41,12 +41,13 @@ Summary: 16/17 checks passed, 1 warning(s), 0 error(s), 2 skipped
 | `config` | `engine.Validate()` runs without blocking results; no `core.deprecated` fields remain in use; literal `${VAR}` patterns are flagged (zhi does not yet expand env vars) |
 | `updates` | Installed plugin versions are compared against the marketplace — opt-in, requires network |
 
-Filter with `--check`:
+Filter with `--check`. The reserved name `all` expands to every category, including those that need the network:
 
 ```bash
 zhi doctor --check workspace
 zhi doctor --check plugins --check store
-zhi doctor --check updates                 # marketplace lookup
+zhi doctor --check updates                 # marketplace lookup only
+zhi doctor --check all                     # everything, including updates
 ```
 
 ## JSON output
@@ -72,14 +73,13 @@ The full payload contains a `groups` array keyed by category, each with a `resul
 
 | Flag | Purpose |
 |------|---------|
-| `--check <category>` | Run only the named category. Repeatable. |
+| `--check <category>` | Run only the named category. Repeatable. `all` expands to every category. |
 | `--json` | Machine-readable output. Suppresses colors and headings. |
 | `--quiet` | Skip OK and Skipped results in text output; useful when piping to review summaries. |
 | `--deep` | Enable slow checks — currently plugin signature verification against `zhi-plugins.lock`. |
 | `--timeout <duration>` | Per-check wall-clock deadline (default 10s). |
 | `--no-color` | Disable ANSI output. Also honours `NO_COLOR`. |
 | `--fix` | Apply auto-fixable remediations. The v1 fixer set is empty — this flag is reserved for future releases. |
-| `--updates` | Shortcut for `--check updates`. |
 
 ## Vault checks
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,348 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MrWong99/zhi/internal/core/doctor"
+)
+
+var (
+	doctorChecks  []string
+	doctorJSON    bool
+	doctorQuiet   bool
+	doctorFix     bool
+	doctorDeep    bool
+	doctorTimeout time.Duration
+	doctorNoColor bool
+	doctorUpdates bool
+)
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Diagnose workspace health",
+	Long: `Run a battery of health checks against the current workspace.
+
+Checks are grouped into categories: workspace (integrity of zhi.yaml),
+plugins (referenced plugins installed and compatible), store (store
+plugin reachability, including Vault seal/token probes when vault is
+configured), config (tree validation, deprecated fields), and updates
+(marketplace version comparison — opt-in).
+
+The exit code is 1 if any check fails, 0 otherwise. Warnings do not
+affect the exit code.`,
+	Example: `  zhi doctor
+  zhi doctor --check workspace --check plugins
+  zhi doctor --check updates
+  zhi doctor --json | jq .
+  zhi doctor --deep`,
+	RunE: runDoctor,
+}
+
+func init() {
+	f := doctorCmd.Flags()
+	f.StringSliceVar(&doctorChecks, "check", nil,
+		"run only the given categories (workspace|plugins|store|config|updates)")
+	f.BoolVar(&doctorJSON, "json", false, "machine-readable output")
+	f.BoolVar(&doctorQuiet, "quiet", false, "suppress OK and skipped results in text output")
+	f.BoolVar(&doctorFix, "fix", false, "apply auto-fixable remediations (empty set in v1)")
+	f.BoolVar(&doctorDeep, "deep", false, "enable slow / expensive checks (signature verification, etc.)")
+	f.DurationVar(&doctorTimeout, "timeout", 10*time.Second, "per-check timeout")
+	f.BoolVar(&doctorNoColor, "no-color", false, "disable colored output")
+	f.BoolVar(&doctorUpdates, "updates", false,
+		"shortcut: include the updates category (same as --check updates)")
+	rootCmd.AddCommand(doctorCmd)
+}
+
+func runDoctor(cmd *cobra.Command, _ []string) error {
+	applyVerbose()
+
+	// If --updates is set, ensure "updates" is in the list.
+	checkFlags := slices.Clone(doctorChecks)
+	if doctorUpdates && !slices.Contains(checkFlags, string(doctor.CategoryUpdates)) {
+		checkFlags = append(checkFlags, string(doctor.CategoryUpdates))
+	}
+
+	cats, err := doctor.ParseCategories(checkFlags)
+	if err != nil {
+		return err
+	}
+
+	env := doctor.BuildEnvironment(doctor.EnvironmentOptions{
+		WorkspacePath: workspace,
+		ZhiVersion:    appVersion,
+		Deep:          doctorDeep,
+		Timeout:       doctorTimeout,
+		Updates:       slices.Contains(cats, doctor.CategoryUpdates),
+	})
+	defer env.Close()
+
+	runner := doctor.NewRunner(doctor.AllChecks(), cats)
+	report := runner.Run(cmd.Context(), env)
+
+	w := cmd.OutOrStdout()
+	if doctorJSON {
+		if err := writeJSON(w, report); err != nil {
+			return err
+		}
+	} else {
+		writeText(w, report, doctorQuiet, useColor(w))
+	}
+
+	if doctorFix {
+		fmt.Fprintln(w, "\n--fix has no registered fixers in this release.")
+	}
+
+	if report.HasError() {
+		return &doctorExitError{}
+	}
+	return nil
+}
+
+// doctorExitError carries a non-zero exit code without printing anything
+// beyond what was already written.
+type doctorExitError struct{}
+
+func (doctorExitError) Error() string { return "doctor reported errors" }
+func (doctorExitError) ExitCode() int { return 1 }
+
+// writeJSON serialises the report as a single object with grouped
+// results plus a summary stanza so callers can branch on counts.
+func writeJSON(w io.Writer, r doctor.Report) error {
+	ok, warn, errCount, skipped := r.Counts()
+	payload := struct {
+		Groups  []doctor.CategoryGroup `json:"groups"`
+		Summary struct {
+			OK       int `json:"ok"`
+			Warnings int `json:"warnings"`
+			Errors   int `json:"errors"`
+			Skipped  int `json:"skipped"`
+			Total    int `json:"total"`
+			ExitCode int `json:"exit_code"`
+		} `json:"summary"`
+	}{Groups: r.Groups}
+	payload.Summary.OK = ok
+	payload.Summary.Warnings = warn
+	payload.Summary.Errors = errCount
+	payload.Summary.Skipped = skipped
+	payload.Summary.Total = r.Total()
+	payload.Summary.ExitCode = r.ExitCode()
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(data))
+	return err
+}
+
+// writeText renders the report in the human-friendly table-ish format
+// shown in the command's example output. Quiet mode suppresses OK and
+// Skipped lines, keeping only Warnings and Errors.
+func writeText(w io.Writer, r doctor.Report, quiet, color bool) {
+	fmt.Fprintln(w, "Running zhi doctor…")
+	fmt.Fprintln(w)
+
+	for _, g := range r.Groups {
+		header := statusLabel(groupStatus(g), color) + "  " +
+			titleCase(string(g.Category)) + summary(g)
+		fmt.Fprintln(w, header)
+
+		for _, res := range g.Results {
+			if quiet && (res.Status == doctor.StatusOK || res.Status == doctor.StatusSkipped) {
+				continue
+			}
+			fmt.Fprint(w, "  ", statusIcon(res.Status, color), " ", res.Name)
+			if res.Message != "" {
+				fmt.Fprint(w, " — ", res.Message)
+			}
+			fmt.Fprintln(w)
+			if res.Detail != "" {
+				for _, line := range strings.Split(strings.TrimRight(res.Detail, "\n"), "\n") {
+					fmt.Fprintln(w, "      ", line)
+				}
+			}
+			if res.Hint != "" {
+				fmt.Fprintln(w, "       hint:", res.Hint)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	ok, warn, errs, skipped := r.Counts()
+	total := ok + warn + errs
+	fmt.Fprintf(w, "Summary: %d/%d checks passed, %d warning(s), %d error(s)",
+		ok, total, warn, errs)
+	if skipped > 0 {
+		fmt.Fprintf(w, ", %d skipped", skipped)
+	}
+	fmt.Fprintln(w)
+}
+
+// groupStatus returns the most severe status in a category for the
+// header label. Precedence from most to least severe: Error, Warning,
+// OK, Skipped. OK outranks Skipped so a category with any successful
+// check doesn't look like it was entirely skipped.
+func groupStatus(g doctor.CategoryGroup) doctor.Status {
+	var hasWarning, hasOK, hasSkipped bool
+	for _, r := range g.Results {
+		switch r.Status {
+		case doctor.StatusError:
+			return doctor.StatusError
+		case doctor.StatusWarning:
+			hasWarning = true
+		case doctor.StatusOK:
+			hasOK = true
+		case doctor.StatusSkipped:
+			hasSkipped = true
+		}
+	}
+	switch {
+	case hasWarning:
+		return doctor.StatusWarning
+	case hasOK:
+		return doctor.StatusOK
+	case hasSkipped:
+		return doctor.StatusSkipped
+	}
+	return doctor.StatusOK
+}
+
+// summary formats the per-category tally shown in the header.
+func summary(g doctor.CategoryGroup) string {
+	ok, warn, errs, skipped := 0, 0, 0, 0
+	for _, r := range g.Results {
+		switch r.Status {
+		case doctor.StatusOK:
+			ok++
+		case doctor.StatusWarning:
+			warn++
+		case doctor.StatusError:
+			errs++
+		case doctor.StatusSkipped:
+			skipped++
+		}
+	}
+	total := ok + warn + errs
+	var extras []string
+	if warn > 0 {
+		extras = append(extras, fmt.Sprintf("%d warning", warn))
+	}
+	if errs > 0 {
+		extras = append(extras, fmt.Sprintf("%d error", errs))
+	}
+	if skipped > 0 {
+		extras = append(extras, fmt.Sprintf("%d skipped", skipped))
+	}
+	s := fmt.Sprintf(" — %d/%d checks passed", ok, total)
+	if len(extras) > 0 {
+		s += " (" + strings.Join(extras, ", ") + ")"
+	}
+	return s
+}
+
+// statusIcon returns a short marker for per-result lines. Icons fall
+// back to ASCII when color is disabled.
+func statusIcon(s doctor.Status, color bool) string {
+	switch s {
+	case doctor.StatusOK:
+		if color {
+			return colorize("✓", ansiGreen)
+		}
+		return "[OK]"
+	case doctor.StatusWarning:
+		if color {
+			return colorize("⚠", ansiYellow)
+		}
+		return "[WARN]"
+	case doctor.StatusError:
+		if color {
+			return colorize("✗", ansiRed)
+		}
+		return "[FAIL]"
+	case doctor.StatusSkipped:
+		if color {
+			return colorize("·", ansiGrey)
+		}
+		return "[SKIP]"
+	}
+	return "?"
+}
+
+// statusLabel returns the per-category heading prefix.
+func statusLabel(s doctor.Status, color bool) string {
+	switch s {
+	case doctor.StatusOK:
+		if color {
+			return colorize("✅", "")
+		}
+		return "[OK] "
+	case doctor.StatusWarning:
+		if color {
+			return colorize("⚠️ ", "")
+		}
+		return "[WARN]"
+	case doctor.StatusError:
+		if color {
+			return colorize("❌", "")
+		}
+		return "[FAIL]"
+	case doctor.StatusSkipped:
+		if color {
+			return colorize("·", ansiGrey)
+		}
+		return "[SKIP]"
+	}
+	return "?"
+}
+
+// titleCase capitalises the first letter of a category name for display.
+// Lower-cased input is assumed.
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// useColor decides whether to emit ANSI codes: respect --no-color and
+// NO_COLOR, and fall back to ASCII when stdout is not a TTY.
+func useColor(w io.Writer) bool {
+	if doctorNoColor {
+		return false
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+const (
+	ansiGreen  = "\x1b[32m"
+	ansiYellow = "\x1b[33m"
+	ansiRed    = "\x1b[31m"
+	ansiGrey   = "\x1b[90m"
+	ansiReset  = "\x1b[0m"
+)
+
+func colorize(s, code string) string {
+	if code == "" {
+		return s
+	}
+	return code + s + ansiReset
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -22,7 +22,6 @@ var (
 	doctorDeep    bool
 	doctorTimeout time.Duration
 	doctorNoColor bool
-	doctorUpdates bool
 )
 
 var doctorCmd = &cobra.Command{
@@ -41,6 +40,7 @@ affect the exit code.`,
 	Example: `  zhi doctor
   zhi doctor --check workspace --check plugins
   zhi doctor --check updates
+  zhi doctor --check all
   zhi doctor --json | jq .
   zhi doctor --deep`,
 	RunE: runDoctor,
@@ -49,28 +49,20 @@ affect the exit code.`,
 func init() {
 	f := doctorCmd.Flags()
 	f.StringSliceVar(&doctorChecks, "check", nil,
-		"run only the given categories (workspace|plugins|store|config|updates)")
+		"run only the given categories (workspace|plugins|store|config|updates|all)")
 	f.BoolVar(&doctorJSON, "json", false, "machine-readable output")
 	f.BoolVar(&doctorQuiet, "quiet", false, "suppress OK and skipped results in text output")
 	f.BoolVar(&doctorFix, "fix", false, "apply auto-fixable remediations (empty set in v1)")
 	f.BoolVar(&doctorDeep, "deep", false, "enable slow / expensive checks (signature verification, etc.)")
 	f.DurationVar(&doctorTimeout, "timeout", 10*time.Second, "per-check timeout")
 	f.BoolVar(&doctorNoColor, "no-color", false, "disable colored output")
-	f.BoolVar(&doctorUpdates, "updates", false,
-		"shortcut: include the updates category (same as --check updates)")
 	rootCmd.AddCommand(doctorCmd)
 }
 
 func runDoctor(cmd *cobra.Command, _ []string) error {
 	applyVerbose()
 
-	// If --updates is set, ensure "updates" is in the list.
-	checkFlags := slices.Clone(doctorChecks)
-	if doctorUpdates && !slices.Contains(checkFlags, string(doctor.CategoryUpdates)) {
-		checkFlags = append(checkFlags, string(doctor.CategoryUpdates))
-	}
-
-	cats, err := doctor.ParseCategories(checkFlags)
+	cats, err := doctor.ParseCategories(doctorChecks)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -108,24 +108,23 @@ func (doctorExitError) ExitCode() int { return 1 }
 // writeJSON serialises the report as a single object with grouped
 // results plus a summary stanza so callers can branch on counts.
 func writeJSON(w io.Writer, r doctor.Report) error {
-	ok, warn, errCount, skipped := r.Counts()
+	type summaryPayload struct {
+		doctor.Counts
+		Total    int `json:"total"`
+		ExitCode int `json:"exit_code"`
+	}
+	counts := r.Counts()
 	payload := struct {
 		Groups  []doctor.CategoryGroup `json:"groups"`
-		Summary struct {
-			OK       int `json:"ok"`
-			Warnings int `json:"warnings"`
-			Errors   int `json:"errors"`
-			Skipped  int `json:"skipped"`
-			Total    int `json:"total"`
-			ExitCode int `json:"exit_code"`
-		} `json:"summary"`
-	}{Groups: r.Groups}
-	payload.Summary.OK = ok
-	payload.Summary.Warnings = warn
-	payload.Summary.Errors = errCount
-	payload.Summary.Skipped = skipped
-	payload.Summary.Total = r.Total()
-	payload.Summary.ExitCode = r.ExitCode()
+		Summary summaryPayload         `json:"summary"`
+	}{
+		Groups: r.Groups,
+		Summary: summaryPayload{
+			Counts:   counts,
+			Total:    counts.Total(),
+			ExitCode: r.ExitCode(),
+		},
+	}
 
 	data, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
@@ -168,12 +167,11 @@ func writeText(w io.Writer, r doctor.Report, quiet, color bool) {
 		fmt.Fprintln(w)
 	}
 
-	ok, warn, errs, skipped := r.Counts()
-	total := ok + warn + errs
+	c := r.Counts()
 	fmt.Fprintf(w, "Summary: %d/%d checks passed, %d warning(s), %d error(s)",
-		ok, total, warn, errs)
-	if skipped > 0 {
-		fmt.Fprintf(w, ", %d skipped", skipped)
+		c.OK, c.Total(), c.Warnings, c.Errors)
+	if c.Skipped > 0 {
+		fmt.Fprintf(w, ", %d skipped", c.Skipped)
 	}
 	fmt.Fprintln(w)
 }
@@ -209,31 +207,18 @@ func groupStatus(g doctor.CategoryGroup) doctor.Status {
 
 // summary formats the per-category tally shown in the header.
 func summary(g doctor.CategoryGroup) string {
-	ok, warn, errs, skipped := 0, 0, 0, 0
-	for _, r := range g.Results {
-		switch r.Status {
-		case doctor.StatusOK:
-			ok++
-		case doctor.StatusWarning:
-			warn++
-		case doctor.StatusError:
-			errs++
-		case doctor.StatusSkipped:
-			skipped++
-		}
-	}
-	total := ok + warn + errs
+	c := g.Counts()
 	var extras []string
-	if warn > 0 {
-		extras = append(extras, fmt.Sprintf("%d warning", warn))
+	if c.Warnings > 0 {
+		extras = append(extras, fmt.Sprintf("%d warning", c.Warnings))
 	}
-	if errs > 0 {
-		extras = append(extras, fmt.Sprintf("%d error", errs))
+	if c.Errors > 0 {
+		extras = append(extras, fmt.Sprintf("%d error", c.Errors))
 	}
-	if skipped > 0 {
-		extras = append(extras, fmt.Sprintf("%d skipped", skipped))
+	if c.Skipped > 0 {
+		extras = append(extras, fmt.Sprintf("%d skipped", c.Skipped))
 	}
-	s := fmt.Sprintf(" — %d/%d checks passed", ok, total)
+	s := fmt.Sprintf(" — %d/%d checks passed", c.OK, c.Total())
 	if len(extras) > 0 {
 		s += " (" + strings.Join(extras, ", ") + ")"
 	}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/zhi/internal/core/doctor"
+)
+
+// writeMinimalWorkspace writes a zhi.yaml that declares the built-in
+// structuredfile config provider and nothing else, which is enough for
+// workspace checks to pass.
+func writeMinimalWorkspace(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := []byte(`version: "1"
+config:
+  provider: structuredfile
+  options:
+    directory: structuredfile
+`)
+	if err := os.WriteFile(filepath.Join(dir, "zhi.yaml"), cfg, 0o600); err != nil {
+		t.Fatalf("write zhi.yaml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "structuredfile"), 0o700); err != nil {
+		t.Fatalf("mkdir structuredfile: %v", err)
+	}
+	return dir
+}
+
+func TestDoctorCmd_TextOutput(t *testing.T) {
+	dir := writeMinimalWorkspace(t)
+
+	var buf bytes.Buffer
+	resetDoctorFlags(t)
+	workspace = dir
+	doctorNoColor = true
+	doctorChecks = []string{"workspace"}
+
+	doctorCmd.SetOut(&buf)
+	doctorCmd.SetContext(context.Background())
+	if err := runDoctor(doctorCmd, nil); err != nil {
+		t.Fatalf("runDoctor: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Workspace") {
+		t.Errorf("output missing Workspace header: %q", out)
+	}
+	if !strings.Contains(out, "[OK]") {
+		t.Errorf("output missing OK marker: %q", out)
+	}
+	if !strings.Contains(out, "Summary:") {
+		t.Errorf("output missing summary: %q", out)
+	}
+}
+
+func TestDoctorCmd_JSONOutput(t *testing.T) {
+	dir := writeMinimalWorkspace(t)
+
+	var buf bytes.Buffer
+	resetDoctorFlags(t)
+	workspace = dir
+	doctorJSON = true
+	doctorChecks = []string{"workspace"}
+
+	doctorCmd.SetOut(&buf)
+	doctorCmd.SetContext(context.Background())
+	if err := runDoctor(doctorCmd, nil); err != nil {
+		t.Fatalf("runDoctor: %v", err)
+	}
+
+	var payload struct {
+		Groups  []doctor.CategoryGroup `json:"groups"`
+		Summary struct {
+			OK       int `json:"ok"`
+			Errors   int `json:"errors"`
+			Total    int `json:"total"`
+			ExitCode int `json:"exit_code"`
+		} `json:"summary"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, buf.String())
+	}
+	if len(payload.Groups) != 1 {
+		t.Fatalf("want 1 group, got %d", len(payload.Groups))
+	}
+	if payload.Groups[0].Category != doctor.CategoryWorkspace {
+		t.Errorf("unexpected category: %s", payload.Groups[0].Category)
+	}
+	if payload.Summary.ExitCode != 0 {
+		t.Errorf("want exit 0, got %d", payload.Summary.ExitCode)
+	}
+	if payload.Summary.OK == 0 {
+		t.Errorf("want at least one OK, got %d", payload.Summary.OK)
+	}
+}
+
+func TestDoctorCmd_ExitCodeOnError(t *testing.T) {
+	// No workspace anywhere — `workspace.exists` should fail with an
+	// error, which the runner surfaces via doctorExitError.
+	dir := t.TempDir()
+
+	resetDoctorFlags(t)
+	workspace = dir
+	doctorNoColor = true
+	doctorChecks = []string{"workspace"}
+
+	var buf bytes.Buffer
+	doctorCmd.SetOut(&buf)
+	doctorCmd.SetContext(context.Background())
+	err := runDoctor(doctorCmd, nil)
+	if err == nil {
+		t.Fatal("expected an error because workspace.exists should fail")
+	}
+	// runDoctor returns a pointer receiver implementation.
+	var de *doctorExitError
+	if !errors.As(err, &de) {
+		t.Fatalf("want *doctorExitError, got %T: %v", err, err)
+	}
+	if ExitCode(err) != 1 {
+		t.Errorf("want exit code 1, got %d", ExitCode(err))
+	}
+}
+
+func TestDoctorCmd_InvalidCategory(t *testing.T) {
+	dir := writeMinimalWorkspace(t)
+
+	resetDoctorFlags(t)
+	workspace = dir
+	doctorChecks = []string{"nonsense"}
+
+	var buf bytes.Buffer
+	doctorCmd.SetOut(&buf)
+	doctorCmd.SetContext(context.Background())
+	err := runDoctor(doctorCmd, nil)
+	if err == nil {
+		t.Fatal("expected category parse error")
+	}
+	if !strings.Contains(err.Error(), "nonsense") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// resetDoctorFlags returns the package-level doctor flags to their
+// defaults between subtests so tests stay independent.
+func resetDoctorFlags(t *testing.T) {
+	t.Helper()
+	doctorChecks = nil
+	doctorJSON = false
+	doctorQuiet = false
+	doctorFix = false
+	doctorDeep = false
+	doctorTimeout = 0
+	doctorNoColor = false
+	doctorUpdates = false
+	workspace = ""
+	t.Cleanup(func() {
+		doctorChecks = nil
+		doctorJSON = false
+		doctorQuiet = false
+		doctorFix = false
+		doctorDeep = false
+		doctorTimeout = 0
+		doctorNoColor = false
+		doctorUpdates = false
+		workspace = ""
+	})
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -159,7 +159,6 @@ func resetDoctorFlags(t *testing.T) {
 	doctorDeep = false
 	doctorTimeout = 0
 	doctorNoColor = false
-	doctorUpdates = false
 	workspace = ""
 	t.Cleanup(func() {
 		doctorChecks = nil
@@ -169,7 +168,6 @@ func resetDoctorFlags(t *testing.T) {
 		doctorDeep = false
 		doctorTimeout = 0
 		doctorNoColor = false
-		doctorUpdates = false
 		workspace = ""
 	})
 }

--- a/internal/core/doctor/check.go
+++ b/internal/core/doctor/check.go
@@ -1,0 +1,171 @@
+// Package doctor implements health-check diagnostics for a zhi workspace.
+//
+// The package exposes a small set of primitives — Check, Result, Runner,
+// Report — and a handful of Check implementations grouped into categories
+// (workspace, plugins, store, config, updates). The cli/doctor command
+// drives the Runner and renders the Report. Checks are self-contained:
+// they inspect the Environment they are handed and return findings. The
+// Runner tags each finding with the owning check's Category so Result
+// instances never carry a category field of their own.
+package doctor
+
+import (
+	"context"
+	"time"
+
+	"github.com/MrWong99/zhi/internal/core"
+	"github.com/MrWong99/zhi/pkg/sharing/marketplace"
+)
+
+// Category identifies a group of related checks. The CLI filters by
+// category and the Report groups findings by category.
+type Category string
+
+const (
+	CategoryWorkspace Category = "workspace"
+	CategoryPlugins   Category = "plugins"
+	CategoryStore     Category = "store"
+	CategoryConfig    Category = "config"
+	CategoryUpdates   Category = "updates"
+)
+
+// AllCategories lists every category in the order they are rendered.
+// Updates runs last and only when explicitly requested.
+var AllCategories = []Category{
+	CategoryWorkspace,
+	CategoryPlugins,
+	CategoryStore,
+	CategoryConfig,
+	CategoryUpdates,
+}
+
+// DefaultCategories is the set of categories that run when the user does
+// not pass --check. Updates requires network access and is opt-in.
+var DefaultCategories = []Category{
+	CategoryWorkspace,
+	CategoryPlugins,
+	CategoryStore,
+	CategoryConfig,
+}
+
+// Status is the outcome of a single check finding.
+type Status string
+
+const (
+	// StatusOK — the check passed.
+	StatusOK Status = "ok"
+	// StatusWarning — a non-blocking issue that deserves attention.
+	StatusWarning Status = "warning"
+	// StatusError — a blocking issue; the workspace is unhealthy.
+	StatusError Status = "error"
+	// StatusSkipped — the check did not apply in this environment.
+	StatusSkipped Status = "skipped"
+)
+
+// Result is a single finding emitted by a Check. The owning Check
+// determines the Category — Result deliberately does not carry a
+// Category field (that would duplicate Check.Category()). Grouping is
+// the Report's job.
+type Result struct {
+	CheckID string `json:"check_id"`
+	Name    string `json:"name"`
+	Status  Status `json:"status"`
+	Message string `json:"message,omitempty"`
+	Detail  string `json:"detail,omitempty"`
+	Hint    string `json:"hint,omitempty"`
+	Fixable bool   `json:"fixable,omitempty"`
+}
+
+// Check is a single diagnostic. The Runner invokes Run and labels the
+// returned results with Category() before adding them to the Report.
+type Check interface {
+	ID() string
+	Category() Category
+	Description() string
+	Run(ctx context.Context, env *Environment) []Result
+}
+
+// Fixer is an optional Check extension that knows how to repair state
+// it reported on. The CLI calls Fix when --fix is passed and the
+// associated Result has Fixable=true.
+type Fixer interface {
+	Check
+	Fix(ctx context.Context, env *Environment, r Result) error
+}
+
+// Environment bundles everything a Check might need. Fields may be nil
+// when doctor is running in degraded mode — for example, Engine is nil
+// if engine construction failed, but Workspace and Discovered may still
+// be populated so workspace and plugin checks can still run.
+type Environment struct {
+	WorkspacePath string
+	Workspace     *core.WorkspaceConfig
+	WorkspaceErr  error
+	Registry      *core.Registry
+	Engine        *core.Engine
+	EngineErr     error
+	Discovered    []core.PluginInfo
+	ZhiVersion    string
+	Marketplace   *marketplace.Client
+	Deep          bool
+	// Timeout is the Runner's per-check wall-clock deadline. Checks may
+	// consult this for their own internal sub-timeouts, but they must
+	// also honour the context passed to Run — the Runner installs a
+	// derived context with this deadline.
+	Timeout time.Duration
+}
+
+// CategoryGroup bundles results from checks that share a category.
+type CategoryGroup struct {
+	Category Category `json:"category"`
+	Results  []Result `json:"results"`
+}
+
+// Report is the aggregated output of a Runner.Run invocation. Groups
+// preserves the order in which categories ran.
+type Report struct {
+	Groups []CategoryGroup `json:"groups"`
+}
+
+// Counts returns the total number of results with each status across
+// the whole report.
+func (r Report) Counts() (ok, warning, errCount, skipped int) {
+	for _, g := range r.Groups {
+		for _, res := range g.Results {
+			switch res.Status {
+			case StatusOK:
+				ok++
+			case StatusWarning:
+				warning++
+			case StatusError:
+				errCount++
+			case StatusSkipped:
+				skipped++
+			}
+		}
+	}
+	return
+}
+
+// Total returns the total number of non-skipped results.
+func (r Report) Total() int {
+	ok, warn, errCount, _ := r.Counts()
+	return ok + warn + errCount
+}
+
+// HasError reports whether any result has StatusError.
+func (r Report) HasError() bool {
+	_, _, e, _ := r.Counts()
+	return e > 0
+}
+
+// ExitCode maps a Report to a process exit code:
+//
+//	0 — no errors (warnings allowed).
+//	1 — at least one error result.
+func (r Report) ExitCode() int {
+	if r.HasError() {
+		return 1
+	}
+	return 0
+}

--- a/internal/core/doctor/check.go
+++ b/internal/core/doctor/check.go
@@ -121,43 +121,67 @@ type CategoryGroup struct {
 	Results  []Result `json:"results"`
 }
 
+// Counts tallies the results in this category.
+func (g CategoryGroup) Counts() Counts {
+	var c Counts
+	for _, res := range g.Results {
+		switch res.Status {
+		case StatusOK:
+			c.OK++
+		case StatusWarning:
+			c.Warnings++
+		case StatusError:
+			c.Errors++
+		case StatusSkipped:
+			c.Skipped++
+		}
+	}
+	return c
+}
+
 // Report is the aggregated output of a Runner.Run invocation. Groups
 // preserves the order in which categories ran.
 type Report struct {
 	Groups []CategoryGroup `json:"groups"`
 }
 
-// Counts returns the total number of results with each status across
-// the whole report.
-func (r Report) Counts() (ok, warning, errCount, skipped int) {
+// Counts bundles per-status result totals. Named fields make callers
+// self-documenting — no positional unpacking of anonymous ints.
+type Counts struct {
+	OK       int `json:"ok"`
+	Warnings int `json:"warnings"`
+	Errors   int `json:"errors"`
+	Skipped  int `json:"skipped"`
+}
+
+// Total returns the number of non-skipped results (OK + Warnings + Errors).
+func (c Counts) Total() int { return c.OK + c.Warnings + c.Errors }
+
+// Counts tallies results by status across the whole report.
+func (r Report) Counts() Counts {
+	var c Counts
 	for _, g := range r.Groups {
 		for _, res := range g.Results {
 			switch res.Status {
 			case StatusOK:
-				ok++
+				c.OK++
 			case StatusWarning:
-				warning++
+				c.Warnings++
 			case StatusError:
-				errCount++
+				c.Errors++
 			case StatusSkipped:
-				skipped++
+				c.Skipped++
 			}
 		}
 	}
-	return
+	return c
 }
 
 // Total returns the total number of non-skipped results.
-func (r Report) Total() int {
-	ok, warn, errCount, _ := r.Counts()
-	return ok + warn + errCount
-}
+func (r Report) Total() int { return r.Counts().Total() }
 
 // HasError reports whether any result has StatusError.
-func (r Report) HasError() bool {
-	_, _, e, _ := r.Counts()
-	return e > 0
-}
+func (r Report) HasError() bool { return r.Counts().Errors > 0 }
 
 // ExitCode maps a Report to a process exit code:
 //

--- a/internal/core/doctor/config.go
+++ b/internal/core/doctor/config.go
@@ -1,0 +1,341 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/labels"
+)
+
+// envVarPattern detects literal ${VAR} expansions that zhi currently stores
+// verbatim (no shell-style substitution is performed).
+var envVarPattern = regexp.MustCompile(`\$\{[^}]+\}`)
+
+// envVarHint is attached to every env-var expansion warning so users know
+// how to track the feature request.
+const envVarHint = "env-var expansion is not implemented in zhi; these strings are stored literally. See https://github.com/MrWong99/zhi/issues (file a request)"
+
+type configValidatesCheck struct{}
+
+func (configValidatesCheck) ID() string         { return "config.validates" }
+func (configValidatesCheck) Category() Category { return CategoryConfig }
+func (configValidatesCheck) Description() string {
+	return "engine.Validate returns no blocking results across the full tree."
+}
+
+func (c configValidatesCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env == nil || env.Engine == nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusSkipped,
+			Message: "engine not initialized",
+		}}
+	}
+
+	tree, err := env.Engine.LoadTree(ctx)
+	if err != nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusError,
+			Message: "could not load config tree",
+			Detail:  err.Error(),
+			Hint:    "run `zhi validate` for detail",
+		}}
+	}
+
+	// Transform failures are non-fatal — fall back to the raw tree so
+	// validation still runs and users hear about the transform issue.
+	var out []Result
+	if err := env.Engine.TransformForDisplay(ctx, tree); err != nil {
+		out = append(out, Result{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusWarning,
+			Message: "transform for display failed",
+			Detail:  err.Error(),
+		})
+	}
+
+	results, err := env.Engine.Validate(ctx, tree)
+	if err != nil {
+		out = append(out, Result{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusError,
+			Message: "validation failed",
+			Detail:  err.Error(),
+			Hint:    "run `zhi validate` for detail",
+		})
+		return out
+	}
+
+	var blocking, warning, info int
+	var blockingMsgs []string
+	for _, r := range results {
+		switch r.Severity {
+		case config.Blocking:
+			blocking++
+			if len(blockingMsgs) < 3 {
+				blockingMsgs = append(blockingMsgs, r.Message)
+			}
+		case config.Warning:
+			warning++
+		case config.Info:
+			info++
+		}
+	}
+
+	switch {
+	case blocking > 0:
+		out = append(out, Result{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusError,
+			Message: fmt.Sprintf("%d blocking, %d warning, %d info", blocking, warning, info),
+			Detail:  strings.Join(blockingMsgs, "; "),
+			Hint:    "run `zhi validate` for detail",
+		})
+	case warning > 0:
+		out = append(out, Result{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusWarning,
+			Message: fmt.Sprintf("%d blocking, %d warning, %d info", blocking, warning, info),
+			Hint:    "run `zhi validate` for detail",
+		})
+	default:
+		out = append(out, Result{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusOK,
+			Message: "no validation findings",
+		})
+	}
+	return out
+}
+
+type configNoDeprecatedCheck struct{}
+
+func (configNoDeprecatedCheck) ID() string         { return "config.no_deprecated_fields" }
+func (configNoDeprecatedCheck) Category() Category { return CategoryConfig }
+func (configNoDeprecatedCheck) Description() string {
+	return "No configuration value carries a core.deprecated label."
+}
+
+func (c configNoDeprecatedCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env == nil || env.Engine == nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusSkipped,
+			Message: "engine not initialized",
+		}}
+	}
+
+	tree, err := env.Engine.LoadTree(ctx)
+	if err != nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusSkipped,
+			Message: "tree load failed, see config.validates",
+			Detail:  err.Error(),
+		}}
+	}
+
+	var out []Result
+	paths := tree.List()
+	for _, path := range paths {
+		v, ok := tree.Get(path)
+		if !ok {
+			continue
+		}
+		raw, present := v.Metadata[labels.LabelCoreDeprecated]
+		if !present {
+			continue
+		}
+		msg := fmt.Sprintf("%v", raw)
+		if msg == "" {
+			continue
+		}
+		out = append(out, Result{
+			CheckID: c.ID(),
+			Name:    path,
+			Status:  StatusWarning,
+			Message: "deprecated",
+			Hint:    msg,
+		})
+	}
+
+	if len(out) == 0 {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusOK,
+			Message: "no deprecated fields in use",
+		}}
+	}
+	return out
+}
+
+type configEnvVarCheck struct{}
+
+func (configEnvVarCheck) ID() string         { return "config.env_var_expansion" }
+func (configEnvVarCheck) Category() Category { return CategoryConfig }
+func (configEnvVarCheck) Description() string {
+	return "Detect literal ${VAR} expressions — zhi does not yet expand them."
+}
+
+func (c configEnvVarCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env == nil || env.Workspace == nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusSkipped,
+			Message: "workspace not loaded",
+		}}
+	}
+
+	type match struct {
+		location string
+		expr     string
+	}
+	var matches []match
+
+	// Scan the raw workspace file if we can find it.
+	path, ok := findWorkspaceFile(env.Workspace.Dir)
+	if ok {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return []Result{{
+				CheckID: c.ID(),
+				Name:    c.ID(),
+				Status:  StatusSkipped,
+				Message: "could not read workspace file",
+				Detail:  err.Error(),
+			}}
+		}
+		base := filepath.Base(path)
+		for i, line := range strings.Split(string(data), "\n") {
+			for _, m := range envVarPattern.FindAllString(line, -1) {
+				matches = append(matches, match{
+					location: fmt.Sprintf("%s:%d: %s", base, i+1, m),
+					expr:     m,
+				})
+			}
+		}
+	}
+
+	// Also inspect any string-typed values in the loaded tree.
+	if env.Engine != nil {
+		if tree, err := env.Engine.LoadTree(ctx); err == nil {
+			for _, p := range tree.List() {
+				v, ok := tree.Get(p)
+				if !ok {
+					continue
+				}
+				s, ok := v.Val.(string)
+				if !ok {
+					continue
+				}
+				for _, m := range envVarPattern.FindAllString(s, -1) {
+					matches = append(matches, match{
+						location: fmt.Sprintf("%s: %s", p, m),
+						expr:     m,
+					})
+				}
+			}
+		}
+	}
+
+	if len(matches) == 0 {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusOK,
+			Message: "no literal ${VAR} patterns detected",
+		}}
+	}
+
+	// Collapse into a single summary — per-match results are too noisy
+	// when a workspace leans heavily on placeholders.
+	previewCount := 5
+	if previewCount > len(matches) {
+		previewCount = len(matches)
+	}
+	preview := make([]string, previewCount)
+	for i := 0; i < previewCount; i++ {
+		preview[i] = matches[i].location
+	}
+	return []Result{{
+		CheckID: c.ID(),
+		Name:    c.ID(),
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d literal ${VAR} patterns detected", len(matches)),
+		Detail:  strings.Join(preview, "\n"),
+		Hint:    envVarHint,
+	}}
+}
+
+type configNoConflictsCheck struct{}
+
+func (configNoConflictsCheck) ID() string         { return "config.no_conflicts" }
+func (configNoConflictsCheck) Category() Category { return CategoryConfig }
+func (configNoConflictsCheck) Description() string {
+	return "Component dependencies resolve without cycles or overlaps."
+}
+
+func (c configNoConflictsCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env == nil || env.Engine == nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusSkipped,
+			Message: "engine not initialized",
+		}}
+	}
+
+	errs := env.Engine.Components().ValidateDependencies()
+	if len(errs) == 0 {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusOK,
+			Message: "component dependencies are consistent",
+		}}
+	}
+
+	out := make([]Result, 0, len(errs))
+	for _, e := range errs {
+		out = append(out, Result{
+			CheckID: c.ID(),
+			Name:    "components",
+			Status:  StatusError,
+			Message: e.Error(),
+		})
+	}
+	return out
+}
+
+// findWorkspaceFile returns the on-disk path of the workspace config file in
+// dir. Mirrors the candidate order used by core.LoadWorkspace so the raw file
+// scan sees exactly what the loader did.
+func findWorkspaceFile(dir string) (string, bool) {
+	if dir == "" {
+		return "", false
+	}
+	for _, name := range []string{"zhi.yaml", "zhi.yml", "zhi.json"} {
+		p := filepath.Join(dir, name)
+		if _, err := os.Stat(p); err == nil {
+			return p, true
+		}
+	}
+	return "", false
+}

--- a/internal/core/doctor/config_test.go
+++ b/internal/core/doctor/config_test.go
@@ -1,0 +1,390 @@
+package doctor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/zhi/internal/core"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/labels"
+)
+
+// mockConfigPlugin is a minimal config.Plugin used by doctor tests. Each
+// field can be overridden per-test so we can exercise error branches.
+type mockConfigPlugin struct {
+	values       map[string]config.Value
+	listErr      error
+	getErr       error
+	validateFunc func(path string) []config.ValidationResult
+}
+
+func newMockConfigPlugin(vals map[string]config.Value) *mockConfigPlugin {
+	if vals == nil {
+		vals = make(map[string]config.Value)
+	}
+	return &mockConfigPlugin{values: vals}
+}
+
+func (m *mockConfigPlugin) List(context.Context) ([]string, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	paths := make([]string, 0, len(m.values))
+	for p := range m.values {
+		paths = append(paths, p)
+	}
+	return paths, nil
+}
+
+func (m *mockConfigPlugin) Get(_ context.Context, path string) (config.Value, bool, error) {
+	if m.getErr != nil {
+		return config.Value{}, false, m.getErr
+	}
+	v, ok := m.values[path]
+	return v, ok, nil
+}
+
+func (m *mockConfigPlugin) Set(_ context.Context, path string, v config.Value) error {
+	m.values[path] = v
+	return nil
+}
+
+func (m *mockConfigPlugin) Validate(_ context.Context, path string, _ config.TreeReader) ([]config.ValidationResult, error) {
+	if m.validateFunc != nil {
+		return m.validateFunc(path), nil
+	}
+	return nil, nil
+}
+
+// newTestEngine builds a core.Engine backed by mc under the provider name
+// "mock". A zhi.yaml is NOT written to disk — most tests don't need one;
+// callers that do write one pass the dir back in via ws.Dir.
+func newTestEngine(t *testing.T, mc *mockConfigPlugin, comps []core.ComponentDef, dir string) *core.Engine {
+	t.Helper()
+
+	reg := core.NewRegistry()
+	if err := reg.RegisterConfig("mock", func(string, map[string]any) (config.Plugin, error) {
+		return mc, nil
+	}); err != nil {
+		t.Fatalf("RegisterConfig: %v", err)
+	}
+
+	if dir == "" {
+		dir = t.TempDir()
+	}
+	ws := &core.WorkspaceConfig{
+		Version:    "1",
+		Config:     core.ProviderRef{Provider: "mock"},
+		Components: comps,
+		Dir:        dir,
+	}
+	eng, err := core.NewEngine(reg, ws)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	t.Cleanup(eng.Close)
+	return eng
+}
+
+func findResult(rs []Result, status Status) (Result, bool) {
+	for _, r := range rs {
+		if r.Status == status {
+			return r, true
+		}
+	}
+	return Result{}, false
+}
+
+func TestConfigValidatesCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		engineNil  bool
+		validateFn func(path string) []config.ValidationResult
+		wantStatus Status
+		wantMsgSub string
+	}{
+		{
+			name:       "engine nil skips",
+			engineNil:  true,
+			wantStatus: StatusSkipped,
+			wantMsgSub: "engine not initialized",
+		},
+		{
+			name: "blocking finding yields error",
+			validateFn: func(path string) []config.ValidationResult {
+				if path == "database/host" {
+					return []config.ValidationResult{
+						{Severity: config.Blocking, Message: "host required"},
+					}
+				}
+				return nil
+			},
+			wantStatus: StatusError,
+			wantMsgSub: "1 blocking",
+		},
+		{
+			name: "warning only yields warning",
+			validateFn: func(path string) []config.ValidationResult {
+				if path == "app/name" {
+					return []config.ValidationResult{
+						{Severity: config.Warning, Message: "too short"},
+					}
+				}
+				return nil
+			},
+			wantStatus: StatusWarning,
+			wantMsgSub: "1 warning",
+		},
+		{
+			name:       "clean tree yields ok",
+			validateFn: nil,
+			wantStatus: StatusOK,
+			wantMsgSub: "no validation findings",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := &Environment{}
+			if !tc.engineNil {
+				mc := newMockConfigPlugin(map[string]config.Value{
+					"database/host": {Val: "localhost"},
+					"app/name":      {Val: "myapp"},
+				})
+				mc.validateFunc = tc.validateFn
+				env.Engine = newTestEngine(t, mc, nil, "")
+				env.Workspace = env.Engine.Workspace()
+			}
+
+			results := configValidatesCheck{}.Run(context.Background(), env)
+			if len(results) == 0 {
+				t.Fatalf("expected at least one result")
+			}
+			r, ok := findResult(results, tc.wantStatus)
+			if !ok {
+				t.Fatalf("no result with status %s: %+v", tc.wantStatus, results)
+			}
+			if !strings.Contains(r.Message, tc.wantMsgSub) {
+				t.Errorf("message %q does not contain %q", r.Message, tc.wantMsgSub)
+			}
+		})
+	}
+}
+
+func TestConfigValidatesCheckLoadError(t *testing.T) {
+	mc := newMockConfigPlugin(map[string]config.Value{"a": {Val: "x"}})
+	mc.listErr = os.ErrPermission
+	env := &Environment{Engine: newTestEngine(t, mc, nil, "")}
+
+	results := configValidatesCheck{}.Run(context.Background(), env)
+	if len(results) != 1 || results[0].Status != StatusError {
+		t.Fatalf("expected single error result, got %+v", results)
+	}
+	if !strings.Contains(results[0].Message, "could not load config tree") {
+		t.Errorf("unexpected message: %q", results[0].Message)
+	}
+}
+
+func TestConfigNoDeprecatedCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		values     map[string]config.Value
+		engineNil  bool
+		wantStatus Status
+		wantName   string
+		wantHint   string
+	}{
+		{
+			name:       "engine nil skips",
+			engineNil:  true,
+			wantStatus: StatusSkipped,
+		},
+		{
+			name: "deprecated field flagged",
+			values: map[string]config.Value{
+				"legacy/flag": {
+					Val: true,
+					Metadata: map[string]any{
+						labels.LabelCoreDeprecated: "use X instead",
+					},
+				},
+				"app/name": {Val: "myapp"},
+			},
+			wantStatus: StatusWarning,
+			wantName:   "legacy/flag",
+			wantHint:   "use X instead",
+		},
+		{
+			name: "empty deprecated metadata ignored",
+			values: map[string]config.Value{
+				"app/name": {
+					Val:      "myapp",
+					Metadata: map[string]any{labels.LabelCoreDeprecated: ""},
+				},
+			},
+			wantStatus: StatusOK,
+		},
+		{
+			name: "clean tree yields ok",
+			values: map[string]config.Value{
+				"app/name": {Val: "myapp"},
+			},
+			wantStatus: StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := &Environment{}
+			if !tc.engineNil {
+				mc := newMockConfigPlugin(tc.values)
+				env.Engine = newTestEngine(t, mc, nil, "")
+			}
+
+			results := configNoDeprecatedCheck{}.Run(context.Background(), env)
+			if len(results) == 0 {
+				t.Fatalf("expected at least one result")
+			}
+			r, ok := findResult(results, tc.wantStatus)
+			if !ok {
+				t.Fatalf("no result with status %s: %+v", tc.wantStatus, results)
+			}
+			if tc.wantName != "" && r.Name != tc.wantName {
+				t.Errorf("name = %q, want %q", r.Name, tc.wantName)
+			}
+			if tc.wantHint != "" && r.Hint != tc.wantHint {
+				t.Errorf("hint = %q, want %q", r.Hint, tc.wantHint)
+			}
+		})
+	}
+}
+
+func TestConfigEnvVarCheck(t *testing.T) {
+	t.Run("workspace nil skipped", func(t *testing.T) {
+		results := configEnvVarCheck{}.Run(context.Background(), &Environment{})
+		if len(results) != 1 || results[0].Status != StatusSkipped {
+			t.Fatalf("expected single skipped result, got %+v", results)
+		}
+	})
+
+	t.Run("literal env var yields warning", func(t *testing.T) {
+		dir := t.TempDir()
+		yaml := "version: \"1\"\nconfig:\n  provider: mock\n  options:\n    token: \"${FOO}\"\n"
+		if err := os.WriteFile(filepath.Join(dir, "zhi.yaml"), []byte(yaml), 0o644); err != nil {
+			t.Fatalf("write zhi.yaml: %v", err)
+		}
+
+		mc := newMockConfigPlugin(map[string]config.Value{"app/name": {Val: "myapp"}})
+		env := &Environment{
+			Engine:    newTestEngine(t, mc, nil, dir),
+			Workspace: &core.WorkspaceConfig{Dir: dir},
+		}
+
+		results := configEnvVarCheck{}.Run(context.Background(), env)
+		if len(results) != 1 || results[0].Status != StatusWarning {
+			t.Fatalf("expected single warning, got %+v", results)
+		}
+		if !strings.Contains(results[0].Message, "literal ${VAR}") {
+			t.Errorf("message %q missing summary", results[0].Message)
+		}
+		if !strings.Contains(results[0].Detail, "${FOO}") {
+			t.Errorf("detail %q missing placeholder", results[0].Detail)
+		}
+		if !strings.Contains(results[0].Hint, "not implemented") {
+			t.Errorf("hint missing feature-request pointer: %q", results[0].Hint)
+		}
+	})
+
+	t.Run("clean workspace yields ok", func(t *testing.T) {
+		dir := t.TempDir()
+		yaml := "version: \"1\"\nconfig:\n  provider: mock\n"
+		if err := os.WriteFile(filepath.Join(dir, "zhi.yaml"), []byte(yaml), 0o644); err != nil {
+			t.Fatalf("write zhi.yaml: %v", err)
+		}
+		mc := newMockConfigPlugin(map[string]config.Value{"app/name": {Val: "myapp"}})
+		env := &Environment{
+			Engine:    newTestEngine(t, mc, nil, dir),
+			Workspace: &core.WorkspaceConfig{Dir: dir},
+		}
+
+		results := configEnvVarCheck{}.Run(context.Background(), env)
+		if len(results) != 1 || results[0].Status != StatusOK {
+			t.Fatalf("expected single OK result, got %+v", results)
+		}
+	})
+
+	t.Run("env var in tree value flagged", func(t *testing.T) {
+		dir := t.TempDir()
+		// No zhi.yaml — only the tree value carries the placeholder.
+		mc := newMockConfigPlugin(map[string]config.Value{
+			"secrets/api_key": {Val: "${SECRET_TOKEN}"},
+		})
+		env := &Environment{
+			Engine:    newTestEngine(t, mc, nil, dir),
+			Workspace: &core.WorkspaceConfig{Dir: dir},
+		}
+
+		results := configEnvVarCheck{}.Run(context.Background(), env)
+		if len(results) != 1 || results[0].Status != StatusWarning {
+			t.Fatalf("expected warning, got %+v", results)
+		}
+		if !strings.Contains(results[0].Detail, "secrets/api_key") {
+			t.Errorf("detail %q missing tree path", results[0].Detail)
+		}
+	})
+}
+
+func TestConfigNoConflictsCheck(t *testing.T) {
+	t.Run("engine nil skips", func(t *testing.T) {
+		results := configNoConflictsCheck{}.Run(context.Background(), &Environment{})
+		if len(results) != 1 || results[0].Status != StatusSkipped {
+			t.Fatalf("expected single skipped result, got %+v", results)
+		}
+	})
+
+	t.Run("consistent components yields ok", func(t *testing.T) {
+		mc := newMockConfigPlugin(map[string]config.Value{"app/name": {Val: "myapp"}})
+		comps := []core.ComponentDef{
+			{Name: "database", Paths: []string{"database/"}, Mandatory: true},
+			{Name: "redis", Paths: []string{"redis/"}, Dependencies: []string{"database"}, Mandatory: true},
+		}
+		env := &Environment{Engine: newTestEngine(t, mc, comps, "")}
+
+		results := configNoConflictsCheck{}.Run(context.Background(), env)
+		if len(results) != 1 || results[0].Status != StatusOK {
+			t.Fatalf("expected single OK result, got %+v", results)
+		}
+	})
+
+	t.Run("dependency violation yields error", func(t *testing.T) {
+		mc := newMockConfigPlugin(map[string]config.Value{"app/name": {Val: "myapp"}})
+		// redis depends on database; enable redis but disable database to
+		// trigger a violation via ValidateDependencies.
+		comps := []core.ComponentDef{
+			{Name: "database", Paths: []string{"database/"}},
+			{Name: "redis", Paths: []string{"redis/"}, Dependencies: []string{"database"}, Mandatory: true},
+		}
+		env := &Environment{Engine: newTestEngine(t, mc, comps, "")}
+		// Disable database manually by toggling state via Enable/Disable.
+		// Mandatory redis is already enabled; database starts disabled, so
+		// ValidateDependencies should already report the violation.
+
+		results := configNoConflictsCheck{}.Run(context.Background(), env)
+		if len(results) == 0 {
+			t.Fatalf("expected at least one error result")
+		}
+		r := results[0]
+		if r.Status != StatusError {
+			t.Fatalf("expected error status, got %s: %+v", r.Status, results)
+		}
+		if r.Name != "components" {
+			t.Errorf("name = %q, want %q", r.Name, "components")
+		}
+		if !strings.Contains(r.Message, "redis") {
+			t.Errorf("message %q missing component name", r.Message)
+		}
+	})
+}

--- a/internal/core/doctor/doctor.go
+++ b/internal/core/doctor/doctor.go
@@ -1,0 +1,239 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/MrWong99/zhi/internal/core"
+	"github.com/MrWong99/zhi/pkg/sharing/marketplace"
+)
+
+// DefaultTimeout is the per-check wall-clock deadline used when the
+// caller does not specify one.
+const DefaultTimeout = 10 * time.Second
+
+// EnvironmentOptions configures BuildEnvironment.
+type EnvironmentOptions struct {
+	// WorkspacePath is the directory to load the workspace from.
+	WorkspacePath string
+	// ZhiVersion is the running zhi version; passed in by the caller
+	// because the build-time version lives in the cli package and the
+	// doctor package must not import it (cycle).
+	ZhiVersion string
+	// Deep enables slow / expensive checks (signature verification etc.).
+	Deep bool
+	// Timeout is the per-check deadline. Zero means DefaultTimeout.
+	Timeout time.Duration
+	// MarketplaceURL overrides the marketplace endpoint. Empty =
+	// marketplace.DefaultURL. Only consulted when Updates is true.
+	MarketplaceURL string
+	// Updates enables the updates category (requires network).
+	Updates bool
+}
+
+// BuildEnvironment loads the workspace, discovers plugins, and builds an
+// Engine. Failures are captured on the returned Environment rather than
+// returned as errors so checks can still run and report them.
+func BuildEnvironment(opts EnvironmentOptions) *Environment {
+	env := &Environment{
+		WorkspacePath: opts.WorkspacePath,
+		ZhiVersion:    opts.ZhiVersion,
+		Deep:          opts.Deep,
+		Timeout:       opts.Timeout,
+	}
+	if env.Timeout == 0 {
+		env.Timeout = DefaultTimeout
+	}
+	if opts.Updates {
+		url := opts.MarketplaceURL
+		if url == "" {
+			url = marketplace.DefaultURL
+		}
+		env.Marketplace = marketplace.NewClient(url)
+	}
+
+	env.Registry = core.DefaultRegistry()
+
+	ws, err := core.LoadWorkspace(opts.WorkspacePath)
+	if err != nil {
+		env.WorkspaceErr = err
+		return env
+	}
+	env.Workspace = ws
+
+	// Discover external plugins. Errors here are non-fatal — the
+	// registry will still contain built-ins.
+	_ = env.Registry.RefreshExternal(core.DiscoveryConfig{
+		Directories: ws.PluginDirectories(),
+	})
+
+	// Snapshot discovered plugins so checks can see exactly what was
+	// found without re-running discovery.
+	env.Discovered, _ = core.Discover(core.DiscoveryConfig{
+		Directories: ws.PluginDirectories(),
+	})
+
+	eng, err := core.NewEngine(env.Registry, ws)
+	if err != nil {
+		env.EngineErr = err
+		return env
+	}
+	env.Engine = eng
+
+	return env
+}
+
+// Close releases resources held by the Environment — at present, any
+// plugin processes launched while constructing the engine.
+func (e *Environment) Close() {
+	if e == nil || e.Engine == nil {
+		return
+	}
+	e.Engine.Close()
+}
+
+// Runner executes a filtered set of Checks and aggregates their
+// results into a Report.
+type Runner struct {
+	checks     []Check
+	categories []Category
+}
+
+// NewRunner builds a Runner that will execute the given checks when
+// their category is in the filter. An empty filter selects every
+// category listed in AllCategories.
+func NewRunner(checks []Check, filter []Category) *Runner {
+	if len(filter) == 0 {
+		filter = DefaultCategories
+	}
+	return &Runner{checks: checks, categories: filter}
+}
+
+// Run executes every selected check and returns the aggregated Report.
+// Checks are invoked sequentially within a category so output order is
+// stable; categories themselves run in the order declared by filter.
+//
+// Each check receives a context derived from ctx with env.Timeout as
+// the deadline. Panics inside a check are recovered and surfaced as a
+// StatusError Result so one bad check does not take down the whole run.
+func (r *Runner) Run(ctx context.Context, env *Environment) Report {
+	var report Report
+	for _, cat := range r.categories {
+		group := CategoryGroup{Category: cat}
+		for _, check := range r.checks {
+			if check.Category() != cat {
+				continue
+			}
+			group.Results = append(group.Results, runCheck(ctx, env, check)...)
+		}
+		report.Groups = append(report.Groups, group)
+	}
+	return report
+}
+
+// runCheck wraps a single Check invocation with timeout + panic recovery.
+func runCheck(parent context.Context, env *Environment, c Check) (out []Result) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			out = append(out, Result{
+				CheckID: c.ID(),
+				Name:    c.ID(),
+				Status:  StatusError,
+				Message: fmt.Sprintf("check panicked: %v", rec),
+			})
+		}
+	}()
+
+	ctx := parent
+	if env.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(parent, env.Timeout)
+		defer cancel()
+	}
+
+	results := c.Run(ctx, env)
+	// Honour context cancellation — if the check ignored the deadline
+	// but the context did expire we emit a warning alongside any
+	// returned results, so users know the run was cut short.
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		results = append(results, Result{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusWarning,
+			Message: fmt.Sprintf("check exceeded %s deadline", env.Timeout),
+		})
+	}
+	return results
+}
+
+// AllChecks returns every registered Check, in the order they should
+// appear for each category.
+func AllChecks() []Check {
+	return []Check{
+		// Workspace
+		&workspaceExistsCheck{},
+		&workspaceParsesCheck{},
+		&workspaceValidatesCheck{},
+		&workspacePluginDirsCheck{},
+		&workspaceFileStoreCheck{},
+
+		// Plugins
+		&pluginsReferencedInstalledCheck{},
+		&pluginsManifestReadableCheck{},
+		&pluginsVersionCompatibleCheck{},
+		&pluginsAliveCheck{},
+		&pluginsSignatureVerifiedCheck{},
+
+		// Store
+		&storeCapabilitiesCheck{},
+		&storeListTreesCheck{},
+		&vaultReachableCheck{},
+		&vaultUnsealedCheck{},
+		&vaultTokenValidCheck{},
+		&vaultTokenTTLCheck{},
+		&vaultMountAccessibleCheck{},
+
+		// Config
+		&configValidatesCheck{},
+		&configNoDeprecatedCheck{},
+		&configEnvVarCheck{},
+		&configNoConflictsCheck{},
+
+		// Updates
+		&updatesAvailableCheck{},
+	}
+}
+
+// ParseCategories turns a list of user-supplied strings into Category
+// values, preserving order and rejecting unknown names. An empty input
+// returns DefaultCategories.
+func ParseCategories(names []string) ([]Category, error) {
+	if len(names) == 0 {
+		return DefaultCategories, nil
+	}
+	out := make([]Category, 0, len(names))
+	for _, raw := range names {
+		c := Category(raw)
+		if !slices.Contains(AllCategories, c) {
+			return nil, fmt.Errorf("unknown check category %q (valid: %s)", raw, categoriesString())
+		}
+		if !slices.Contains(out, c) {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+func categoriesString() string {
+	s := ""
+	for i, c := range AllCategories {
+		if i > 0 {
+			s += "|"
+		}
+		s += string(c)
+	}
+	return s
+}

--- a/internal/core/doctor/doctor.go
+++ b/internal/core/doctor/doctor.go
@@ -207,9 +207,14 @@ func AllChecks() []Check {
 	}
 }
 
+// CategoryAll is a pseudo-category that expands to every real category
+// including those excluded from DefaultCategories (e.g. updates).
+const CategoryAll = Category("all")
+
 // ParseCategories turns a list of user-supplied strings into Category
 // values, preserving order and rejecting unknown names. An empty input
-// returns DefaultCategories.
+// returns DefaultCategories. The reserved name "all" expands to every
+// registered category, including those that need network access.
 func ParseCategories(names []string) ([]Category, error) {
 	if len(names) == 0 {
 		return DefaultCategories, nil
@@ -217,8 +222,16 @@ func ParseCategories(names []string) ([]Category, error) {
 	out := make([]Category, 0, len(names))
 	for _, raw := range names {
 		c := Category(raw)
+		if c == CategoryAll {
+			for _, every := range AllCategories {
+				if !slices.Contains(out, every) {
+					out = append(out, every)
+				}
+			}
+			continue
+		}
 		if !slices.Contains(AllCategories, c) {
-			return nil, fmt.Errorf("unknown check category %q (valid: %s)", raw, categoriesString())
+			return nil, fmt.Errorf("unknown check category %q (valid: %s|all)", raw, categoriesString())
 		}
 		if !slices.Contains(out, c) {
 			out = append(out, c)

--- a/internal/core/doctor/doctor_test.go
+++ b/internal/core/doctor/doctor_test.go
@@ -1,0 +1,72 @@
+package doctor
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseCategories(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    []string
+		want  []Category
+		isErr bool
+	}{
+		{
+			name: "empty falls back to defaults",
+			in:   nil,
+			want: DefaultCategories,
+		},
+		{
+			name: "single category",
+			in:   []string{"workspace"},
+			want: []Category{CategoryWorkspace},
+		},
+		{
+			name: "dedupes repeated entries",
+			in:   []string{"workspace", "plugins", "workspace"},
+			want: []Category{CategoryWorkspace, CategoryPlugins},
+		},
+		{
+			name: "all expands to every category",
+			in:   []string{"all"},
+			want: AllCategories,
+		},
+		{
+			name: "all merges with explicit entries without duplicating",
+			in:   []string{"plugins", "all"},
+			// order: explicit plugins first, then the remaining categories
+			// from AllCategories that weren't already added.
+			want: []Category{
+				CategoryPlugins,
+				CategoryWorkspace,
+				CategoryStore,
+				CategoryConfig,
+				CategoryUpdates,
+			},
+		},
+		{
+			name:  "unknown category errors",
+			in:    []string{"nonsense"},
+			isErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseCategories(tc.in)
+			if tc.isErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/core/doctor/plugins.go
+++ b/internal/core/doctor/plugins.go
@@ -1,0 +1,515 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"time"
+
+	"github.com/MrWong99/zhi/internal/core"
+	"github.com/MrWong99/zhi/pkg/sharing/lockfile"
+	"github.com/MrWong99/zhi/pkg/sharing/manifest"
+	"github.com/MrWong99/zhi/pkg/sharing/metadata"
+	"github.com/MrWong99/zhi/pkg/sharing/semver"
+	"github.com/MrWong99/zhi/pkg/sharing/verify"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/launch"
+)
+
+// defaultAliveTimeout is used when env.Timeout is zero so alive probes
+// still have a deterministic per-call deadline.
+const defaultAliveTimeout = 5 * time.Second
+
+type pluginsReferencedInstalledCheck struct{}
+
+func (pluginsReferencedInstalledCheck) ID() string         { return "plugins.referenced_installed" }
+func (pluginsReferencedInstalledCheck) Category() Category { return CategoryPlugins }
+func (pluginsReferencedInstalledCheck) Description() string {
+	return "Every provider referenced in zhi.yaml resolves to a built-in or discovered plugin."
+}
+
+func (c pluginsReferencedInstalledCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env == nil || env.Workspace == nil {
+		return []Result{skipped(c.ID(), c.ID(), "no workspace loaded")}
+	}
+	if env.Registry == nil {
+		return []Result{skipped(c.ID(), c.ID(), "no registry available")}
+	}
+
+	ws := env.Workspace
+	// Build lookup sets so we never accidentally launch a plugin here.
+	configNames := env.Registry.ListConfig()
+	transformNames := env.Registry.ListTransform()
+	storeNames := env.Registry.ListStore()
+	uiNames := env.Registry.ListUI()
+
+	var refs []providerRef
+	if ws.Config.Provider != "" {
+		refs = append(refs, providerRef{kind: "config", name: ws.Config.Provider, names: configNames})
+	}
+	for _, t := range ws.Transform {
+		if t.Provider == "" {
+			continue
+		}
+		refs = append(refs, providerRef{kind: "transform", name: t.Provider, names: transformNames})
+	}
+	if ws.Store.Provider != "" {
+		refs = append(refs, providerRef{kind: "store", name: ws.Store.Provider, names: storeNames})
+	}
+	if ws.UI.Provider != "" {
+		refs = append(refs, providerRef{kind: "ui", name: ws.UI.Provider, names: uiNames})
+	}
+
+	if len(refs) == 0 {
+		return []Result{skipped(c.ID(), c.ID(), "no providers referenced")}
+	}
+
+	results := make([]Result, 0, len(refs))
+	for _, ref := range refs {
+		name := ref.kind + "/" + ref.name
+		if slices.Contains(ref.names, ref.name) {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusOK,
+				Message: "resolved",
+			})
+			continue
+		}
+		results = append(results, Result{
+			CheckID: c.ID(),
+			Name:    name,
+			Status:  StatusError,
+			Message: "plugin not installed",
+			Detail:  fmt.Sprintf("no %s provider registered as %q", ref.kind, ref.name),
+			Hint:    "install with `zhi plugin install oci://...` or set the provider name correctly",
+		})
+	}
+	return results
+}
+
+type pluginsManifestReadableCheck struct{}
+
+func (pluginsManifestReadableCheck) ID() string         { return "plugins.manifest_readable" }
+func (pluginsManifestReadableCheck) Category() Category { return CategoryPlugins }
+func (pluginsManifestReadableCheck) Description() string {
+	return "Each discovered plugin has a readable zhi-plugin.yaml manifest."
+}
+
+func (c pluginsManifestReadableCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env == nil || len(env.Discovered) == 0 {
+		return []Result{skipped(c.ID(), c.ID(), "no discovered plugins")}
+	}
+
+	metaStore := metadata.NewStore(metadata.DefaultMetadataDir())
+	results := make([]Result, 0, len(env.Discovered))
+	for _, p := range env.Discovered {
+		name := string(p.Type) + "/" + p.Name
+		// Published plugins include a zhi-plugin.yaml next to the binary;
+		// OCI-installed plugins don't — their metadata lives under
+		// ~/.zhi/metadata/ instead. Try the local manifest first, then
+		// fall back to the install metadata store.
+		path := manifestPathFor(p)
+		m, err := manifest.LoadFile(path)
+		switch {
+		case err == nil:
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusOK,
+				Message: m.Name + " v" + m.Version,
+				Detail:  "source: " + path,
+			})
+		case errors.Is(err, os.ErrNotExist):
+			meta, mErr := metaStore.Load(p.Name)
+			if mErr == nil && meta != nil {
+				results = append(results, Result{
+					CheckID: c.ID(),
+					Name:    name,
+					Status:  StatusOK,
+					Message: meta.Name + " v" + meta.Version,
+					Detail:  "source: install metadata (" + metadata.DefaultMetadataDir() + ")",
+				})
+				continue
+			}
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusWarning,
+				Message: "no manifest or install metadata",
+				Detail:  "looked at " + path,
+				Hint:    "plugin will still work but version-compat checks are skipped",
+			})
+		default:
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusError,
+				Message: "manifest unreadable",
+				Detail:  err.Error(),
+			})
+		}
+	}
+	return results
+}
+
+type pluginsVersionCompatibleCheck struct{}
+
+func (pluginsVersionCompatibleCheck) ID() string         { return "plugins.version_compatible" }
+func (pluginsVersionCompatibleCheck) Category() Category { return CategoryPlugins }
+func (pluginsVersionCompatibleCheck) Description() string {
+	return "Installed plugin manifests declare a minZhiVersion compatible with the current zhi."
+}
+
+func (c pluginsVersionCompatibleCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env == nil || len(env.Discovered) == 0 {
+		return []Result{skipped(c.ID(), c.ID(), "no discovered plugins")}
+	}
+
+	results := make([]Result, 0, len(env.Discovered))
+	for _, p := range env.Discovered {
+		name := string(p.Type) + "/" + p.Name
+		path := manifestPathFor(p)
+		m, err := manifest.LoadFile(path)
+		if err != nil {
+			// Previous check already warned; stay silent here.
+			continue
+		}
+		if m.MinZhiVersion == "" {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusOK,
+				Message: "no minimum specified",
+			})
+			continue
+		}
+		// Dev builds have no meaningful semver; surface a warning instead
+		// of failing parse.
+		if env.ZhiVersion == "" || env.ZhiVersion == "dev" {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusWarning,
+				Message: "running a dev build; compatibility not enforced",
+				Detail:  fmt.Sprintf("plugin requires zhi >= %s", m.MinZhiVersion),
+				Hint:    "running a dev build; version compatibility not enforced",
+			})
+			continue
+		}
+		ok, err := semver.Matches(env.ZhiVersion, ">="+m.MinZhiVersion)
+		if err != nil {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusWarning,
+				Message: "unable to compare versions",
+				Detail:  err.Error(),
+				Hint:    "running a dev build; version compatibility not enforced",
+			})
+			continue
+		}
+		if !ok {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusError,
+				Message: fmt.Sprintf("plugin requires zhi >= %s but you have %s", m.MinZhiVersion, env.ZhiVersion),
+				Hint:    "upgrade zhi or install an older version of the plugin",
+			})
+			continue
+		}
+		results = append(results, Result{
+			CheckID: c.ID(),
+			Name:    name,
+			Status:  StatusOK,
+			Message: fmt.Sprintf("zhi %s satisfies >= %s", env.ZhiVersion, m.MinZhiVersion),
+		})
+	}
+	return results
+}
+
+type pluginsAliveCheck struct{}
+
+func (pluginsAliveCheck) ID() string         { return "plugins.alive" }
+func (pluginsAliveCheck) Category() Category { return CategoryPlugins }
+func (pluginsAliveCheck) Description() string {
+	return "Each referenced plugin launches and responds to a cheap RPC within timeout."
+}
+
+func (c pluginsAliveCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env == nil || env.Workspace == nil {
+		return []Result{skipped(c.ID(), c.ID(), "no workspace loaded")}
+	}
+	if env.Registry == nil {
+		return []Result{skipped(c.ID(), c.ID(), "no registry available")}
+	}
+
+	ws := env.Workspace
+	// Index discovered externals by type+name for quick path lookup.
+	discovered := make(map[string]core.PluginInfo, len(env.Discovered))
+	for _, p := range env.Discovered {
+		discovered[string(p.Type)+"/"+p.Name] = p
+	}
+
+	builtinConfig := builtinSet(env.Registry.ListConfigProviders())
+	builtinTransform := builtinSet(env.Registry.ListTransformProviders())
+	builtinStore := builtinSet(env.Registry.ListStoreProviders())
+	builtinUI := builtinSet(env.Registry.ListUIProviders())
+
+	probeTimeout := defaultAliveTimeout
+	if env.Timeout > 0 {
+		// Leave headroom so two sub-operations fit inside Runner's deadline.
+		probeTimeout = env.Timeout / 2
+		if probeTimeout <= 0 {
+			probeTimeout = env.Timeout
+		}
+	}
+
+	var results []Result
+	if ws.Config.Provider != "" {
+		results = append(results, c.probe(ctx, env, "config", ws.Config.Provider, discovered, builtinConfig, probeTimeout))
+	}
+	for _, t := range ws.Transform {
+		if t.Provider == "" {
+			continue
+		}
+		results = append(results, c.probe(ctx, env, "transform", t.Provider, discovered, builtinTransform, probeTimeout))
+	}
+	if ws.Store.Provider != "" {
+		results = append(results, c.probe(ctx, env, "store", ws.Store.Provider, discovered, builtinStore, probeTimeout))
+	}
+	if ws.UI.Provider != "" {
+		// UI plugins frequently need a TTY, so a liveness launch is risky.
+		results = append(results, Result{
+			CheckID: c.ID(),
+			Name:    "ui/" + ws.UI.Provider,
+			Status:  StatusSkipped,
+			Message: "UI plugin liveness is not probed",
+		})
+		_ = builtinUI // reserved for future use
+	}
+
+	if len(results) == 0 {
+		return []Result{skipped(c.ID(), c.ID(), "no providers referenced")}
+	}
+	return results
+}
+
+func (c pluginsAliveCheck) probe(ctx context.Context, env *Environment, kind, name string, discovered map[string]core.PluginInfo, builtins map[string]bool, timeout time.Duration) Result {
+	label := kind + "/" + name
+	if builtins[name] {
+		// In-process factory: no RPC to make, but report OK for symmetry.
+		return Result{
+			CheckID: pluginsAliveCheck{}.ID(),
+			Name:    label,
+			Status:  StatusOK,
+			Message: "built-in provider (in-process)",
+		}
+	}
+	info, ok := discovered[label]
+	if !ok {
+		return Result{
+			CheckID: pluginsAliveCheck{}.ID(),
+			Name:    label,
+			Status:  StatusError,
+			Message: "plugin binary not discovered",
+			Hint:    "run `zhi plugin install` or check workspace plugin directories",
+		}
+	}
+
+	// Sub-context for a single probe — keep it independent of the parent
+	// context so cancelling it does not affect the enclosing check.
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	start := time.Now()
+	switch kind {
+	case "config":
+		p, cleanup, err := launch.LaunchConfig(info.Path)
+		if err != nil {
+			return rpcFailure(label, "plugin did not respond", err)
+		}
+		defer cleanup()
+		if _, err := p.List(probeCtx); err != nil {
+			return rpcFailure(label, "plugin did not respond", err)
+		}
+	case "transform":
+		p, cleanup, err := launch.LaunchTransform(info.Path)
+		if err != nil {
+			return rpcFailure(label, "plugin did not respond", err)
+		}
+		defer cleanup()
+		if _, err := p.ValidatePolicy(probeCtx); err != nil {
+			return rpcFailure(label, "plugin did not respond", err)
+		}
+	case "store":
+		p, cleanup, err := launch.LaunchStore(info.Path)
+		if err != nil {
+			return rpcFailure(label, "plugin did not respond", err)
+		}
+		defer cleanup()
+		if _, err := p.Capabilities(probeCtx); err != nil {
+			return rpcFailure(label, "plugin did not respond", err)
+		}
+	default:
+		return Result{
+			CheckID: pluginsAliveCheck{}.ID(),
+			Name:    label,
+			Status:  StatusSkipped,
+			Message: "unknown plugin kind",
+		}
+	}
+
+	latency := time.Since(start).Round(time.Millisecond)
+	return Result{
+		CheckID: pluginsAliveCheck{}.ID(),
+		Name:    label,
+		Status:  StatusOK,
+		Message: fmt.Sprintf("responded in %s", latency),
+	}
+}
+
+type pluginsSignatureVerifiedCheck struct{}
+
+func (pluginsSignatureVerifiedCheck) ID() string         { return "plugins.signature_verified" }
+func (pluginsSignatureVerifiedCheck) Category() Category { return CategoryPlugins }
+func (pluginsSignatureVerifiedCheck) Description() string {
+	return "Installed plugin binaries match their lockfile digests (deep mode only)."
+}
+
+func (c pluginsSignatureVerifiedCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env == nil || !env.Deep {
+		return []Result{skipped(c.ID(), c.ID(), "enable with --deep")}
+	}
+	if env.Workspace == nil {
+		return []Result{skipped(c.ID(), c.ID(), "no workspace loaded")}
+	}
+	if len(env.Discovered) == 0 {
+		return []Result{skipped(c.ID(), c.ID(), "no discovered plugins")}
+	}
+
+	lockPath := filepath.Join(env.Workspace.Dir, "zhi-plugins.lock")
+	lf, err := lockfile.LoadFile(lockPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []Result{skipped(c.ID(), c.ID(), "no zhi-plugins.lock found")}
+		}
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusError,
+			Message: "lockfile unreadable",
+			Detail:  err.Error(),
+		}}
+	}
+
+	platformKey := runtime.GOOS + "/" + runtime.GOARCH
+	results := make([]Result, 0, len(lf.Plugins))
+	for _, locked := range lf.Plugins {
+		label := locked.Type + "/" + locked.Name
+		info, ok := findDiscovered(env.Discovered, locked.Name, locked.Type)
+		if !ok {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    label,
+				Status:  StatusWarning,
+				Message: "locked plugin not discovered",
+				Detail:  "no binary matching lockfile entry",
+			})
+			continue
+		}
+		expected, has := locked.Platforms[platformKey]
+		if !has {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    label,
+				Status:  StatusWarning,
+				Message: "no digest recorded for this platform",
+				Detail:  "platform " + platformKey + " not in lockfile entry",
+			})
+			continue
+		}
+		if err := verify.VerifyBinaryDigest(info.Path, expected); err != nil {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    label,
+				Status:  StatusError,
+				Message: "digest mismatch",
+				Detail:  err.Error(),
+				Hint:    "reinstall with `zhi plugin install --force`",
+			})
+			continue
+		}
+		results = append(results, Result{
+			CheckID: c.ID(),
+			Name:    label,
+			Status:  StatusOK,
+			Message: "digest matches lockfile",
+		})
+	}
+	return results
+}
+
+// --- helpers ---
+
+// providerRef bundles a workspace provider reference with the set of
+// known names for that plugin type, so the check can do a lookup without
+// launching external plugins.
+type providerRef struct {
+	kind  string
+	name  string
+	names []string
+}
+
+// manifestPathFor returns the conventional manifest location next to a
+// plugin binary. The binary layout is either flat (~/.zhi/plugins/zhi-<type>-<name>)
+// or subdirectory-based (~/.zhi/plugins/<type>/<name>); in both cases the
+// manifest is expected as a sibling file.
+func manifestPathFor(p core.PluginInfo) string {
+	return filepath.Join(filepath.Dir(p.Path), "zhi-plugin.yaml")
+}
+
+// builtinSet returns the set of provider names marked as built-in in the
+// registry info slice. External providers have Source equal to their
+// binary path rather than "built-in".
+func builtinSet(infos []core.ProviderInfo) map[string]bool {
+	out := make(map[string]bool, len(infos))
+	for _, info := range infos {
+		if info.Source == "built-in" {
+			out[info.Name] = true
+		}
+	}
+	return out
+}
+
+func findDiscovered(plugins []core.PluginInfo, name, typ string) (core.PluginInfo, bool) {
+	for _, p := range plugins {
+		if p.Name == name && string(p.Type) == typ {
+			return p, true
+		}
+	}
+	return core.PluginInfo{}, false
+}
+
+func skipped(checkID, name, message string) Result {
+	return Result{
+		CheckID: checkID,
+		Name:    name,
+		Status:  StatusSkipped,
+		Message: message,
+	}
+}
+
+func rpcFailure(name, message string, err error) Result {
+	return Result{
+		CheckID: pluginsAliveCheck{}.ID(),
+		Name:    name,
+		Status:  StatusError,
+		Message: message,
+		Detail:  err.Error(),
+	}
+}

--- a/internal/core/doctor/plugins_test.go
+++ b/internal/core/doctor/plugins_test.go
@@ -1,0 +1,498 @@
+package doctor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/zhi/internal/core"
+	"github.com/MrWong99/zhi/pkg/sharing/lockfile"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+)
+
+// stubConfigPlugin is the smallest config.Plugin needed for registry
+// tests here; the checks only ever look at the registered name.
+type stubConfigPlugin struct{}
+
+func (stubConfigPlugin) List(context.Context) ([]string, error) { return nil, nil }
+func (stubConfigPlugin) Get(context.Context, string) (config.Value, bool, error) {
+	return config.Value{}, false, nil
+}
+func (stubConfigPlugin) Set(context.Context, string, config.Value) error { return nil }
+func (stubConfigPlugin) Validate(context.Context, string, config.TreeReader) ([]config.ValidationResult, error) {
+	return nil, nil
+}
+
+// stubConfigFactory produces a stubConfigPlugin for any options.
+func stubConfigFactory(string, map[string]any) (config.Plugin, error) {
+	return stubConfigPlugin{}, nil
+}
+
+// newRegistryWith returns a fresh Registry with the given built-in config
+// factories registered. The doctor checks never call the factories, but
+// registration makes the names appear in ListConfig().
+func newRegistryWith(t *testing.T, configNames ...string) *core.Registry {
+	t.Helper()
+	r := core.NewRegistry()
+	for _, n := range configNames {
+		if err := r.RegisterConfig(n, stubConfigFactory); err != nil {
+			t.Fatalf("RegisterConfig(%q): %v", n, err)
+		}
+	}
+	return r
+}
+
+// writeFile is a small convenience for tests that create manifest and
+// lockfile fixtures in a tempdir.
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func statusesByCheckID(t *testing.T, results []Result, wantID string) []Status {
+	t.Helper()
+	var out []Status
+	for _, r := range results {
+		if r.CheckID != wantID {
+			t.Fatalf("unexpected CheckID: got %q want %q", r.CheckID, wantID)
+		}
+		out = append(out, r.Status)
+	}
+	return out
+}
+
+func TestPluginsReferencedInstalled(t *testing.T) {
+	t.Parallel()
+
+	check := pluginsReferencedInstalledCheck{}
+
+	tests := []struct {
+		name     string
+		env      *Environment
+		want     []Status
+		wantMsgs []string // optional message assertions keyed by index
+	}{
+		{
+			name: "nil workspace is skipped",
+			env:  &Environment{},
+			want: []Status{StatusSkipped},
+		},
+		{
+			name: "registered config provider resolves",
+			env: &Environment{
+				Registry: newRegistryWith(t, "test-config"),
+				Workspace: &core.WorkspaceConfig{
+					Config: core.ProviderRef{Provider: "test-config"},
+				},
+			},
+			want: []Status{StatusOK},
+		},
+		{
+			name: "missing config provider errors",
+			env: &Environment{
+				Registry: newRegistryWith(t),
+				Workspace: &core.WorkspaceConfig{
+					Config: core.ProviderRef{Provider: "missing"},
+				},
+			},
+			want: []Status{StatusError},
+		},
+		{
+			name: "no providers referenced is skipped",
+			env: &Environment{
+				Registry:  newRegistryWith(t),
+				Workspace: &core.WorkspaceConfig{},
+			},
+			want: []Status{StatusSkipped},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := check.Run(context.Background(), tc.env)
+			gotStatuses := statusesByCheckID(t, got, check.ID())
+			if len(gotStatuses) != len(tc.want) {
+				t.Fatalf("result count: got %d %v want %d %v", len(gotStatuses), gotStatuses, len(tc.want), tc.want)
+			}
+			for i, s := range tc.want {
+				if gotStatuses[i] != s {
+					t.Errorf("result[%d].Status: got %q want %q", i, gotStatuses[i], s)
+				}
+			}
+		})
+	}
+}
+
+func TestPluginsManifestReadable(t *testing.T) {
+	t.Parallel()
+
+	check := pluginsManifestReadableCheck{}
+
+	t.Run("no discovered plugins is skipped", func(t *testing.T) {
+		t.Parallel()
+		res := check.Run(context.Background(), &Environment{})
+		if len(res) != 1 || res[0].Status != StatusSkipped {
+			t.Fatalf("want single skipped, got %+v", res)
+		}
+	})
+
+	t.Run("readable manifest yields OK", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		binPath := filepath.Join(dir, "zhi-config-sample")
+		writeFile(t, binPath, "#!/bin/sh\n")
+		writeFile(t, filepath.Join(dir, "zhi-plugin.yaml"), `schemaVersion: "1"
+name: sample
+type: config
+version: 1.2.3
+`)
+		env := &Environment{
+			Discovered: []core.PluginInfo{{
+				Name: "sample",
+				Type: core.PluginTypeConfig,
+				Path: binPath,
+			}},
+		}
+		res := check.Run(context.Background(), env)
+		if len(res) != 1 {
+			t.Fatalf("want 1 result, got %d", len(res))
+		}
+		if res[0].Status != StatusOK {
+			t.Fatalf("want OK, got %+v", res[0])
+		}
+		if want := "sample v1.2.3"; res[0].Message != want {
+			t.Errorf("Message: got %q want %q", res[0].Message, want)
+		}
+	})
+
+	t.Run("missing manifest warns", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		env := &Environment{
+			Discovered: []core.PluginInfo{{
+				Name: "sample",
+				Type: core.PluginTypeConfig,
+				Path: filepath.Join(dir, "zhi-config-sample"),
+			}},
+		}
+		res := check.Run(context.Background(), env)
+		if len(res) != 1 || res[0].Status != StatusWarning {
+			t.Fatalf("want single warning, got %+v", res)
+		}
+	})
+
+	t.Run("invalid manifest errors", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		// Name omitted → Validate() rejects the manifest.
+		writeFile(t, filepath.Join(dir, "zhi-plugin.yaml"), `schemaVersion: "1"
+type: config
+version: 1.2.3
+`)
+		env := &Environment{
+			Discovered: []core.PluginInfo{{
+				Name: "sample",
+				Type: core.PluginTypeConfig,
+				Path: filepath.Join(dir, "zhi-config-sample"),
+			}},
+		}
+		res := check.Run(context.Background(), env)
+		if len(res) != 1 || res[0].Status != StatusError {
+			t.Fatalf("want single error, got %+v", res)
+		}
+	})
+}
+
+func TestPluginsVersionCompatible(t *testing.T) {
+	t.Parallel()
+
+	check := pluginsVersionCompatibleCheck{}
+
+	t.Run("no discovered plugins is skipped", func(t *testing.T) {
+		t.Parallel()
+		res := check.Run(context.Background(), &Environment{})
+		if len(res) != 1 || res[0].Status != StatusSkipped {
+			t.Fatalf("want single skipped, got %+v", res)
+		}
+	})
+
+	type caseDef struct {
+		name       string
+		minVer     string
+		zhiVersion string
+		want       Status
+	}
+	cases := []caseDef{
+		{name: "compatible version is OK", minVer: "1.0.0", zhiVersion: "1.7.0", want: StatusOK},
+		{name: "too old zhi errors", minVer: "1.5.0", zhiVersion: "0.5.0", want: StatusError},
+		{name: "dev build warns", minVer: "1.0.0", zhiVersion: "dev", want: StatusWarning},
+		{name: "no minimum is OK", minVer: "", zhiVersion: "1.7.0", want: StatusOK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			body := `schemaVersion: "1"
+name: sample
+type: config
+version: 1.0.0
+`
+			if tc.minVer != "" {
+				body += "minZhiVersion: " + tc.minVer + "\n"
+			}
+			writeFile(t, filepath.Join(dir, "zhi-plugin.yaml"), body)
+			env := &Environment{
+				ZhiVersion: tc.zhiVersion,
+				Discovered: []core.PluginInfo{{
+					Name: "sample",
+					Type: core.PluginTypeConfig,
+					Path: filepath.Join(dir, "zhi-config-sample"),
+				}},
+			}
+			res := check.Run(context.Background(), env)
+			if len(res) != 1 {
+				t.Fatalf("want 1 result, got %d: %+v", len(res), res)
+			}
+			if res[0].Status != tc.want {
+				t.Fatalf("Status: got %q want %q (%+v)", res[0].Status, tc.want, res[0])
+			}
+		})
+	}
+
+	t.Run("manifest absent is silent", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		env := &Environment{
+			ZhiVersion: "1.0.0",
+			Discovered: []core.PluginInfo{{
+				Name: "sample",
+				Type: core.PluginTypeConfig,
+				Path: filepath.Join(dir, "zhi-config-sample"),
+			}},
+		}
+		res := check.Run(context.Background(), env)
+		if len(res) != 0 {
+			t.Fatalf("want no results when manifest missing (previous check warns), got %+v", res)
+		}
+	})
+}
+
+// TestPluginsAlive exercises the branches that do not require launching a
+// real plugin binary: nil workspace, empty references, and the built-in
+// short-circuit. Exercising a true external probe would need a prebuilt
+// plugin binary, which is out of scope here.
+//
+// TODO: add an end-to-end alive probe using one of the bin/examples/
+// plugins when they are available at test time.
+func TestPluginsAlive(t *testing.T) {
+	t.Parallel()
+
+	check := pluginsAliveCheck{}
+
+	t.Run("nil workspace is skipped", func(t *testing.T) {
+		t.Parallel()
+		res := check.Run(context.Background(), &Environment{Registry: core.NewRegistry()})
+		if len(res) != 1 || res[0].Status != StatusSkipped {
+			t.Fatalf("want single skipped, got %+v", res)
+		}
+	})
+
+	t.Run("no references is skipped", func(t *testing.T) {
+		t.Parallel()
+		env := &Environment{
+			Registry:  core.NewRegistry(),
+			Workspace: &core.WorkspaceConfig{},
+		}
+		res := check.Run(context.Background(), env)
+		if len(res) != 1 || res[0].Status != StatusSkipped {
+			t.Fatalf("want single skipped, got %+v", res)
+		}
+	})
+
+	t.Run("built-in provider is OK without launch", func(t *testing.T) {
+		t.Parallel()
+		env := &Environment{
+			Registry: newRegistryWith(t, "test-config"),
+			Workspace: &core.WorkspaceConfig{
+				Config: core.ProviderRef{Provider: "test-config"},
+			},
+			Timeout: time.Second,
+		}
+		res := check.Run(context.Background(), env)
+		if len(res) != 1 {
+			t.Fatalf("want 1 result, got %+v", res)
+		}
+		if res[0].Status != StatusOK {
+			t.Errorf("Status: got %q want %q", res[0].Status, StatusOK)
+		}
+		if res[0].Name != "config/test-config" {
+			t.Errorf("Name: got %q", res[0].Name)
+		}
+	})
+
+	t.Run("external provider without binary errors", func(t *testing.T) {
+		t.Parallel()
+		env := &Environment{
+			Registry: core.NewRegistry(),
+			Workspace: &core.WorkspaceConfig{
+				Config: core.ProviderRef{Provider: "phantom"},
+			},
+			Timeout: time.Second,
+		}
+		res := check.Run(context.Background(), env)
+		if len(res) != 1 {
+			t.Fatalf("want 1 result, got %+v", res)
+		}
+		if res[0].Status != StatusError {
+			t.Errorf("Status: got %q want %q", res[0].Status, StatusError)
+		}
+	})
+
+	t.Run("UI provider is skipped", func(t *testing.T) {
+		t.Parallel()
+		env := &Environment{
+			Registry: core.NewRegistry(),
+			Workspace: &core.WorkspaceConfig{
+				UI: core.ProviderRef{Provider: "some-ui"},
+			},
+		}
+		res := check.Run(context.Background(), env)
+		if len(res) != 1 || res[0].Status != StatusSkipped {
+			t.Fatalf("want single skipped, got %+v", res)
+		}
+		if res[0].Name != "ui/some-ui" {
+			t.Errorf("Name: got %q", res[0].Name)
+		}
+	})
+}
+
+func TestPluginsSignatureVerified(t *testing.T) {
+	t.Parallel()
+
+	check := pluginsSignatureVerifiedCheck{}
+
+	t.Run("deep disabled is skipped", func(t *testing.T) {
+		t.Parallel()
+		res := check.Run(context.Background(), &Environment{Deep: false})
+		if len(res) != 1 || res[0].Status != StatusSkipped {
+			t.Fatalf("want single skipped, got %+v", res)
+		}
+		if res[0].Message != "enable with --deep" {
+			t.Errorf("Message: got %q", res[0].Message)
+		}
+	})
+
+	t.Run("deep with no lockfile is skipped", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		env := &Environment{
+			Deep:      true,
+			Workspace: &core.WorkspaceConfig{Dir: dir},
+			Discovered: []core.PluginInfo{{
+				Name: "sample",
+				Type: core.PluginTypeConfig,
+				Path: filepath.Join(dir, "zhi-config-sample"),
+			}},
+		}
+		res := check.Run(context.Background(), env)
+		if len(res) != 1 || res[0].Status != StatusSkipped {
+			t.Fatalf("want single skipped, got %+v", res)
+		}
+	})
+
+	t.Run("deep with empty discovered is skipped", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		env := &Environment{
+			Deep:      true,
+			Workspace: &core.WorkspaceConfig{Dir: dir},
+		}
+		res := check.Run(context.Background(), env)
+		if len(res) != 1 || res[0].Status != StatusSkipped {
+			t.Fatalf("want single skipped, got %+v", res)
+		}
+	})
+
+	t.Run("lockfile without platform digest warns", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		binPath := filepath.Join(dir, "zhi-config-sample")
+		writeFile(t, binPath, "not really a binary")
+		// Craft a lockfile with a platform entry that intentionally does
+		// not match the current runtime, forcing the "missing platform"
+		// warning branch.
+		otherPlatform := "nonexistent/arch"
+		if otherPlatform == runtime.GOOS+"/"+runtime.GOARCH {
+			otherPlatform = "xyz/xyz"
+		}
+		lf := &lockfile.LockFile{
+			Version:    lockfile.Version,
+			ZhiVersion: "1.0.0",
+			Plugins: []lockfile.LockedPlugin{{
+				Name:   "sample",
+				Type:   string(core.PluginTypeConfig),
+				Ref:    "oci://example/sample:v1",
+				Digest: "sha256:deadbeef",
+				Platforms: map[string]string{
+					otherPlatform: "sha256:deadbeef",
+				},
+			}},
+		}
+		data, err := lf.Marshal()
+		if err != nil {
+			t.Fatalf("marshal lockfile: %v", err)
+		}
+		writeFile(t, filepath.Join(dir, "zhi-plugins.lock"), string(data))
+
+		env := &Environment{
+			Deep:      true,
+			Workspace: &core.WorkspaceConfig{Dir: dir},
+			Discovered: []core.PluginInfo{{
+				Name: "sample",
+				Type: core.PluginTypeConfig,
+				Path: binPath,
+			}},
+		}
+		res := check.Run(context.Background(), env)
+		if len(res) != 1 {
+			t.Fatalf("want 1 result, got %+v", res)
+		}
+		if res[0].Status != StatusWarning {
+			t.Errorf("Status: got %q want %q", res[0].Status, StatusWarning)
+		}
+	})
+}
+
+func TestManifestPathFor(t *testing.T) {
+	t.Parallel()
+	p := core.PluginInfo{Path: "/tmp/plugins/zhi-config-foo"}
+	if got, want := manifestPathFor(p), "/tmp/plugins/zhi-plugin.yaml"; got != want {
+		t.Errorf("manifestPathFor: got %q want %q", got, want)
+	}
+}
+
+func TestBuiltinSet(t *testing.T) {
+	t.Parallel()
+	infos := []core.ProviderInfo{
+		{Name: "builtin-one", Source: "built-in"},
+		{Name: "external-one", Source: "/path/to/bin"},
+		{Name: "builtin-two", Source: "built-in"},
+	}
+	got := builtinSet(infos)
+	if !got["builtin-one"] || !got["builtin-two"] {
+		t.Errorf("expected both built-in entries, got %v", got)
+	}
+	if got["external-one"] {
+		t.Errorf("did not expect external entry, got %v", got)
+	}
+}

--- a/internal/core/doctor/store.go
+++ b/internal/core/doctor/store.go
@@ -1,0 +1,85 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+)
+
+type storeCapabilitiesCheck struct{}
+
+func (storeCapabilitiesCheck) ID() string         { return "store.capabilities" }
+func (storeCapabilitiesCheck) Category() Category { return CategoryStore }
+func (storeCapabilitiesCheck) Description() string {
+	return "Store plugin responds to Capabilities() RPC."
+}
+
+func (c storeCapabilitiesCheck) Run(ctx context.Context, env *Environment) []Result {
+	res := Result{CheckID: c.ID(), Name: c.ID()}
+
+	if env == nil || env.Workspace == nil || env.Workspace.Store.Provider == "" {
+		res.Status = StatusSkipped
+		res.Message = "no store configured"
+		return []Result{res}
+	}
+	if env.Engine == nil {
+		res.Status = StatusSkipped
+		res.Message = "engine not initialized"
+		if env.EngineErr != nil {
+			res.Detail = env.EngineErr.Error()
+		}
+		return []Result{res}
+	}
+
+	caps, err := env.Engine.StoreCapabilities(ctx)
+	if err != nil {
+		res.Status = StatusError
+		res.Message = "store Capabilities() failed"
+		res.Detail = err.Error()
+		res.Hint = "store plugin may be misconfigured or unreachable"
+		return []Result{res}
+	}
+
+	res.Status = StatusOK
+	res.Message = fmt.Sprintf("versioning=%s, encryption=%s, auth=%t, access_control=%t",
+		caps.Versioning, caps.Encryption, caps.Auth, caps.AccessControl)
+	return []Result{res}
+}
+
+type storeListTreesCheck struct{}
+
+func (storeListTreesCheck) ID() string         { return "store.list_trees" }
+func (storeListTreesCheck) Category() Category { return CategoryStore }
+func (storeListTreesCheck) Description() string {
+	return "Store plugin responds to ListTrees() — proves credentials and read access."
+}
+
+func (c storeListTreesCheck) Run(ctx context.Context, env *Environment) []Result {
+	res := Result{CheckID: c.ID(), Name: c.ID()}
+
+	if env == nil || env.Workspace == nil || env.Workspace.Store.Provider == "" {
+		res.Status = StatusSkipped
+		res.Message = "no store configured"
+		return []Result{res}
+	}
+	if env.Engine == nil {
+		res.Status = StatusSkipped
+		res.Message = "engine not initialized"
+		if env.EngineErr != nil {
+			res.Detail = env.EngineErr.Error()
+		}
+		return []Result{res}
+	}
+
+	trees, err := env.Engine.ListTrees(ctx)
+	if err != nil {
+		res.Status = StatusError
+		res.Message = "store ListTrees() failed"
+		res.Detail = err.Error()
+		res.Hint = "check auth credentials if this is an authenticated store"
+		return []Result{res}
+	}
+
+	res.Status = StatusOK
+	res.Message = fmt.Sprintf("%d tree(s) accessible", len(trees))
+	return []Result{res}
+}

--- a/internal/core/doctor/store_test.go
+++ b/internal/core/doctor/store_test.go
@@ -1,0 +1,108 @@
+package doctor
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/zhi/internal/core"
+	"github.com/MrWong99/zhi/pkg/zhiplugin/config"
+)
+
+// jsonStoreEngine builds a core.Engine wired up to the built-in jsonfile
+// store under t.TempDir(). That exercises the real Engine code paths
+// without depending on network I/O or a gRPC plugin process.
+func jsonStoreEngine(t *testing.T) (*core.Engine, *core.WorkspaceConfig) {
+	t.Helper()
+	reg := core.NewRegistry()
+	if err := reg.RegisterConfig("mock", func(string, map[string]any) (config.Plugin, error) {
+		return newMockConfigPlugin(nil), nil
+	}); err != nil {
+		t.Fatalf("RegisterConfig: %v", err)
+	}
+	if err := reg.RegisterStore("jsonfile", core.NewJSONFileStoreProvider); err != nil {
+		t.Fatalf("RegisterStore: %v", err)
+	}
+	ws := &core.WorkspaceConfig{
+		Version: "1",
+		Config:  core.ProviderRef{Provider: "mock"},
+		Store:   core.ProviderRef{Provider: "jsonfile"},
+		Dir:     t.TempDir(),
+	}
+	eng, err := core.NewEngine(reg, ws)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	t.Cleanup(eng.Close)
+	return eng, ws
+}
+
+func TestStoreCapabilities_OK(t *testing.T) {
+	eng, ws := jsonStoreEngine(t)
+	env := &Environment{Workspace: ws, Engine: eng, Timeout: time.Second}
+
+	got := storeCapabilitiesCheck{}.Run(context.Background(), env)
+	if len(got) != 1 {
+		t.Fatalf("want 1 result, got %d", len(got))
+	}
+	if got[0].Status != StatusOK {
+		t.Fatalf("status = %s, want OK (msg=%s detail=%s)", got[0].Status, got[0].Message, got[0].Detail)
+	}
+	if !strings.Contains(got[0].Message, "versioning=") || !strings.Contains(got[0].Message, "encryption=") {
+		t.Errorf("message = %q, want versioning+encryption summary", got[0].Message)
+	}
+}
+
+func TestStoreCapabilities_NoStoreConfigured(t *testing.T) {
+	env := &Environment{
+		Workspace: &core.WorkspaceConfig{},
+		Timeout:   time.Second,
+	}
+	got := storeCapabilitiesCheck{}.Run(context.Background(), env)
+	if got[0].Status != StatusSkipped {
+		t.Errorf("status = %s, want Skipped", got[0].Status)
+	}
+	if !strings.Contains(got[0].Message, "no store") {
+		t.Errorf("message = %q, want mention of no store", got[0].Message)
+	}
+}
+
+func TestStoreCapabilities_NoEngine(t *testing.T) {
+	env := &Environment{
+		Workspace: &core.WorkspaceConfig{
+			Store: core.ProviderRef{Provider: "jsonfile"},
+		},
+		Timeout: time.Second,
+	}
+	got := storeCapabilitiesCheck{}.Run(context.Background(), env)
+	if got[0].Status != StatusSkipped {
+		t.Errorf("status = %s, want Skipped", got[0].Status)
+	}
+}
+
+func TestStoreListTrees_OK(t *testing.T) {
+	eng, ws := jsonStoreEngine(t)
+	env := &Environment{Workspace: ws, Engine: eng, Timeout: time.Second}
+
+	got := storeListTreesCheck{}.Run(context.Background(), env)
+	if got[0].Status != StatusOK {
+		t.Fatalf("status = %s, want OK (msg=%s detail=%s)", got[0].Status, got[0].Message, got[0].Detail)
+	}
+	if !strings.Contains(got[0].Message, "tree(s)") {
+		t.Errorf("message = %q, want tree count", got[0].Message)
+	}
+}
+
+func TestStoreListTrees_NoEngine(t *testing.T) {
+	env := &Environment{
+		Workspace: &core.WorkspaceConfig{
+			Store: core.ProviderRef{Provider: "jsonfile"},
+		},
+		Timeout: time.Second,
+	}
+	got := storeListTreesCheck{}.Run(context.Background(), env)
+	if got[0].Status != StatusSkipped {
+		t.Errorf("status = %s, want Skipped", got[0].Status)
+	}
+}

--- a/internal/core/doctor/updates.go
+++ b/internal/core/doctor/updates.go
@@ -1,0 +1,176 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/MrWong99/zhi/pkg/sharing/lockfile"
+	"github.com/MrWong99/zhi/pkg/sharing/semver"
+)
+
+type updatesAvailableCheck struct{}
+
+func (updatesAvailableCheck) ID() string         { return "updates.available" }
+func (updatesAvailableCheck) Category() Category { return CategoryUpdates }
+func (updatesAvailableCheck) Description() string {
+	return "Installed plugin versions are the latest published on the marketplace."
+}
+
+func (c updatesAvailableCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env == nil || env.Marketplace == nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusSkipped,
+			Message: "marketplace client not configured (enable with --check updates)",
+		}}
+	}
+	if env.Workspace == nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusSkipped,
+			Message: "no workspace loaded",
+		}}
+	}
+
+	lockPath := filepath.Join(env.Workspace.Dir, "zhi-plugins.lock")
+	lf, err := lockfile.LoadFile(lockPath)
+	if err != nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusSkipped,
+			Message: "no zhi-plugins.lock found",
+			Detail:  err.Error(),
+		}}
+	}
+
+	if len(lf.Plugins) == 0 {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    c.ID(),
+			Status:  StatusOK,
+			Message: "no plugins locked",
+		}}
+	}
+
+	results := make([]Result, 0, len(lf.Plugins))
+	for _, p := range lf.Plugins {
+		name := p.Type + "/" + p.Name
+		publisher, short, ok := parseOCIRef(p.Ref)
+		if !ok {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusSkipped,
+				Message: "could not parse OCI ref for marketplace lookup",
+				Detail:  p.Ref,
+			})
+			continue
+		}
+
+		detail, err := env.Marketplace.GetPlugin(ctx, p.Type, publisher, short)
+		if err != nil {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusWarning,
+				Message: "marketplace lookup failed",
+				Detail:  err.Error(),
+			})
+			continue
+		}
+		if len(detail.Versions) == 0 {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusSkipped,
+				Message: "no published versions",
+			})
+			continue
+		}
+
+		// Versions are ordered newest-first per the marketplace API contract.
+		current := trimVersion(p.Ref)
+		latest := detail.Versions[0].Version
+		if current == "" {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusSkipped,
+				Message: "installed version could not be determined",
+			})
+			continue
+		}
+
+		newer, cmpErr := semver.IsNewer(current, latest)
+		if cmpErr != nil {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusSkipped,
+				Message: "version comparison failed",
+				Detail:  cmpErr.Error(),
+			})
+			continue
+		}
+		if newer {
+			results = append(results, Result{
+				CheckID: c.ID(),
+				Name:    name,
+				Status:  StatusWarning,
+				Message: fmt.Sprintf("update available: %s → %s", current, latest),
+				Hint:    "run `zhi plugin update " + short + "`",
+			})
+			continue
+		}
+		results = append(results, Result{
+			CheckID: c.ID(),
+			Name:    name,
+			Status:  StatusOK,
+			Message: "up to date (" + current + ")",
+		})
+	}
+	return results
+}
+
+// parseOCIRef pulls the publisher and short name from a ref like
+// "ghcr.io/mrwong99/zhi/zhi-store-memory:v0.0.9". We treat the first path
+// segment after the host as the publisher and the last segment (before the
+// tag, stripping any "zhi-<type>-" prefix) as the short name.
+func parseOCIRef(ref string) (publisher, short string, ok bool) {
+	ref = strings.TrimPrefix(ref, "oci://")
+	// Drop the tag.
+	if i := strings.LastIndex(ref, ":"); i >= 0 {
+		ref = ref[:i]
+	}
+	parts := strings.Split(ref, "/")
+	if len(parts) < 3 {
+		return "", "", false
+	}
+	publisher = parts[1]
+	last := parts[len(parts)-1]
+	// zhi-<type>-<name> → <name>; otherwise use the raw last segment.
+	if strings.HasPrefix(last, "zhi-") {
+		rest := strings.TrimPrefix(last, "zhi-")
+		for _, t := range []string{"config-", "transform-", "store-", "ui-"} {
+			if strings.HasPrefix(rest, t) {
+				short = strings.TrimPrefix(rest, t)
+				return publisher, short, short != ""
+			}
+		}
+	}
+	return publisher, last, last != ""
+}
+
+// trimVersion extracts a trailing :vX.Y.Z tag from an OCI ref.
+func trimVersion(ref string) string {
+	i := strings.LastIndex(ref, ":")
+	if i < 0 {
+		return ""
+	}
+	return strings.TrimPrefix(ref[i+1:], "v")
+}

--- a/internal/core/doctor/updates_test.go
+++ b/internal/core/doctor/updates_test.go
@@ -1,0 +1,117 @@
+package doctor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/zhi/internal/core"
+	"github.com/MrWong99/zhi/pkg/sharing/lockfile"
+	"github.com/MrWong99/zhi/pkg/sharing/marketplace"
+)
+
+func TestParseOCIRef(t *testing.T) {
+	cases := []struct {
+		in            string
+		wantPublisher string
+		wantShort     string
+		wantOK        bool
+	}{
+		{"ghcr.io/mrwong99/zhi/zhi-store-memory:v0.0.9", "mrwong99", "memory", true},
+		{"ghcr.io/mrwong99/zhi/zhi-config-pokedex:v1.0.0", "mrwong99", "pokedex", true},
+		{"oci://ghcr.io/acme/zhi/zhi-transform-encrypt", "acme", "encrypt", true},
+		{"ghcr.io/acme/raw-name:v1", "acme", "raw-name", true},
+		{"broken", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			pub, short, ok := parseOCIRef(tc.in)
+			if ok != tc.wantOK || pub != tc.wantPublisher || short != tc.wantShort {
+				t.Fatalf("parseOCIRef(%q) = %q, %q, %v — want %q, %q, %v",
+					tc.in, pub, short, ok, tc.wantPublisher, tc.wantShort, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestUpdatesAvailable_NoMarketplace(t *testing.T) {
+	env := &Environment{Workspace: &core.WorkspaceConfig{Dir: t.TempDir()}}
+	res := (updatesAvailableCheck{}).Run(context.Background(), env)
+	if len(res) != 1 || res[0].Status != StatusSkipped {
+		t.Fatalf("want single skipped, got %+v", res)
+	}
+}
+
+func TestUpdatesAvailable_NoLockfile(t *testing.T) {
+	dir := t.TempDir()
+	env := &Environment{
+		Workspace:   &core.WorkspaceConfig{Dir: dir},
+		Marketplace: marketplace.NewClient("http://unused.example"),
+	}
+	res := (updatesAvailableCheck{}).Run(context.Background(), env)
+	if len(res) != 1 || res[0].Status != StatusSkipped {
+		t.Fatalf("want skipped (no lockfile), got %+v", res)
+	}
+}
+
+func TestUpdatesAvailable_UpToDateAndStale(t *testing.T) {
+	// Simulate a marketplace that returns a different latest per plugin.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// r.URL.Path is like /api/v1/plugins/store/mrwong99/memory
+		var latest string
+		switch r.URL.Path {
+		case "/api/v1/plugins/store/mrwong99/memory":
+			latest = "0.0.9" // same as installed → up to date
+		case "/api/v1/plugins/config/mrwong99/pokedex":
+			latest = "2.0.0" // newer than installed 1.0.0 → stale
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		detail := marketplace.PluginDetail{
+			Versions: []marketplace.PluginVersion{{Version: latest}},
+		}
+		_ = json.NewEncoder(w).Encode(detail)
+	}))
+	t.Cleanup(srv.Close)
+
+	dir := t.TempDir()
+	lf := &lockfile.LockFile{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		ZhiVersion:  "1.7.0",
+		Plugins: []lockfile.LockedPlugin{
+			{Name: "memory", Type: "store", Ref: "ghcr.io/mrwong99/zhi/zhi-store-memory:v0.0.9", Digest: "sha256:abc"},
+			{Name: "pokedex", Type: "config", Ref: "ghcr.io/mrwong99/zhi/zhi-config-pokedex:v1.0.0", Digest: "sha256:def"},
+		},
+	}
+	data, err := lf.Marshal()
+	if err != nil {
+		t.Fatalf("marshal lockfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "zhi-plugins.lock"), data, 0o644); err != nil {
+		t.Fatalf("write lockfile: %v", err)
+	}
+
+	env := &Environment{
+		Workspace:   &core.WorkspaceConfig{Dir: dir},
+		Marketplace: marketplace.NewClient(srv.URL),
+	}
+	res := (updatesAvailableCheck{}).Run(context.Background(), env)
+	if len(res) != 2 {
+		t.Fatalf("want 2 results, got %d: %+v", len(res), res)
+	}
+
+	// Results preserve lockfile order.
+	if res[0].Status != StatusOK {
+		t.Errorf("memory: want OK, got %s — %s", res[0].Status, res[0].Message)
+	}
+	if res[1].Status != StatusWarning {
+		t.Errorf("pokedex: want Warning, got %s — %s", res[1].Status, res[1].Message)
+	}
+}

--- a/internal/core/doctor/vault.go
+++ b/internal/core/doctor/vault.go
@@ -1,0 +1,419 @@
+package doctor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/MrWong99/zhi/pkg/providers/store/vault/httpclient"
+)
+
+// vaultProbe bundles the resolved Vault connection settings used by every
+// vault doctor check.
+type vaultProbe struct {
+	addr      string
+	token     string
+	namespace string
+	mount     string
+	prefix    string
+	client    *httpclient.Client
+}
+
+// vaultSetup extracts the connection settings from the environment and
+// builds a shared httpclient. When the configured store isn't vault or no
+// workspace is present, it returns a populated skipped Result so the
+// caller can short-circuit.
+//
+// NOTE: TLS config (VAULT_CACERT, VAULT_CLIENT_CERT, VAULT_CLIENT_KEY,
+// VAULT_SKIP_VERIFY) is intentionally not wired up in this v1 — doctor
+// probes assume plaintext or the system trust store. A full TLS probe
+// can be added later by re-using tlsutil.ClientConfig.
+func vaultSetup(env *Environment) (*vaultProbe, *Result) {
+	if env == nil || env.Workspace == nil || env.Workspace.Store.Provider != "vault" {
+		skipped := &Result{
+			Status:  StatusSkipped,
+			Message: "store provider is not vault",
+		}
+		return nil, skipped
+	}
+
+	opts := env.Workspace.Store.Options
+
+	addr, _ := stringOpt(opts, "addr")
+	if addr == "" {
+		if v := os.Getenv("VAULT_ADDR"); v != "" {
+			addr = v
+		} else {
+			addr = "http://127.0.0.1:8200"
+		}
+	}
+
+	namespace, _ := stringOpt(opts, "namespace")
+	if namespace == "" {
+		namespace = os.Getenv("VAULT_NAMESPACE")
+	}
+
+	mount, _ := stringOpt(opts, "mount")
+	if mount == "" {
+		mount = "secret"
+	}
+	prefix, _ := stringOpt(opts, "prefix")
+	if prefix == "" {
+		prefix = "zhi"
+	}
+
+	// auth.credentials.token is the nested map path the vault provider
+	// uses in zhi.yaml. Any missing level falls back to env.
+	token := nestedString(opts, "auth", "credentials", "token")
+	if token == "" {
+		token = os.Getenv("VAULT_TOKEN")
+	}
+
+	timeout := env.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+
+	httpClient := &http.Client{Timeout: timeout}
+	client := httpclient.New(addr, token, namespace, httpClient)
+
+	return &vaultProbe{
+		addr:      addr,
+		token:     token,
+		namespace: namespace,
+		mount:     mount,
+		prefix:    prefix,
+		client:    client,
+	}, nil
+}
+
+// stringOpt returns opts[key] when present and a string.
+func stringOpt(opts map[string]any, key string) (string, bool) {
+	if opts == nil {
+		return "", false
+	}
+	v, ok := opts[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+// nestedString walks a nested map[string]any by keys, returning the final
+// string value if every level is present. Tolerates missing levels and
+// non-map intermediate types.
+func nestedString(opts map[string]any, keys ...string) string {
+	cur := any(opts)
+	for i, k := range keys {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return ""
+		}
+		v, ok := m[k]
+		if !ok {
+			return ""
+		}
+		if i == len(keys)-1 {
+			s, _ := v.(string)
+			return s
+		}
+		cur = v
+	}
+	return ""
+}
+
+// sealStatus is the subset of sys/seal-status we care about. Vault
+// returns these at the top level (not wrapped in "data") so we must
+// bypass httpclient.Client for this endpoint.
+type sealStatus struct {
+	Sealed      bool `json:"sealed"`
+	Initialized bool `json:"initialized"`
+}
+
+// fetchSealStatus makes a plain HTTP GET to /v1/sys/seal-status. We do a
+// raw request because Vault returns the fields at the top level of the
+// body — httpclient.Client would try to unmarshal them into the standard
+// Response envelope (Data json.RawMessage).
+func fetchSealStatus(ctx context.Context, p *vaultProbe) (*sealStatus, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.addr+"/v1/sys/seal-status", nil)
+	if err != nil {
+		return nil, err
+	}
+	if p.namespace != "" {
+		req.Header.Set("X-Vault-Namespace", p.namespace)
+	}
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusServiceUnavailable {
+		// 503 is expected when Vault is sealed, so we still parse the body.
+		return nil, fmt.Errorf("sys/seal-status returned %d: %s", resp.StatusCode, string(body))
+	}
+	var ss sealStatus
+	if err := json.Unmarshal(body, &ss); err != nil {
+		return nil, fmt.Errorf("parsing sys/seal-status: %w", err)
+	}
+	return &ss, nil
+}
+
+// tokenLookup mirrors the fields of auth/token/lookup-self we need.
+type tokenLookup struct {
+	TTL        int    `json:"ttl"`
+	ExpireTime string `json:"expire_time"`
+	Renewable  bool   `json:"renewable"`
+}
+
+func fetchTokenLookup(ctx context.Context, p *vaultProbe) (*tokenLookup, error) {
+	resp, err := p.client.Request(ctx, http.MethodGet, "auth/token/lookup-self", nil)
+	if err != nil {
+		return nil, err
+	}
+	var tl tokenLookup
+	if len(resp.Data) > 0 {
+		if err := json.Unmarshal(resp.Data, &tl); err != nil {
+			return nil, fmt.Errorf("parsing token lookup: %w", err)
+		}
+	}
+	return &tl, nil
+}
+
+type vaultReachableCheck struct{}
+
+func (vaultReachableCheck) ID() string         { return "store.vault.reachable" }
+func (vaultReachableCheck) Category() Category { return CategoryStore }
+func (vaultReachableCheck) Description() string {
+	return "Vault sys/seal-status endpoint responds over HTTP."
+}
+
+func (c vaultReachableCheck) Run(ctx context.Context, env *Environment) []Result {
+	res := Result{CheckID: c.ID(), Name: c.ID()}
+	probe, skipped := vaultSetup(env)
+	if skipped != nil {
+		skipped.CheckID = c.ID()
+		skipped.Name = c.ID()
+		return []Result{*skipped}
+	}
+	if _, err := fetchSealStatus(ctx, probe); err != nil {
+		res.Status = StatusError
+		res.Message = "vault unreachable"
+		res.Detail = err.Error()
+		res.Hint = "check addr and network connectivity"
+		return []Result{res}
+	}
+	res.Status = StatusOK
+	res.Message = "vault reachable at " + probe.addr
+	return []Result{res}
+}
+
+type vaultUnsealedCheck struct{}
+
+func (vaultUnsealedCheck) ID() string         { return "store.vault.unsealed" }
+func (vaultUnsealedCheck) Category() Category { return CategoryStore }
+func (vaultUnsealedCheck) Description() string {
+	return "Vault reports initialized=true and sealed=false."
+}
+
+func (c vaultUnsealedCheck) Run(ctx context.Context, env *Environment) []Result {
+	res := Result{CheckID: c.ID(), Name: c.ID()}
+	probe, skipped := vaultSetup(env)
+	if skipped != nil {
+		skipped.CheckID = c.ID()
+		skipped.Name = c.ID()
+		return []Result{*skipped}
+	}
+	ss, err := fetchSealStatus(ctx, probe)
+	if err != nil {
+		res.Status = StatusSkipped
+		res.Message = "skipped, see store.vault.reachable"
+		return []Result{res}
+	}
+	if !ss.Initialized {
+		res.Status = StatusError
+		res.Message = "vault is not initialized"
+		res.Hint = "vault operator init"
+		return []Result{res}
+	}
+	if ss.Sealed {
+		res.Status = StatusError
+		res.Message = "vault is sealed"
+		res.Hint = "vault operator unseal"
+		return []Result{res}
+	}
+	res.Status = StatusOK
+	res.Message = "vault initialized and unsealed"
+	return []Result{res}
+}
+
+type vaultTokenValidCheck struct{}
+
+func (vaultTokenValidCheck) ID() string         { return "store.vault.token_valid" }
+func (vaultTokenValidCheck) Category() Category { return CategoryStore }
+func (vaultTokenValidCheck) Description() string {
+	return "Vault token authenticates via auth/token/lookup-self."
+}
+
+func (c vaultTokenValidCheck) Run(ctx context.Context, env *Environment) []Result {
+	res := Result{CheckID: c.ID(), Name: c.ID()}
+	probe, skipped := vaultSetup(env)
+	if skipped != nil {
+		skipped.CheckID = c.ID()
+		skipped.Name = c.ID()
+		return []Result{*skipped}
+	}
+	if probe.token == "" {
+		res.Status = StatusError
+		res.Message = "no VAULT_TOKEN or auth.credentials.token set"
+		res.Hint = "provide a token via env or workspace config"
+		return []Result{res}
+	}
+	if _, err := fetchTokenLookup(ctx, probe); err != nil {
+		res.Status = StatusError
+		res.Message = "token lookup failed"
+		res.Detail = err.Error()
+		res.Hint = "generate or refresh your Vault token"
+		return []Result{res}
+	}
+	res.Status = StatusOK
+	res.Message = "token authenticates successfully"
+	return []Result{res}
+}
+
+type vaultTokenTTLCheck struct{}
+
+func (vaultTokenTTLCheck) ID() string         { return "store.vault.token_ttl" }
+func (vaultTokenTTLCheck) Category() Category { return CategoryStore }
+func (vaultTokenTTLCheck) Description() string {
+	return "Vault token has sufficient remaining TTL."
+}
+
+func (c vaultTokenTTLCheck) Run(ctx context.Context, env *Environment) []Result {
+	res := Result{CheckID: c.ID(), Name: c.ID()}
+	probe, skipped := vaultSetup(env)
+	if skipped != nil {
+		skipped.CheckID = c.ID()
+		skipped.Name = c.ID()
+		return []Result{*skipped}
+	}
+	if probe.token == "" {
+		res.Status = StatusSkipped
+		res.Message = "no token configured, see store.vault.token_valid"
+		return []Result{res}
+	}
+	tl, err := fetchTokenLookup(ctx, probe)
+	if err != nil {
+		res.Status = StatusSkipped
+		res.Message = "skipped, see store.vault.token_valid"
+		return []Result{res}
+	}
+
+	// TTL 0 is idiomatic for root / no-expiry tokens.
+	if tl.TTL == 0 {
+		res.Status = StatusOK
+		res.Message = "token has no expiry (root-like)"
+		return []Result{res}
+	}
+
+	ttl := time.Duration(tl.TTL) * time.Second
+	ttlStr := formatDuration(ttl)
+	if tl.ExpireTime != "" {
+		if exp, err := time.Parse(time.RFC3339, tl.ExpireTime); err == nil {
+			ttlStr = fmt.Sprintf("%s (expires %s)", ttlStr, exp.Format(time.RFC3339))
+		}
+	}
+
+	if tl.TTL <= 3600 {
+		res.Status = StatusWarning
+		res.Message = fmt.Sprintf("TTL %s, consider renewing", ttlStr)
+		res.Hint = "vault token renew"
+		return []Result{res}
+	}
+	res.Status = StatusOK
+	res.Message = "TTL: " + ttlStr
+	return []Result{res}
+}
+
+type vaultMountAccessibleCheck struct{}
+
+func (vaultMountAccessibleCheck) ID() string         { return "store.vault.mount_accessible" }
+func (vaultMountAccessibleCheck) Category() Category { return CategoryStore }
+func (vaultMountAccessibleCheck) Description() string {
+	return "The configured Vault mount/prefix is readable by the current token."
+}
+
+func (c vaultMountAccessibleCheck) Run(ctx context.Context, env *Environment) []Result {
+	res := Result{CheckID: c.ID(), Name: c.ID()}
+	probe, skipped := vaultSetup(env)
+	if skipped != nil {
+		skipped.CheckID = c.ID()
+		skipped.Name = c.ID()
+		return []Result{*skipped}
+	}
+
+	listPath := probe.mount + "/metadata/" + probe.prefix + "/"
+	resp, err := probe.client.List(ctx, listPath)
+	if err != nil {
+		var apiErr *httpclient.APIError
+		if errors.As(err, &apiErr) {
+			switch apiErr.StatusCode {
+			case http.StatusNotFound:
+				// Empty KV v2 mount — still accessible, just no data yet.
+				res.Status = StatusOK
+				res.Message = "mount accessible (no trees yet)"
+				return []Result{res}
+			case http.StatusForbidden:
+				res.Status = StatusError
+				res.Message = "token lacks read permission on mount"
+				res.Detail = apiErr.Error()
+				res.Hint = "grant `list` on this path"
+				return []Result{res}
+			}
+		}
+		res.Status = StatusError
+		res.Message = "LIST on mount failed"
+		res.Detail = err.Error()
+		return []Result{res}
+	}
+
+	keys, _ := httpclient.ParseListKeys(resp)
+	res.Status = StatusOK
+	res.Message = fmt.Sprintf("%d tree(s) under %s", len(keys), listPath)
+	return []Result{res}
+}
+
+// formatDuration prints a compact, human-friendly duration without the
+// default Go "0s" noise (e.g. "1h0m0s" → "1h").
+func formatDuration(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	d = d.Round(time.Second)
+	h := d / time.Hour
+	d -= h * time.Hour
+	m := d / time.Minute
+	d -= m * time.Minute
+	s := d / time.Second
+	out := ""
+	if h > 0 {
+		out += fmt.Sprintf("%dh", h)
+	}
+	if m > 0 {
+		out += fmt.Sprintf("%dm", m)
+	}
+	if s > 0 || out == "" {
+		out += fmt.Sprintf("%ds", s)
+	}
+	return out
+}

--- a/internal/core/doctor/vault_test.go
+++ b/internal/core/doctor/vault_test.go
@@ -1,0 +1,355 @@
+package doctor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/zhi/internal/core"
+)
+
+// vaultServerOpts drives the fake Vault mux built by newVaultServer.
+type vaultServerOpts struct {
+	sealed       bool
+	initialized  bool
+	lookupStatus int // 0 => 200 with body; otherwise return this code
+	ttl          int
+	expireTime   string
+	listStatus   int      // 0 => 200; otherwise return this code
+	listKeys     []string // keys returned on a successful LIST
+}
+
+func newVaultServer(t *testing.T, opts vaultServerOpts) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// sys/seal-status is unauthenticated and returns fields at the top
+	// level (not wrapped in "data").
+	mux.HandleFunc("/v1/sys/seal-status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if opts.sealed {
+			// Match real Vault's 503 when sealed. Body still decodes.
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"sealed":      opts.sealed,
+			"initialized": opts.initialized,
+		})
+	})
+
+	mux.HandleFunc("/v1/auth/token/lookup-self", func(w http.ResponseWriter, r *http.Request) {
+		if opts.lookupStatus != 0 {
+			w.WriteHeader(opts.lookupStatus)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"errors": []string{"permission denied"},
+			})
+			return
+		}
+		body := map[string]any{
+			"data": map[string]any{
+				"ttl":         opts.ttl,
+				"expire_time": opts.expireTime,
+				"renewable":   false,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	})
+
+	// LIST /v1/secret/metadata/zhi/
+	mux.HandleFunc("/v1/secret/metadata/zhi/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "LIST" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if opts.listStatus != 0 {
+			w.WriteHeader(opts.listStatus)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"errors": []string{"forbidden"},
+			})
+			return
+		}
+		keys := opts.listKeys
+		if keys == nil {
+			keys = []string{}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"keys": keys},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// vaultEnv builds an Environment whose workspace points at srv.
+func vaultEnv(srv *httptest.Server, token string) *Environment {
+	ws := &core.WorkspaceConfig{
+		Store: core.ProviderRef{
+			Provider: "vault",
+			Options: map[string]any{
+				"addr":   srv.URL,
+				"mount":  "secret",
+				"prefix": "zhi",
+				"auth": map[string]any{
+					"credentials": map[string]any{
+						"token": token,
+					},
+				},
+			},
+		},
+	}
+	return &Environment{
+		Workspace: ws,
+		Timeout:   5 * time.Second,
+	}
+}
+
+// runAll runs a list of checks back-to-back, collecting their results
+// keyed by check ID.
+func runAll(t *testing.T, env *Environment, checks ...Check) map[string]Result {
+	t.Helper()
+	out := make(map[string]Result, len(checks))
+	for _, c := range checks {
+		results := c.Run(context.Background(), env)
+		if len(results) != 1 {
+			t.Fatalf("check %s: want 1 result, got %d (%+v)", c.ID(), len(results), results)
+		}
+		out[c.ID()] = results[0]
+	}
+	return out
+}
+
+func TestVaultChecks_AllOK(t *testing.T) {
+	srv := newVaultServer(t, vaultServerOpts{
+		sealed:      false,
+		initialized: true,
+		ttl:         4 * 3600,
+		expireTime:  time.Now().Add(4 * time.Hour).Format(time.RFC3339),
+		listKeys:    []string{"prod/", "staging/"},
+	})
+	env := vaultEnv(srv, "test-token")
+
+	res := runAll(t, env,
+		vaultReachableCheck{},
+		vaultUnsealedCheck{},
+		vaultTokenValidCheck{},
+		vaultTokenTTLCheck{},
+		vaultMountAccessibleCheck{},
+	)
+
+	for id, r := range res {
+		if r.Status != StatusOK {
+			t.Errorf("%s: status = %s, want OK (msg=%s detail=%s)", id, r.Status, r.Message, r.Detail)
+		}
+	}
+	if !strings.Contains(res["store.vault.mount_accessible"].Message, "2 tree(s)") {
+		t.Errorf("mount_accessible message = %q, want 2 tree(s)", res["store.vault.mount_accessible"].Message)
+	}
+}
+
+func TestVaultChecks_Sealed(t *testing.T) {
+	srv := newVaultServer(t, vaultServerOpts{
+		sealed:      true,
+		initialized: true,
+	})
+	env := vaultEnv(srv, "test-token")
+
+	reach := runAll(t, env, vaultReachableCheck{})["store.vault.reachable"]
+	if reach.Status != StatusOK {
+		t.Errorf("reachable: status = %s, want OK", reach.Status)
+	}
+
+	unsealed := runAll(t, env, vaultUnsealedCheck{})["store.vault.unsealed"]
+	if unsealed.Status != StatusError {
+		t.Fatalf("unsealed: status = %s, want Error", unsealed.Status)
+	}
+	if !strings.Contains(unsealed.Hint, "unseal") {
+		t.Errorf("unsealed hint = %q, want mention of unseal", unsealed.Hint)
+	}
+}
+
+func TestVaultChecks_NotInitialized(t *testing.T) {
+	srv := newVaultServer(t, vaultServerOpts{
+		sealed:      false,
+		initialized: false,
+	})
+	env := vaultEnv(srv, "test-token")
+
+	unsealed := runAll(t, env, vaultUnsealedCheck{})["store.vault.unsealed"]
+	if unsealed.Status != StatusError {
+		t.Fatalf("unsealed: status = %s, want Error", unsealed.Status)
+	}
+	if !strings.Contains(unsealed.Hint, "init") {
+		t.Errorf("unsealed hint = %q, want mention of init", unsealed.Hint)
+	}
+}
+
+func TestVaultChecks_ExpiredToken(t *testing.T) {
+	srv := newVaultServer(t, vaultServerOpts{
+		sealed:       false,
+		initialized:  true,
+		lookupStatus: http.StatusForbidden,
+	})
+	env := vaultEnv(srv, "bad-token")
+
+	got := runAll(t, env, vaultTokenValidCheck{}, vaultTokenTTLCheck{})
+	valid := got["store.vault.token_valid"]
+	if valid.Status != StatusError {
+		t.Errorf("token_valid: status = %s, want Error", valid.Status)
+	}
+	// When lookup fails, the TTL check can't do anything useful — it
+	// skips and tells the user where to look.
+	ttl := got["store.vault.token_ttl"]
+	if ttl.Status != StatusSkipped {
+		t.Errorf("token_ttl: status = %s, want Skipped", ttl.Status)
+	}
+}
+
+func TestVaultChecks_LowTTL(t *testing.T) {
+	srv := newVaultServer(t, vaultServerOpts{
+		sealed:      false,
+		initialized: true,
+		ttl:         300,
+		expireTime:  time.Now().Add(5 * time.Minute).Format(time.RFC3339),
+	})
+	env := vaultEnv(srv, "soon-expiring")
+
+	ttl := runAll(t, env, vaultTokenTTLCheck{})["store.vault.token_ttl"]
+	if ttl.Status != StatusWarning {
+		t.Fatalf("token_ttl: status = %s, want Warning (msg=%s)", ttl.Status, ttl.Message)
+	}
+	if !strings.Contains(ttl.Message, "5m") && !strings.Contains(ttl.Message, "300s") {
+		t.Errorf("token_ttl message = %q, want duration", ttl.Message)
+	}
+}
+
+func TestVaultChecks_RootToken(t *testing.T) {
+	// ttl=0 is Vault's signal for no-expiry (root-like) tokens.
+	srv := newVaultServer(t, vaultServerOpts{
+		sealed:      false,
+		initialized: true,
+		ttl:         0,
+	})
+	env := vaultEnv(srv, "root")
+
+	ttl := runAll(t, env, vaultTokenTTLCheck{})["store.vault.token_ttl"]
+	if ttl.Status != StatusOK {
+		t.Fatalf("token_ttl: status = %s, want OK", ttl.Status)
+	}
+	if !strings.Contains(ttl.Message, "no expiry") {
+		t.Errorf("token_ttl message = %q, want mention of no expiry", ttl.Message)
+	}
+}
+
+func TestVaultChecks_ForbiddenMount(t *testing.T) {
+	srv := newVaultServer(t, vaultServerOpts{
+		sealed:      false,
+		initialized: true,
+		listStatus:  http.StatusForbidden,
+	})
+	env := vaultEnv(srv, "test-token")
+
+	mount := runAll(t, env, vaultMountAccessibleCheck{})["store.vault.mount_accessible"]
+	if mount.Status != StatusError {
+		t.Fatalf("mount_accessible: status = %s, want Error", mount.Status)
+	}
+	if !strings.Contains(mount.Hint, "list") {
+		t.Errorf("mount_accessible hint = %q, want mention of list", mount.Hint)
+	}
+}
+
+func TestVaultChecks_EmptyMount(t *testing.T) {
+	// A 404 on LIST for a KV v2 mount with no data is normal; the
+	// check should still report OK.
+	srv := newVaultServer(t, vaultServerOpts{
+		sealed:      false,
+		initialized: true,
+		listStatus:  http.StatusNotFound,
+	})
+	env := vaultEnv(srv, "test-token")
+
+	mount := runAll(t, env, vaultMountAccessibleCheck{})["store.vault.mount_accessible"]
+	if mount.Status != StatusOK {
+		t.Fatalf("mount_accessible: status = %s, want OK (msg=%s detail=%s)", mount.Status, mount.Message, mount.Detail)
+	}
+}
+
+func TestVaultChecks_NoToken(t *testing.T) {
+	srv := newVaultServer(t, vaultServerOpts{
+		sealed:      false,
+		initialized: true,
+	})
+	env := vaultEnv(srv, "")
+	// Also clear VAULT_TOKEN env so the fallback doesn't mask the case.
+	t.Setenv("VAULT_TOKEN", "")
+
+	valid := runAll(t, env, vaultTokenValidCheck{})["store.vault.token_valid"]
+	if valid.Status != StatusError {
+		t.Fatalf("token_valid: status = %s, want Error", valid.Status)
+	}
+	if !strings.Contains(valid.Message, "no VAULT_TOKEN") {
+		t.Errorf("token_valid message = %q, want no-token message", valid.Message)
+	}
+}
+
+func TestVaultChecks_Unreachable(t *testing.T) {
+	// Close the server immediately so the URL refuses connections.
+	srv := httptest.NewServer(http.NewServeMux())
+	url := srv.URL
+	srv.Close()
+
+	ws := &core.WorkspaceConfig{
+		Store: core.ProviderRef{
+			Provider: "vault",
+			Options: map[string]any{
+				"addr": url,
+			},
+		},
+	}
+	env := &Environment{Workspace: ws, Timeout: 500 * time.Millisecond}
+
+	reach := runAll(t, env, vaultReachableCheck{})["store.vault.reachable"]
+	if reach.Status != StatusError {
+		t.Fatalf("reachable: status = %s, want Error", reach.Status)
+	}
+	// The unsealed check should degrade to skipped so the user sees the
+	// error in one place only.
+	unsealed := runAll(t, env, vaultUnsealedCheck{})["store.vault.unsealed"]
+	if unsealed.Status != StatusSkipped {
+		t.Errorf("unsealed: status = %s, want Skipped", unsealed.Status)
+	}
+}
+
+func TestVaultChecks_ProviderNotVault(t *testing.T) {
+	ws := &core.WorkspaceConfig{
+		Store: core.ProviderRef{Provider: "jsonfile"},
+	}
+	env := &Environment{Workspace: ws, Timeout: time.Second}
+
+	checks := []Check{
+		vaultReachableCheck{},
+		vaultUnsealedCheck{},
+		vaultTokenValidCheck{},
+		vaultTokenTTLCheck{},
+		vaultMountAccessibleCheck{},
+	}
+	got := runAll(t, env, checks...)
+	for id, r := range got {
+		if r.Status != StatusSkipped {
+			t.Errorf("%s: status = %s, want Skipped", id, r.Status)
+		}
+	}
+}
+
+func TestVaultChecks_NilWorkspace(t *testing.T) {
+	env := &Environment{}
+	r := vaultReachableCheck{}.Run(context.Background(), env)
+	if len(r) != 1 || r[0].Status != StatusSkipped {
+		t.Errorf("reachable on nil workspace: want Skipped, got %+v", r)
+	}
+}

--- a/internal/core/doctor/workspace.go
+++ b/internal/core/doctor/workspace.go
@@ -1,0 +1,315 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MrWong99/zhi/internal/core"
+)
+
+// Workspace integrity checks. Each check is an empty struct whose
+// behaviour lives entirely in its Run method — the types exist so they
+// can be listed in AllChecks.
+
+type workspaceExistsCheck struct{}
+
+func (workspaceExistsCheck) ID() string         { return "workspace.exists" }
+func (workspaceExistsCheck) Category() Category { return CategoryWorkspace }
+func (workspaceExistsCheck) Description() string {
+	return "Workspace config file (zhi.yaml / zhi.json) is present and readable."
+}
+
+func (c workspaceExistsCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env.WorkspaceErr != nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "workspace present",
+			Status:  StatusError,
+			Message: "could not locate workspace",
+			Detail:  env.WorkspaceErr.Error(),
+			Hint:    "run this command inside a directory containing zhi.yaml, or pass --workspace",
+		}}
+	}
+	if env.Workspace == nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "workspace present",
+			Status:  StatusError,
+			Message: "workspace not loaded",
+			Hint:    "run this command inside a directory containing zhi.yaml, or pass --workspace",
+		}}
+	}
+	return []Result{{
+		CheckID: c.ID(),
+		Name:    "workspace present",
+		Status:  StatusOK,
+		Message: "loaded from " + env.Workspace.Dir,
+	}}
+}
+
+type workspaceParsesCheck struct{}
+
+func (workspaceParsesCheck) ID() string         { return "workspace.parses" }
+func (workspaceParsesCheck) Category() Category { return CategoryWorkspace }
+func (workspaceParsesCheck) Description() string {
+	return "Workspace YAML / JSON parses without errors."
+}
+
+func (c workspaceParsesCheck) Run(ctx context.Context, env *Environment) []Result {
+	// LoadWorkspace wraps parse errors with "parsing <path>: ..."; anything
+	// else (missing file, unreadable file) is reported by workspace.exists
+	// and leaves this check as skipped to avoid double-reporting.
+	if env.WorkspaceErr != nil {
+		if strings.Contains(env.WorkspaceErr.Error(), "parsing") {
+			return []Result{{
+				CheckID: c.ID(),
+				Name:    "workspace parses",
+				Status:  StatusError,
+				Message: "workspace could not be parsed",
+				Detail:  env.WorkspaceErr.Error(),
+				Hint:    "fix the YAML/JSON syntax reported above",
+			}}
+		}
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "workspace parses",
+			Status:  StatusSkipped,
+			Message: "workspace not loaded",
+		}}
+	}
+	if env.Workspace == nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "workspace parses",
+			Status:  StatusSkipped,
+			Message: "workspace not loaded",
+		}}
+	}
+	return []Result{{
+		CheckID: c.ID(),
+		Name:    "workspace parses",
+		Status:  StatusOK,
+		Message: "workspace.yaml parsed successfully",
+	}}
+}
+
+type workspaceValidatesCheck struct{}
+
+func (workspaceValidatesCheck) ID() string         { return "workspace.validates" }
+func (workspaceValidatesCheck) Category() Category { return CategoryWorkspace }
+func (workspaceValidatesCheck) Description() string {
+	return "Workspace passes core.ValidateWorkspace (references, components, templates)."
+}
+
+func (c workspaceValidatesCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env.Workspace == nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "workspace validates",
+			Status:  StatusSkipped,
+			Message: "workspace not loaded",
+		}}
+	}
+	if err := core.ValidateWorkspace(env.Workspace, env.Registry); err != nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "workspace validates",
+			Status:  StatusError,
+			Message: "workspace validation failed",
+			Detail:  err.Error(),
+			Hint:    "run `zhi validate` for per-path detail",
+		}}
+	}
+	return []Result{{
+		CheckID: c.ID(),
+		Name:    "workspace validates",
+		Status:  StatusOK,
+		Message: "workspace validates cleanly",
+	}}
+}
+
+type workspacePluginDirsCheck struct{}
+
+func (workspacePluginDirsCheck) ID() string         { return "workspace.plugin_dirs_accessible" }
+func (workspacePluginDirsCheck) Category() Category { return CategoryWorkspace }
+func (workspacePluginDirsCheck) Description() string {
+	return "Every configured plugin directory exists and is readable."
+}
+
+func (c workspacePluginDirsCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env.Workspace == nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "plugin directories",
+			Status:  StatusSkipped,
+			Message: "workspace not loaded",
+		}}
+	}
+	dirs := env.Workspace.PluginDirectories()
+	if len(dirs) == 0 {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "plugin directories",
+			Status:  StatusOK,
+			Message: "no plugin directories configured",
+		}}
+	}
+
+	out := make([]Result, 0, len(dirs))
+	for _, raw := range dirs {
+		dir := expandTilde(raw)
+		info, err := os.Stat(dir)
+		switch {
+		case err == nil && info.IsDir():
+			out = append(out, Result{
+				CheckID: c.ID(),
+				Name:    "plugin directory",
+				Status:  StatusOK,
+				Message: dir,
+			})
+		case err == nil:
+			out = append(out, Result{
+				CheckID: c.ID(),
+				Name:    "plugin directory",
+				Status:  StatusError,
+				Message: dir,
+				Detail:  "path exists but is not a directory",
+			})
+		case os.IsNotExist(err):
+			out = append(out, Result{
+				CheckID: c.ID(),
+				Name:    "plugin directory",
+				Status:  StatusWarning,
+				Message: dir,
+				Hint:    "plugin directory does not exist; zhi will behave as if no external plugins are installed",
+			})
+		default:
+			out = append(out, Result{
+				CheckID: c.ID(),
+				Name:    "plugin directory",
+				Status:  StatusError,
+				Message: dir,
+				Detail:  err.Error(),
+			})
+		}
+	}
+	return out
+}
+
+type workspaceFileStoreCheck struct{}
+
+func (workspaceFileStoreCheck) ID() string         { return "workspace.file_store_path" }
+func (workspaceFileStoreCheck) Category() Category { return CategoryWorkspace }
+func (workspaceFileStoreCheck) Description() string {
+	return "File-backed store providers point at an accessible directory."
+}
+
+func (c workspaceFileStoreCheck) Run(ctx context.Context, env *Environment) []Result {
+	if env.Workspace == nil {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "file store path",
+			Status:  StatusSkipped,
+			Message: "workspace not loaded",
+		}}
+	}
+
+	provider := env.Workspace.Store.Provider
+	dir, ok := fileStoreDir(env.Workspace)
+	if !ok {
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "file store path",
+			Status:  StatusSkipped,
+			Message: "store provider is not file-backed",
+		}}
+	}
+
+	info, err := os.Stat(dir)
+	switch {
+	case err == nil && info.IsDir():
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "file store path",
+			Status:  StatusOK,
+			Message: fmt.Sprintf("%s store directory %s", provider, dir),
+		}}
+	case err == nil:
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "file store path",
+			Status:  StatusError,
+			Message: dir,
+			Detail:  "path exists but is not a directory",
+		}}
+	case os.IsNotExist(err):
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "file store path",
+			Status:  StatusWarning,
+			Message: dir,
+			Hint:    "directory will be created on first write",
+		}}
+	default:
+		return []Result{{
+			CheckID: c.ID(),
+			Name:    "file store path",
+			Status:  StatusError,
+			Message: dir,
+			Detail:  err.Error(),
+		}}
+	}
+}
+
+// fileStoreDir resolves the on-disk directory for the workspace's store
+// provider when it is one of the file-backed built-ins. The second
+// return value is false for providers that do not persist to a
+// workspace-relative directory (vault, memory, external plugins, etc.).
+//
+// The built-in providers read the "directory" option (see
+// internal/core/builtin.go); defaults mirror those in
+// internal/core/builtin.go and
+// pkg/providers/config/structuredfile/structuredfile.go.
+func fileStoreDir(ws *core.WorkspaceConfig) (string, bool) {
+	var dir string
+	switch ws.Store.Provider {
+	case "jsonfile":
+		dir = core.DefaultStoreDir
+	case "structuredfile":
+		// The structuredfile default lives at
+		// pkg/providers/config/structuredfile/structuredfile.go as
+		// DefaultDir = "./structuredfile". We hardcode the literal here
+		// to avoid pulling that package into the doctor import graph.
+		dir = "./structuredfile"
+	default:
+		return "", false
+	}
+	if ws.Store.Options != nil {
+		if raw, ok := ws.Store.Options["directory"]; ok {
+			if s, ok := raw.(string); ok && s != "" {
+				dir = s
+			}
+		}
+	}
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(ws.Dir, dir)
+	}
+	return dir, true
+}
+
+// expandTilde replaces a leading "~/" with the user's home directory.
+// Anything else is returned unchanged. Mirrors the (unexported) helper
+// used by core's plugin discovery.
+func expandTilde(p string) string {
+	if !strings.HasPrefix(p, "~/") {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return p
+	}
+	return filepath.Join(home, p[2:])
+}

--- a/internal/core/doctor/workspace_test.go
+++ b/internal/core/doctor/workspace_test.go
@@ -1,0 +1,361 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/zhi/internal/core"
+)
+
+func newEnv(t *testing.T, ws *core.WorkspaceConfig) *Environment {
+	t.Helper()
+	return &Environment{
+		Workspace: ws,
+		Registry:  core.NewRegistry(),
+	}
+}
+
+// resultOrFail returns the single Result in results or fails the test.
+func resultOrFail(t *testing.T, results []Result) Result {
+	t.Helper()
+	if len(results) != 1 {
+		t.Fatalf("expected exactly one result, got %d: %+v", len(results), results)
+	}
+	return results[0]
+}
+
+func TestWorkspaceExists(t *testing.T) {
+	ctx := context.Background()
+	check := workspaceExistsCheck{}
+
+	t.Run("ok when workspace loaded", func(t *testing.T) {
+		env := newEnv(t, &core.WorkspaceConfig{Dir: "/path/to/ws"})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusOK {
+			t.Fatalf("status = %q, want %q", res.Status, StatusOK)
+		}
+		if !strings.Contains(res.Message, "/path/to/ws") {
+			t.Errorf("message missing workspace dir: %q", res.Message)
+		}
+	})
+
+	t.Run("error when workspace err set", func(t *testing.T) {
+		env := &Environment{WorkspaceErr: errors.New("no zhi.yaml found")}
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusError {
+			t.Fatalf("status = %q, want %q", res.Status, StatusError)
+		}
+		if res.Detail != "no zhi.yaml found" {
+			t.Errorf("detail = %q, want the underlying error", res.Detail)
+		}
+		if res.Hint == "" {
+			t.Error("expected a hint")
+		}
+	})
+}
+
+func TestWorkspaceParses(t *testing.T) {
+	ctx := context.Background()
+	check := workspaceParsesCheck{}
+
+	t.Run("ok when workspace loaded", func(t *testing.T) {
+		env := newEnv(t, &core.WorkspaceConfig{Version: "1"})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusOK {
+			t.Fatalf("status = %q, want %q", res.Status, StatusOK)
+		}
+	})
+
+	t.Run("error when parse error present", func(t *testing.T) {
+		env := &Environment{WorkspaceErr: errors.New("parsing zhi.yaml: yaml: line 3: did not find expected key")}
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusError {
+			t.Fatalf("status = %q, want %q", res.Status, StatusError)
+		}
+		if !strings.Contains(res.Detail, "parsing") {
+			t.Errorf("detail = %q, expected to contain parse error", res.Detail)
+		}
+	})
+
+	t.Run("skipped when non-parse error", func(t *testing.T) {
+		env := &Environment{WorkspaceErr: errors.New("no zhi.yaml or zhi.json found in /tmp")}
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusSkipped {
+			t.Fatalf("status = %q, want %q", res.Status, StatusSkipped)
+		}
+	})
+}
+
+func TestWorkspaceValidates(t *testing.T) {
+	ctx := context.Background()
+	check := workspaceValidatesCheck{}
+
+	t.Run("skipped when workspace nil", func(t *testing.T) {
+		env := &Environment{}
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusSkipped {
+			t.Fatalf("status = %q, want %q", res.Status, StatusSkipped)
+		}
+	})
+
+	t.Run("error when validation fails", func(t *testing.T) {
+		// Version "" and empty config provider → ValidateWorkspace
+		// returns "unsupported workspace version" + "config provider is required".
+		env := newEnv(t, &core.WorkspaceConfig{})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusError {
+			t.Fatalf("status = %q, want %q", res.Status, StatusError)
+		}
+		if !strings.Contains(res.Detail, "unsupported workspace version") {
+			t.Errorf("detail missing version error: %q", res.Detail)
+		}
+		if res.Hint == "" {
+			t.Error("expected a hint")
+		}
+	})
+
+	t.Run("ok when validation passes", func(t *testing.T) {
+		reg := core.DefaultRegistry()
+		env := &Environment{
+			Workspace: &core.WorkspaceConfig{
+				Version: "1",
+				Config:  core.ProviderRef{Provider: "structuredfile"},
+			},
+			Registry: reg,
+		}
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusOK {
+			t.Fatalf("status = %q, want %q; detail=%q", res.Status, StatusOK, res.Detail)
+		}
+	})
+}
+
+func TestWorkspacePluginDirsAccessible(t *testing.T) {
+	ctx := context.Background()
+	check := workspacePluginDirsCheck{}
+
+	t.Run("skipped when workspace nil", func(t *testing.T) {
+		env := &Environment{}
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusSkipped {
+			t.Fatalf("status = %q, want %q", res.Status, StatusSkipped)
+		}
+	})
+
+	t.Run("existing dir reports ok", func(t *testing.T) {
+		existing := t.TempDir()
+		env := newEnv(t, &core.WorkspaceConfig{
+			Plugins: core.PluginsConfig{Directories: []string{existing}},
+		})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusOK {
+			t.Fatalf("status = %q, want %q; message=%q", res.Status, StatusOK, res.Message)
+		}
+		if res.Message != existing {
+			t.Errorf("message = %q, want %q", res.Message, existing)
+		}
+	})
+
+	t.Run("missing dir reports warning", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "does-not-exist")
+		env := newEnv(t, &core.WorkspaceConfig{
+			Plugins: core.PluginsConfig{Directories: []string{missing}},
+		})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusWarning {
+			t.Fatalf("status = %q, want %q", res.Status, StatusWarning)
+		}
+		if res.Hint == "" {
+			t.Error("expected a hint for missing dir")
+		}
+	})
+
+	t.Run("non-dir path reports error", func(t *testing.T) {
+		tmp := t.TempDir()
+		filePath := filepath.Join(tmp, "not-a-dir")
+		if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
+			t.Fatalf("writing file: %v", err)
+		}
+		env := newEnv(t, &core.WorkspaceConfig{
+			Plugins: core.PluginsConfig{Directories: []string{filePath}},
+		})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusError {
+			t.Fatalf("status = %q, want %q", res.Status, StatusError)
+		}
+	})
+
+	t.Run("mixed dirs produce one result per directory", func(t *testing.T) {
+		existing := t.TempDir()
+		missing := filepath.Join(t.TempDir(), "gone")
+		env := newEnv(t, &core.WorkspaceConfig{
+			Plugins: core.PluginsConfig{Directories: []string{existing, missing}},
+		})
+		results := check.Run(ctx, env)
+		if len(results) != 2 {
+			t.Fatalf("results = %d, want 2", len(results))
+		}
+		if results[0].Status != StatusOK {
+			t.Errorf("first result status = %q, want %q", results[0].Status, StatusOK)
+		}
+		if results[1].Status != StatusWarning {
+			t.Errorf("second result status = %q, want %q", results[1].Status, StatusWarning)
+		}
+	})
+
+	t.Run("empty list yields single ok", func(t *testing.T) {
+		// Force PluginDirectories() to return an empty slice by making
+		// DefaultPluginDir() empty. On Linux an empty HOME and empty
+		// XDG variables cause UserHomeDir to error.
+		t.Setenv("HOME", "")
+		env := newEnv(t, &core.WorkspaceConfig{
+			Plugins: core.PluginsConfig{Directories: nil},
+		})
+		if len(env.Workspace.PluginDirectories()) != 0 {
+			t.Skip("DefaultPluginDir resolved a non-empty fallback; cannot reach empty-list branch on this host")
+		}
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusOK {
+			t.Fatalf("status = %q, want %q", res.Status, StatusOK)
+		}
+		if !strings.Contains(res.Message, "no plugin directories") {
+			t.Errorf("message = %q, want mention of empty list", res.Message)
+		}
+	})
+
+	t.Run("tilde is expanded", func(t *testing.T) {
+		home := t.TempDir()
+		sub := "my-plugins"
+		if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		t.Setenv("HOME", home)
+		env := newEnv(t, &core.WorkspaceConfig{
+			Plugins: core.PluginsConfig{Directories: []string{"~/" + sub}},
+		})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusOK {
+			t.Fatalf("status = %q, want %q; message=%q", res.Status, StatusOK, res.Message)
+		}
+	})
+}
+
+func TestWorkspaceFileStorePath(t *testing.T) {
+	ctx := context.Background()
+	check := workspaceFileStoreCheck{}
+
+	t.Run("skipped when workspace nil", func(t *testing.T) {
+		env := &Environment{}
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusSkipped {
+			t.Fatalf("status = %q, want %q", res.Status, StatusSkipped)
+		}
+	})
+
+	t.Run("skipped for vault provider", func(t *testing.T) {
+		env := newEnv(t, &core.WorkspaceConfig{
+			Dir:   t.TempDir(),
+			Store: core.ProviderRef{Provider: "vault"},
+		})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusSkipped {
+			t.Fatalf("status = %q, want %q", res.Status, StatusSkipped)
+		}
+	})
+
+	t.Run("skipped when store provider empty", func(t *testing.T) {
+		env := newEnv(t, &core.WorkspaceConfig{Dir: t.TempDir()})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusSkipped {
+			t.Fatalf("status = %q, want %q", res.Status, StatusSkipped)
+		}
+	})
+
+	t.Run("jsonfile default dir present reports ok", func(t *testing.T) {
+		wsDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(wsDir, core.DefaultStoreDir), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		env := newEnv(t, &core.WorkspaceConfig{
+			Dir:   wsDir,
+			Store: core.ProviderRef{Provider: "jsonfile"},
+		})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusOK {
+			t.Fatalf("status = %q, want %q; detail=%q", res.Status, StatusOK, res.Detail)
+		}
+	})
+
+	t.Run("jsonfile missing dir reports warning", func(t *testing.T) {
+		wsDir := t.TempDir()
+		env := newEnv(t, &core.WorkspaceConfig{
+			Dir:   wsDir,
+			Store: core.ProviderRef{Provider: "jsonfile"},
+		})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusWarning {
+			t.Fatalf("status = %q, want %q", res.Status, StatusWarning)
+		}
+		if res.Hint == "" {
+			t.Error("expected a hint mentioning on-demand creation")
+		}
+	})
+
+	t.Run("jsonfile with directory option override", func(t *testing.T) {
+		wsDir := t.TempDir()
+		custom := "custom-store"
+		if err := os.MkdirAll(filepath.Join(wsDir, custom), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		env := newEnv(t, &core.WorkspaceConfig{
+			Dir: wsDir,
+			Store: core.ProviderRef{
+				Provider: "jsonfile",
+				Options:  map[string]any{"directory": custom},
+			},
+		})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusOK {
+			t.Fatalf("status = %q, want %q; message=%q", res.Status, StatusOK, res.Message)
+		}
+		if !strings.Contains(res.Message, custom) {
+			t.Errorf("message = %q, expected to contain custom dir %q", res.Message, custom)
+		}
+	})
+
+	t.Run("jsonfile path is a file not a dir reports error", func(t *testing.T) {
+		wsDir := t.TempDir()
+		// Create the default store path as a regular file.
+		storePath := filepath.Join(wsDir, core.DefaultStoreDir)
+		if err := os.MkdirAll(filepath.Dir(storePath), 0o755); err != nil {
+			t.Fatalf("mkdir parent: %v", err)
+		}
+		if err := os.WriteFile(storePath, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		env := newEnv(t, &core.WorkspaceConfig{
+			Dir:   wsDir,
+			Store: core.ProviderRef{Provider: "jsonfile"},
+		})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusError {
+			t.Fatalf("status = %q, want %q", res.Status, StatusError)
+		}
+	})
+
+	t.Run("structuredfile default dir missing reports warning", func(t *testing.T) {
+		wsDir := t.TempDir()
+		env := newEnv(t, &core.WorkspaceConfig{
+			Dir:   wsDir,
+			Store: core.ProviderRef{Provider: "structuredfile"},
+		})
+		res := resultOrFail(t, check.Run(ctx, env))
+		if res.Status != StatusWarning {
+			t.Fatalf("status = %q, want %q", res.Status, StatusWarning)
+		}
+	})
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
     - Getting Started: user-guide/getting-started.md
     - Workspace Configuration: user-guide/workspace-configuration.md
     - CLI Reference: user-guide/cli-reference.md
+    - Doctor: user-guide/doctor.md
     - Components: user-guide/components.md
     - Export and Templates: user-guide/export-and-templates.md
     - Apply: user-guide/apply.md


### PR DESCRIPTION
## Summary

Closes #113. Adds `zhi doctor` — a `brew doctor`-style single command that answers "is my workspace healthy?". It runs a battery of checks grouped into five categories and reports findings with text, ASCII-icon, or JSON output plus a meaningful exit code.

- **Framework first, checks second.** `internal/core/doctor` exposes a minimal `Check` / `Result` / `Runner` surface; each category is a separate file so new checks can be added by dropping one in. `Result` deliberately does **not** carry a category field — the owning `Check.Category()` is the single source of truth; the `Report` groups results under `CategoryGroup`.
- **Degrades gracefully.** When workspace load or engine construction fails, doctor still runs — the failure becomes the first finding rather than aborting the run. Subsequent checks skip with clean messages.
- **No protocol changes.** v1 probes plugins through existing RPCs (`Capabilities`, `List`, `ValidatePolicy`). The Vault-specific probes go directly through `pkg/providers/store/vault/httpclient` rather than adding a new gRPC `Probe` method — that's an easy follow-up if external store plugins need richer probes later.

## Checks

| Category | Checks |
|---|---|
| workspace | `exists`, `parses`, `validates`, `plugin_dirs_accessible`, `file_store_path` |
| plugins | `referenced_installed`, `manifest_readable` (falls back to `~/.zhi/metadata/` for OCI installs), `version_compatible`, `alive`, `signature_verified` (deep only) |
| store | generic `capabilities` + `list_trees`; Vault-only `reachable`, `unsealed`, `token_valid`, `token_ttl`, `mount_accessible` |
| config | `validates` (reuses `engine.Validate`), `no_deprecated_fields`, `env_var_expansion`, `no_conflicts` |
| updates | opt-in `marketplace.GetPlugin` comparison against `zhi-plugins.lock` |

## CLI

```
zhi doctor
zhi doctor --check workspace --check plugins
zhi doctor --check updates
zhi doctor --json | jq .summary
zhi doctor --deep --timeout 30s
```

Flags: `--check` (repeatable), `--json`, `--quiet`, `--fix`, `--deep`, `--timeout`, `--no-color`, `--updates`. Exit code is 1 when any check reports an error, 0 otherwise; warnings do not affect exit.

## Deliberately deferred to later releases

- `--fix` is plumbed end-to-end but registers no fixers (auto-mutating config has real blast radius; separate issue).
- Env-var expansion itself isn't implemented in zhi — doctor only *detects* literal `${VAR}` patterns and warns.
- A store-plugin `Probe` gRPC RPC — Vault's HTTP probe is enough for v1.
- TUI integration — CLI-only for now.

## Test plan

- [x] `make check` — fmt + vet + lint + test all green
- [x] `go test -race -count=1 ./internal/core/doctor/... ./internal/cli/...`
- [x] Manual runs against `examples/zhi-workspace-ansible-infra`:
  - [x] default text output
  - [x] `--json` — parsed via `python3 json.load`, summary shape stable
  - [x] `--check workspace --quiet` — only headers + summary
  - [x] empty dir (no workspace found) — exit 1, full skipped cascade
  - [x] `--check bogus` — rejected with hint listing valid categories
  - [x] `--fix` — prints placeholder notice
- [ ] Vault matrix (requires a local Vault instance; covered in unit tests via `httptest.Server`, happy to demo in follow-up)
- [ ] Marketplace `--check updates` against a live marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)