### PR TITLE
fix: correctness issues found during project design review

### DIFF
--- a/pkg/sharing/verify/policy.go
+++ b/pkg/sharing/verify/policy.go
@@ -116,10 +116,43 @@ func (p *Policy) IsRegistryAllowed(ref string) bool {
 }
 
 // IsBlocked checks whether a reference matches a blocked plugin pattern.
+// Patterns match whole path segments of the repository (tag and digest are
+// ignored), so blocking "org/plugin" does not block "org/plugin-fork" or
+// "other-org/pluginish".
 func (p *Policy) IsBlocked(ref string) bool {
 	ref = strings.TrimPrefix(ref, "oci://")
+	// Strip a trailing digest or tag so patterns match the repository path.
+	if i := strings.LastIndex(ref, "@"); i >= 0 {
+		ref = ref[:i]
+	}
+	if i := strings.LastIndex(ref, ":"); i > strings.LastIndex(ref, "/") {
+		ref = ref[:i]
+	}
+	segments := strings.Split(ref, "/")
 	for _, blocked := range p.BlockedPlugins {
-		if strings.Contains(ref, blocked) {
+		pattern := strings.Split(strings.TrimPrefix(blocked, "oci://"), "/")
+		if matchesSegments(segments, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesSegments reports whether pattern occurs in segments as a
+// contiguous run of whole path segments.
+func matchesSegments(segments, pattern []string) bool {
+	if len(pattern) == 0 {
+		return false
+	}
+	for i := 0; i+len(pattern) <= len(segments); i++ {
+		matched := true
+		for j, p := range pattern {
+			if segments[i+j] != p {
+				matched = false
+				break
+			}
+		}
+		if matched {
 			return true
 		}
 	}

--- a/pkg/sharing/verify/policy_test.go
+++ b/pkg/sharing/verify/policy_test.go
@@ -197,3 +197,16 @@ func TestIsBlocked(t *testing.T) {
 		t.Error("expected empty pattern to not block")
 	}
 }
+
+func TestMatchesSegments(t *testing.T) {
+	if matchesSegments([]string{"a", "b"}, nil) {
+		t.Error("expected empty pattern to not match")
+	}
+	// First pattern segment matches, a later one does not.
+	if matchesSegments([]string{"ghcr.io", "untrusted", "good-plugin"}, []string{"untrusted", "bad-plugin"}) {
+		t.Error("expected partial segment run to not match")
+	}
+	if !matchesSegments([]string{"ghcr.io", "untrusted", "bad-plugin"}, []string{"untrusted", "bad-plugin"}) {
+		t.Error("expected contiguous segment run to match")
+	}
+}

--- a/pkg/sharing/verify/policy_test.go
+++ b/pkg/sharing/verify/policy_test.go
@@ -161,10 +161,39 @@ func TestIsRegistryAllowed(t *testing.T) {
 
 func TestIsBlocked(t *testing.T) {
 	p := &Policy{BlockedPlugins: []string{"untrusted/bad-plugin"}}
-	if !p.IsBlocked("oci://ghcr.io/untrusted/bad-plugin:v1.0") {
-		t.Error("expected plugin to be blocked")
+
+	tests := []struct {
+		ref     string
+		blocked bool
+	}{
+		{"oci://ghcr.io/untrusted/bad-plugin:v1.0", true},
+		{"oci://ghcr.io/trusted/good-plugin:v1.0", false},
+		// Digest references are matched on the repository path.
+		{"oci://ghcr.io/untrusted/bad-plugin@sha256:abc123", true},
+		// Tag stripping must not eat the digest segment match.
+		{"oci://ghcr.io/untrusted/bad-plugin", true},
+		// Patterns match whole segments, not substrings.
+		{"oci://ghcr.io/untrusted/bad-plugin-fork:v1.0", false},
+		{"oci://ghcr.io/very-untrusted/bad-plugin:v1.0", false},
+		{"oci://ghcr.io/org/xuntrusted/bad-pluginx:v1.0", false},
+		// Registries with a port keep the host segment intact.
+		{"oci://localhost:5000/untrusted/bad-plugin:v1.0", true},
 	}
-	if p.IsBlocked("oci://ghcr.io/trusted/good-plugin:v1.0") {
-		t.Error("expected plugin to not be blocked")
+	for _, tt := range tests {
+		if got := p.IsBlocked(tt.ref); got != tt.blocked {
+			t.Errorf("IsBlocked(%q) = %v, want %v", tt.ref, got, tt.blocked)
+		}
+	}
+
+	// Patterns may carry an oci:// prefix themselves.
+	p = &Policy{BlockedPlugins: []string{"oci://untrusted/bad-plugin"}}
+	if !p.IsBlocked("oci://ghcr.io/untrusted/bad-plugin:v1.0") {
+		t.Error("expected oci://-prefixed pattern to block")
+	}
+
+	// Empty patterns never match.
+	p = &Policy{BlockedPlugins: []string{""}}
+	if p.IsBlocked("oci://ghcr.io/org/plugin:v1.0") {
+		t.Error("expected empty pattern to not block")
 	}
 }

--- a/pkg/sharing/verify/verify.go
+++ b/pkg/sharing/verify/verify.go
@@ -139,9 +139,12 @@ func NewVerifier(policy *Policy) *Verifier {
 	return &Verifier{policy: policy}
 }
 
-// VerifyArtifact checks the signature and policy for an OCI artifact
-// identified by its reference. When skipVerify is true, verification is
-// skipped but a warning-level result is returned.
+// VerifyArtifact checks the local policy (blocked plugins, allowed
+// registries, signature requirements) for an OCI artifact identified by
+// its reference. It does NOT perform cryptographic signature
+// verification — use VerifySignature with a Sigstore bundle for that —
+// so the returned Result always reports Signed: false. When skipVerify
+// is true, policy strictness checks are skipped.
 func (v *Verifier) VerifyArtifact(ref string, skipVerify bool) *Result {
 	// Check if the plugin is blocked by policy.
 	if v.policy.IsBlocked(ref) {

--- a/pkg/zhiplugin/config/config.go
+++ b/pkg/zhiplugin/config/config.go
@@ -3,7 +3,9 @@ package config
 
 import (
 	"errors"
+	"maps"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -154,7 +156,8 @@ func (t *Tree) GetPtr(path string) (*Value, bool) {
 }
 
 // Get returns a copy of the Value at path. The bool reports whether the
-// path exists.
+// path exists. The Metadata map and Validators slice are cloned so that
+// mutating them on the returned copy does not affect the tree.
 func (t *Tree) Get(path string) (Value, bool) {
 	t.mu.RLock()
 	v, ok := t.values[path]
@@ -162,7 +165,10 @@ func (t *Tree) Get(path string) (Value, bool) {
 	if !ok {
 		return Value{}, false
 	}
-	return *v, true
+	cp := *v
+	cp.Metadata = maps.Clone(cp.Metadata)
+	cp.Validators = slices.Clone(cp.Validators)
+	return cp, true
 }
 
 // Delete removes the value at path from the tree. It is a no-op if the

--- a/pkg/zhiplugin/ui/controller_server.go
+++ b/pkg/zhiplugin/ui/controller_server.go
@@ -132,9 +132,7 @@ func (s *controllerGRPCServer) Apply(req *pb.CtrlApplyRequest, stream grpc.Serve
 	if err != nil {
 		finalMsg.Error = err.Error()
 	}
-	_ = stream.Send(finalMsg)
-
-	return nil
+	return stream.Send(finalMsg)
 }
 
 func (s *controllerGRPCServer) ListComponents(ctx context.Context, _ *pb.CtrlListComponentsRequest) (*pb.CtrlListComponentsResponse, error) {

--- a/pkg/zhiplugin/ui/grpc_client.go
+++ b/pkg/zhiplugin/ui/grpc_client.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	goplugin "github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
@@ -26,11 +27,14 @@ func (c *GRPCClient) Run(ctx context.Context, controller Controller) error {
 	// plugin process can call back into the host.
 	controllerServer := &controllerGRPCServer{impl: controller}
 
-	var s *grpc.Server
+	// serverFunc runs on the broker's accept goroutine, so the server
+	// pointer must be published atomically for the read after Run returns.
+	var s atomic.Pointer[grpc.Server]
 	serverFunc := func(opts []grpc.ServerOption) *grpc.Server {
-		s = grpc.NewServer(opts...)
-		pb.RegisterUIControllerServiceServer(s, controllerServer)
-		return s
+		srv := grpc.NewServer(opts...)
+		pb.RegisterUIControllerServiceServer(srv, controllerServer)
+		s.Store(srv)
+		return srv
 	}
 
 	brokerID := c.broker.NextId()
@@ -40,8 +44,8 @@ func (c *GRPCClient) Run(ctx context.Context, controller Controller) error {
 		ControllerBrokerId: brokerID,
 	})
 
-	if s != nil {
-		s.Stop()
+	if srv := s.Load(); srv != nil {
+		srv.Stop()
 	}
 
 	return err


### PR DESCRIPTION
Quick, safe fixes for correctness issues found during a deep design/code review of the project:

- **`config.Tree.Get` metadata aliasing**: `Get` returned a shallow struct copy, so the `Metadata` map (and `Validators` slice backing array) was shared with the tree's internal state — mutating the "copy" silently corrupted the tree. `Get` now clones both.
- **UI controller `Apply` stream**: the final `stream.Send` error was discarded, so a client disconnect during apply was reported as success. The error is now propagated.
- **Data race in `ui.GRPCClient.Run`**: the broker-side controller `*grpc.Server` was written from the broker's accept goroutine and read after `Run` returned without synchronization. It is now published via `atomic.Pointer`.
- **`verify.Policy.IsBlocked` substring matching**: blocking `org/plugin` also blocked `org/plugin-fork` and any reference merely containing the pattern. Matching is now segment-boundary aware on the repository path (tag/digest stripped).
- **Misleading doc comment on `VerifyArtifact`**: it claimed to check signatures, but it only enforces local policy — cryptographic verification (`VerifySignature`) is currently never invoked anywhere in the codebase. The comment now states what the function actually does. (Wiring real signature verification into the install flow is a larger change, flagged separately in the review.)

All tests pass with `-race`; `go vet` and `gofmt -s` are clean.

https://claude.ai/code/session_01LtvEHKLGgYaGHhs9LHnSwY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtvEHKLGgYaGHhs9LHnSwY)_